### PR TITLE
Fix `calculate_deformation_potentials()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
   rev: v1.12.1
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==21.5b0]
+    additional_dependencies: [black]
     exclude: README.md
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,21 +31,11 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
-    name: isort (python)
-    args:
-    - --profile=black
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8
     files: ^src/
-    args:
-    - --max-line-length=125
-    - --extend-ignore=E203,W503,F401,RST21
-    - --min-python-version=3.8.0
-    - --docstring-convention=numpy
-    - --rst-roles=class,func,ref,obj
-    language_version: python3
     additional_dependencies:
     - flake8-typing-imports==1.10.1
     - flake8-docstrings==1.6.0
@@ -63,9 +53,6 @@ repos:
   hooks:
   - id: mypy
     files: ^src/
-    args:
-    - --no-strict-optional
-    - --ignore-missing-imports
     additional_dependencies:
     - tokenize-rt==4.1.0
     - types-pkg_resources==0.1.2

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # atomate2
 
-<a href="https://github.com/materialsproject/atomate2/actions?query=workflow%3Atesting"><img alt="code coverage" src="https://img.shields.io/github/workflow/status/materialsproject/atomate2/testing?label=tests"></a>
-<a href="https://codecov.io/gh/materialsproject/atomate2/"><img alt="code coverage" src="https://img.shields.io/codecov/c/gh/materialsproject/atomate2"></a>
-<a href="https://pypi.org/project/atomate2"><img alt="pypi version" src="https://img.shields.io/pypi/v/atomate2?color=blue"></a>
-<img alt="supported python versions" src="https://img.shields.io/pypi/pyversions/atomate2">
+[![code coverage](https://img.shields.io/github/workflow/status/materialsproject/atomate2/testing?label=tests)](https://github.com/materialsproject/atomate2/actions?query=workflow%3Atesting)
+[![code coverage](https://img.shields.io/codecov/c/gh/materialsproject/atomate2)](https://codecov.io/gh/materialsproject/atomate2)
+[![pypi version](https://img.shields.io/pypi/v/atomate2?color=blue)](https://pypi.org/project/atomate2)
+![supported python versions](https://img.shields.io/pypi/pyversions/atomate2)
 
 **👉 [Full Documentation][docs] 👈**
 
@@ -70,7 +70,7 @@ run_locally(bandstructure_flow, create_folders=True)
 ```
 
 In this example, we run execute the workflow immediately. In many cases, you might want
-to perform calculations on several materials simulatenously. To achieve this, all
+to perform calculations on several materials simultaneously. To achieve this, all
 atomate2 workflows can be run using the [FireWorks] software. See the
 [documentation][atomate2_fireworks] for more details.
 
@@ -125,7 +125,6 @@ A full list of all contributors can be found [here][contributors].
 [changelog]: https://materialsproject.github.io/atomate2/user/changelog.html
 [installation]: https://materialsproject.github.io/atomate2/user/install.html
 [contributing]: https://materialsproject.github.io/atomate2/user/contributing.html
-[contributors]: https://materialsproject.github.io/atomate2/user/contributors.html
 [license]: https://raw.githubusercontent.com/materialsproject/atomate2/main/LICENSE
 [running-workflows]: https://materialsproject.github.io/atomate2/user/running-workflows.html
 [atomate2_fireworks]: https://materialsproject.github.io/atomate2/user/fireworks.html

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ A full list of all contributors can be found [here][contributors].
 [changelog]: https://materialsproject.github.io/atomate2/user/changelog.html
 [installation]: https://materialsproject.github.io/atomate2/user/install.html
 [contributing]: https://materialsproject.github.io/atomate2/user/contributing.html
+[contributors]: https://materialsproject.github.io/atomate2/user/contributors.html
 [license]: https://raw.githubusercontent.com/materialsproject/atomate2/main/LICENSE
 [running-workflows]: https://materialsproject.github.io/atomate2/user/running-workflows.html
 [atomate2_fireworks]: https://materialsproject.github.io/atomate2/user/fireworks.html

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -72,7 +72,7 @@ numpydoc_show_inherited_class_members = False
 numpydoc_attributes_as_param_list = False
 numpydoc_xref_param_type = True
 
-# better napolean support
+# better napoleon support
 # napoleon_use_param = True
 # napoleon_use_rtype = True
 # napoleon_use_ivar = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,11 @@ profile=black
 
 [flake8]
 max-line-length = 125
+extend-ignore = E203,W503,F401,RST21
+min-python-version = 3.8.0
+docstring-convention = numpy
+rst-roles = class,func,ref,obj
 
 [mypy]
 ignore_missing_imports = True
+no_strict_optional = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[isort]
+profile=black
+
+[flake8]
+max-line-length = 125
+
+[mypy]
+ignore_missing_imports = True

