### PR TITLE
Fix auto npar check

### DIFF
--- a/src/atomate2/vasp/run.py
+++ b/src/atomate2/vasp/run.py
@@ -129,8 +129,7 @@ def run_vasp(
     split_vasp_cmd = shlex.split(vasp_cmd)
     split_vasp_gamma_cmd = shlex.split(vasp_gamma_cmd)
 
-    if "auto_npar" not in vasp_job_kwargs:
-        vasp_job_kwargs["auto_npar"] = False
+    vasp_job_kwargs["auto_npar"] = bool(vasp_job_kwargs.get("auto_npar", None))
 
     vasp_job_kwargs.update({"gamma_vasp_cmd": split_vasp_gamma_cmd})
 


### PR DESCRIPTION
~Previously, it looked like `auto_npar` in Custodian would be set to `False` even if the user requested `True` because atomate2 was just looking to see if the `auto_npar` key was in the `.yaml` file (regardless of its associated value). This should be fixed now.~

Apologies about this. Silly oversight on my part.