### PR TITLE
Fix test suite for pymatgen vasprun fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pydantic==1.9.0
-pymatgen==2022.1.24
+pymatgen==2022.2.1
 custodian==2022.1.17
 monty==2022.1.19
 jobflow==0.1.6

--- a/tests/vasp/flows/test_core.py
+++ b/tests/vasp/flows/test_core.py
@@ -35,7 +35,7 @@ def test_double_relax(mock_vasp, clean_dir, si_structure):
     output2 = responses[flow.jobs[1].uuid][1].output
 
     assert isinstance(output1, TaskDocument)
-    assert output1.output.energy == pytest.approx(-10.85083141)
+    assert output1.output.energy == pytest.approx(-10.85043620)
     assert output2.output.energy == pytest.approx(-10.84177648)
 
     # Now try with two identical but non-default makers

--- a/tests/vasp/jobs/test_core.py
+++ b/tests/vasp/jobs/test_core.py
@@ -54,7 +54,7 @@ def test_relax_maker(mock_vasp, clean_dir, si_structure):
     # validation the outputs of the job
     output1 = responses[job.uuid][1].output
     assert isinstance(output1, TaskDocument)
-    assert output1.output.energy == approx(-10.85083141)
+    assert output1.output.energy == approx(-10.85043620)
     assert len(output1.calcs_reversed[0].output.ionic_steps) == 1
     assert output1.input.parameters["NSW"] > 1
 


### PR DESCRIPTION
Updates test suite with correct energies so that pymatgen can be updated. Fixes (and can close) the error with #72.