### PR TITLE
Add some missing functionals

### DIFF
--- a/src/atomate2/vasp/schemas/calc_types/run_types.yaml
+++ b/src/atomate2/vasp/schemas/calc_types/run_types.yaml
@@ -54,14 +54,18 @@ HF:
 METAGGA:
   M06L:
     METAGGA: M06L
-  MBJL:
-    METAGGA: MBJL
+  MBJ:
+    METAGGA: MBJ
   MS0:
     METAGGA: MS0
   MS1:
     METAGGA: MS1
   MS2:
     METAGGA: MS2
+  RSCAN:
+    METAGGA: RSCAN
+  R2SCAN:
+    METAGGA: R2SCAN
   RTPSS:
     METAGGA: RTPSS
   SCAN:
@@ -100,7 +104,7 @@ VDW:
     PARAM1: 0.1234
     PARAM2: 0.711357
     Zab_vdW: -1.8867
-  revPBE-vdW:
+  vdW-DF:
     AGGAC: 0.0
     GGA: RE
     LASPH: true
@@ -111,3 +115,7 @@ VDW:
     LASPH: true
     LUSE_VDW: true
     Zab_vdW: -1.8867
+  BEEF-vdW:
+    GGA: BF
+    Zab_vdW: -1.8867
+    LUSE_VDW: true


### PR DESCRIPTION
- I changed `MBJL` to `MBJ`. I think MBJ is the [supported keyword](https://www.vasp.at/wiki/index.php/METAGGA). Let me know if I'm wrong here.
- I added `RSCAN` and `R2SCAN` to the METAGGAs.
- I renamed `revPBE-vdW` to `vdW-DF` as suggested by the [VASP manual](https://www.vasp.at/wiki/index.php/VdW-DF_functional_of_Langreth_and_Lundqvist_et_al.). Happy to change this back if you think it's important to emphasize the revPBE part.
- I added `BEEF-vdW` since it's commonly used. Not sure what your thoughts are on having defaults set for "third-party" functionals.