--- a/src/atomate2/common/schemas/cclib.py
+++ b/src/atomate2/common/schemas/cclib.py
@@ -297,7 +297,7 @@ def cclib_calculate(
 
     if method in cube_methods and not cube_file:
         raise FileNotFoundError(
-            f"A cube file must be provied for {method}. Returning None."
+            f"A cube file must be provide for {method}. Returning None."
         )
     if method in ["ddec6", "hirshfeld"] and not proatom_dir:
         if "PROATOM_DIR" not in os.environ:

--- a/src/atomate2/common/schemas/cclib.py
+++ b/src/atomate2/common/schemas/cclib.py
@@ -3,7 +3,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Type, TypeVar, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 from monty.dev import requires
 from monty.json import jsanitize
@@ -262,7 +262,7 @@ def cclib_calculate(
     method: str,
     cube_file: Union[Path, str],
     proatom_dir: Union[Path, str],
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """
     Run a cclib population analysis.
 
@@ -362,7 +362,7 @@ def cclib_calculate(
 
 def _get_homos_lumos(
     moenergies: List[List[float]], homo_indices: List[int]
-) -> Tuple[List[float], List[float], List[float]]:
+) -> Tuple[List[float], Optional[List[float]], Optional[List[float]]]:
     """
     Calculate the HOMO, LUMO, and HOMO-LUMO gap energies in eV.
 

--- a/src/atomate2/common/schemas/cclib.py
+++ b/src/atomate2/common/schemas/cclib.py
@@ -297,7 +297,7 @@ def cclib_calculate(
 
     if method in cube_methods and not cube_file:
         raise FileNotFoundError(
-            f"A cube file must be provide for {method}. Returning None."
+            f"A cube file must be provided for {method}. Returning None."
         )
     if method in ["ddec6", "hirshfeld"] and not proatom_dir:
         if "PROATOM_DIR" not in os.environ:

--- a/src/atomate2/common/schemas/molecule.py
+++ b/src/atomate2/common/schemas/molecule.py
@@ -78,7 +78,7 @@ class MoleculeMetadata(BaseModel):
         fields : list of str or None
             Composition fields to include.
         **kwargs
-            Keyword arguements that are passed to the model constructor.
+            Keyword arguments that are passed to the model constructor.
 
         Returns
         -------

--- a/src/atomate2/common/schemas/structure.py
+++ b/src/atomate2/common/schemas/structure.py
@@ -80,7 +80,7 @@ class StructureMetadata(BaseModel):
         fields : list of str or None
             Composition fields to include.
         **kwargs
-            Keyword arguements that are passed to the model constructor.
+            Keyword arguments that are passed to the model constructor.
 
         Returns
         -------

--- a/src/atomate2/vasp/jobs/amset.py
+++ b/src/atomate2/vasp/jobs/amset.py
@@ -302,7 +302,6 @@ def calculate_deformation_potentials(
     # convert arguments into their command line equivalents
     # note, amset expects the band indices to be 1 indexed, whereas we store them
     # as zero indexed
-    bands_str = ".".join(",".join([str(idx + 1) for idx in b]) for b in ibands)
     symprec_str = "N" if symprec is None else str(symprec)
 
     # TODO: Handle hostnames properly
@@ -311,9 +310,12 @@ def calculate_deformation_potentials(
     args = [
         bulk_dir,
         *deformation_dirs,
-        f"--bands={bands_str}",
         f"--symprec={symprec_str}",
     ]
+    if ibands is not None:
+        bands_str = ".".join(",".join([str(idx + 1) for idx in b]) for b in ibands)
+        args.append(f"--bands={bands_str}")
+
     runner = CliRunner()
     result = runner.invoke(read, args, catch_exceptions=False)
 

--- a/src/atomate2/vasp/schemas/task.py
+++ b/src/atomate2/vasp/schemas/task.py
@@ -241,7 +241,7 @@ class TaskDocument(StructureMetadata):
         description="Summary of runtime statistics for each calculation in this task",
     )
     orig_inputs: Dict[str, Union[Kpoints, dict, Poscar, List[PotcarSpec]]] = Field(
-        None, description="Summary of the original VASP inputs writen by custodian"
+        None, description="Summary of the original VASP inputs written by custodian"
     )
     task_label: str = Field(None, description="A description of the task")
     tags: List[str] = Field(None, description="Metadata tags for this task document")

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -104,7 +104,7 @@ class VaspInputSet(InputSet):
             if v is not None and (overwrite or not (directory / k).exists()):
                 with zopen(directory / k, "wt") as f:
                     if isinstance(v, Poscar):
-                        # write POSCAR with more signifcant figures
+                        # write POSCAR with more significant figures
                         f.write(v.get_string(significant_figures=16))
                     else:
                         f.write(v.__str__())
@@ -256,7 +256,7 @@ class VaspInputSetGenerator(InputSetGenerator):
         Tolerance for symmetry finding, used for line mode band structure k-points.
     auto_ispin
         If generating input set from a previous calculation, this controls whether
-        to disable magnetisation (ISPIN = 1) if the absoluate valuue of all magnetic
+        to disable magnetisation (ISPIN = 1) if the absolute value of all magnetic
         moments are less than 0.02.
     config_dict
         The config dictionary to use containing the base input set settings.

--- a/tests/vasp/conftest.py
+++ b/tests/vasp/conftest.py
@@ -30,7 +30,7 @@ def mock_vasp(monkeypatch, vasp_test_dir):
     The primary idea is that instead of running VASP to generate the output files,
     reference files will be copied into the directory instead. As we do not want to
     test whether VASP is giving the correct output rather that the calculation inputs
-    are generated correctly and that the ouputs are parsed properly, this should be
+    are generated correctly and that the outputs are parsed properly, this should be
     sufficient for our needs. An other potential issue is that the POTCAR files
     distribute with VASP are not present on the testing server due to licensing
     constraints. Accordingly, VaspInputSet.write_inputs will fail unless the


### PR DESCRIPTION
I was looking through the code trying to get a feel for the new atomate. 😄 

Noticed the default `ibands` value in `calculate_deformation_potentials()` will raise

```py
TypeError: 'NoneType' object is not iterable
```

https://github.com/materialsproject/atomate2/blob/c3d3fcd3e6edb8bb069cb0c23193ce1f356ed6b7/src/atomate2/vasp/jobs/amset.py

Happy to fix as part of this PR. Should `ibands` become a required arg?