### PR TITLE
Custodian FULL_OPT fix

### DIFF
--- a/src/atomate2/vasp/run.py
+++ b/src/atomate2/vasp/run.py
@@ -146,7 +146,7 @@ def run_vasp(
         jobs = VaspJob.double_relaxation_run(split_vasp_cmd, **vasp_job_kwargs)
     elif job_type == JobType.METAGGA_OPT:
         jobs = VaspJob.metagga_opt_run(split_vasp_cmd, **vasp_job_kwargs)
-    elif job_type == JobType.METAGGA_OPT:
+    elif job_type == JobType.FULL_OPT:
         jobs = VaspJob.full_opt_run(split_vasp_cmd, **vasp_job_kwargs)
     else:
         raise ValueError(f"Unsupported job type: {job_type}")


### PR DESCRIPTION
Previously, specifying the FULL_OPT job type for Custodian would never actually run because of a typo (see below). Now fixed.

https://github.com/materialsproject/atomate2/blob/6ef1188d9e1e038a6d964d8e9d9177c8e54727fd/src/atomate2/vasp/run.py#L147-L150