### PR TITLE
Replace monty which with shutil which

### DIFF
--- a/src/atomate2/vasp/schemas/calculation.py
+++ b/src/atomate2/vasp/schemas/calculation.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from jobflow.utils import ValueEnum
-from monty.os.path import which
+from shutil import which
 from pydantic import BaseModel, Field
 from pydantic.datetime_parse import datetime
 from pymatgen.command_line.bader_caller import bader_analysis_from_path

--- a/src/atomate2/vasp/schemas/calculation.py
+++ b/src/atomate2/vasp/schemas/calculation.py
@@ -49,7 +49,7 @@ __all__ = [
 ]
 
 
-_BADER_EXE_EXISTS = which("bader") or which("bader.exe")
+_BADER_EXE_EXISTS = True if (which("bader") or which("bader.exe")) else False
 
 
 class Status(ValueEnum):

--- a/src/atomate2/vasp/schemas/calculation.py
+++ b/src/atomate2/vasp/schemas/calculation.py
@@ -2,11 +2,11 @@
 
 import logging
 from pathlib import Path
+from shutil import which
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from jobflow.utils import ValueEnum
-from shutil import which
 from pydantic import BaseModel, Field
 from pydantic.datetime_parse import datetime
 from pymatgen.command_line.bader_caller import bader_analysis_from_path


### PR DESCRIPTION
## Summary
`monty.os.path.which` is deprecated and will be removed in v2023. Replaced with `shutil.which`.