### PR TITLE
potcar spec kwarg

### DIFF
--- a/src/atomate2/vasp/files.py
+++ b/src/atomate2/vasp/files.py
@@ -146,6 +146,7 @@ def write_vasp_input_set(
     input_set_generator: VaspInputSetGenerator,
     from_prev: bool = False,
     apply_incar_updates: bool = True,
+    potcar_spec: bool = False,
     clean_prev: bool = True,
     **kwargs,
 ):
@@ -168,7 +169,9 @@ def write_vasp_input_set(
         Keyword arguments that will be passed to :obj:`.VaspInputSet.write_input`.
     """
     prev_dir = "." if from_prev else None
-    vis = input_set_generator.get_input_set(structure, prev_dir=prev_dir)
+    vis = input_set_generator.get_input_set(
+        structure, prev_dir=prev_dir, potcar_spec=potcar_spec
+    )
 
     if apply_incar_updates:
         vis.incar.update(SETTINGS.VASP_INCAR_UPDATES)
@@ -180,4 +183,4 @@ def write_vasp_input_set(
                 Path(filename).unlink()
 
     logger.info("Writing VASP input set.")
-    vis.write_input(".", **kwargs)
+    vis.write_input(".", potcar_spec=potcar_spec, **kwargs)

--- a/src/atomate2/vasp/files.py
+++ b/src/atomate2/vasp/files.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Sequence
+from typing import Sequence, Union
 
 from pymatgen.core import Structure
 
@@ -144,6 +144,7 @@ def get_largest_relax_extension(
 def write_vasp_input_set(
     structure: Structure,
     input_set_generator: VaspInputSetGenerator,
+    directory: Union[str, Path] = ".",
     from_prev: bool = False,
     apply_incar_updates: bool = True,
     potcar_spec: bool = False,
@@ -183,4 +184,4 @@ def write_vasp_input_set(
                 Path(filename).unlink()
 
     logger.info("Writing VASP input set.")
-    vis.write_input(".", potcar_spec=potcar_spec, **kwargs)
+    vis.write_input(directory, potcar_spec=potcar_spec, **kwargs)


### PR DESCRIPTION
## Unused potcar_spec kwarg

It looks like there is an `potcar_spec` kwarg here
https://github.com/materialsproject/atomate2/blob/e7bfdb93cc3748c3465685fffd6efac8eba7257b/src/atomate2/vasp/sets/base.py#L73
which might be useful for live debugging, but `write_vasp_input_set` cannot use it since it breaks the input set creation here:
https://github.com/materialsproject/atomate2/blob/f319382ef47f4d4385d131cb2f9edefc24af83bf/src/atomate2/vasp/files.py#L171

This should allow you to write input files but it still looks like the KPOINTS file is missing.

Is this the expected behavior?
```
from atomate2.vasp.sets.core import RelaxSetGenerator
from atomate2.vasp.files import write_vasp_input_set
from pymatgen.core import Structure

mgo_structure = Structure(
    lattice=[[0, 2.13, 2.13], [2.13, 0, 2.13], [2.13, 2.13, 0]],
    species=["Mg", "O"],
    coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
)
gen = RelaxSetGenerator()
write_vasp_input_set(mgo_structure, input_set_generator=gen, potcar_spec=True)

### creates inputfile but missing KPOINTS
```

 