### PR TITLE
Add missing LASPH flags on vdW functionals

### DIFF
--- a/src/atomate2/vasp/schemas/calc_types/run_types.yaml
+++ b/src/atomate2/vasp/schemas/calc_types/run_types.yaml
@@ -88,6 +88,7 @@ VDW:
   optB88-vdW:
     AGGAC: 0.0
     GGA: BO
+    LASPH: true
     LUSE_VDW: true
     PARAM1: 0.1833333333
     PARAM2: 0.22
@@ -117,5 +118,6 @@ VDW:
     Zab_vdW: -1.8867
   BEEF-vdW:
     GGA: BF
-    Zab_vdW: -1.8867
+    LASPH: true
     LUSE_VDW: true
+    Zab_vdW: -1.8867


### PR DESCRIPTION
Very minor changes:
1. I hadn't noticed that you kept `LASPH = True` for the vdW functionals, so I added this flag for BEEF-vdW.
2. optB88-vdW was missing the `LASPH = True` flag, so I added it in. It's mentioned in the [VASP manual](https://www.vasp.at/wiki/index.php/VdW-DF_functional_of_Langreth_and_Lundqvist_et_al.).