### PR TITLE
Store efermi in CalculationOutput

### DIFF
--- a/src/atomate2/vasp/schemas/calculation.py
+++ b/src/atomate2/vasp/schemas/calculation.py
@@ -382,6 +382,7 @@ class CalculationOutput(BaseModel):
             bandstructure = vasprun.get_band_structure(efermi="smart")
             bandgap_info = bandstructure.get_band_gap()
             electronic_output = dict(
+                efermi=bandstructure.efermi,
                 vbm=bandstructure.get_vbm()["energy"],
                 cbm=bandstructure.get_cbm()["energy"],
                 bandgap=bandgap_info["energy"],


### PR DESCRIPTION
This PR stores the `efermi` from the `vasprun.xml`. It is otherwise always left at `None` because it wasn't assigned in `electronic_output`.

Example:
```python
from atomate2.vasp.schemas.calculation import CalculationOutput
from pymatgen.io.vasp.outputs import Vasprun, Outcar

# run this in, e.g. one of the test double-relax runs
c = CalculationOutput.from_vasp_outputs(Vasprun('vasprun.xml.gz'),Outcar('OUTCAR.gz'))
```