### PR TITLE
[WIP] Add mag_density to VASP output doc

### DIFF
--- a/src/atomate2/vasp/schemas/calculation.py
+++ b/src/atomate2/vasp/schemas/calculation.py
@@ -307,6 +307,10 @@ class CalculationOutput(BaseModel):
     transition: str = Field(
         None, description="Band gap transition given by CBM and VBM k-points"
     )
+    mag_density: float = Field(
+        None,
+        description="The magnetization density, defined as total_mag/volume (units of A^-3)",
+    )
     epsilon_static: Matrix3D = Field(
         None, description="The high-frequency dielectric constant"
     )
@@ -431,6 +435,8 @@ class CalculationOutput(BaseModel):
         outcar_dict.pop("run_stats")
 
         structure = vasprun.final_structure
+        mag_density = outcar.total_mag / structure.volume if outcar.total_mag else None
+
         if len(outcar.magnetization) != 0:
             # patch calculated magnetic moments into final structure
             magmoms = [m["tot"] for m in outcar.magnetization]
@@ -448,6 +454,7 @@ class CalculationOutput(BaseModel):
             structure=structure,
             energy=vasprun.final_energy,
             energy_per_atom=vasprun.final_energy / len(structure),
+            mag_density=mag_density,
             epsilon_static=vasprun.epsilon_static or None,
             epsilon_static_wolfe=vasprun.epsilon_static_wolfe or None,
             epsilon_ionic=vasprun.epsilon_ionic or None,


### PR DESCRIPTION
This PR adds a `mag_density` attribute to the VASP `CalculationOutput` document. This can sometimes be more useful to query by than `total_mag` because the former is invariant to the # of unit cells.