### PR TITLE
Quick start guide

### DIFF
--- a/docs/src/user/install.rst
+++ b/docs/src/user/install.rst
@@ -157,8 +157,8 @@ Create a conda environment
 
 .. note::
 
-   Make sure to create a Python 3.7+ environment as recent versions of atomate2 only
-   support Python 3.7 and higher.
+   Make sure to create a Python 3.8+ environment as recent versions of atomate2 only
+   support Python 3.8 and higher.
 
 We highly recommended that you organize your installation of the atomate2 and the other
 Python codes using a conda virtual environment. Some of the main benefits are:


### PR DESCRIPTION
This is still a WIP. I was reading the [Quick Start](https://materialsproject.github.io/atomate2/user/index.html#quick-start) guide which is very well done! Props for starting out with good docs! 👍 

I think just showing this code snippets could lead to misunderstanding for new users though. People might just run `pip install atomate2` and try to run the snippet, not knowing that it requires

- setting `PMG_VASP_PSP_DIR` in `~/.pmgrc.yaml` to a directory with VASP POTCAR files
- telling `atomate2` where to find your VASP binary
- and having a MongoDB ready to accept incoming connections.

Encountering unexpected errors early on can be discouraging so maybe best to list these requirements immediately after the snippet?

```python
from atomate2.vasp.flows.core import RelaxBandStructureMaker
from jobflow import run_locally
from pymatgen.core import Structure

# construct a rock salt MgO structure
mgo_structure = Structure(
    lattice=[[0, 2.13, 2.13], [2.13, 0, 2.13], [2.13, 2.13, 0]],
    species=["Mg", "O"],
    coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
)

# make a band structure flow to optimise the structure and obtain the band structure
bandstructure_flow = RelaxBandStructureMaker().make(mgo_structure)

# run the job
run_locally(bandstructure_flow, create_folders=True)
```