### PR TITLE
Refactor `test_copy_vasp_outputs` to use builtin `tmp_path` + `monkeypatch` fixtures

### DIFF
--- a/docs/src/user/codes/vasp.rst
+++ b/docs/src/user/codes/vasp.rst
@@ -370,7 +370,7 @@ There are two options when chaining workflows:
    these outputs include INCAR settings, the band gap (used to automatically
    set KSPACING), and the magnetic moments. Some workflows will also use other outputs.
    For example, the `Band Structure`_ workflow will copy the CHGCAR file (charge
-   density) from the previous calculation. This can be achieve by setting both the
+   density) from the previous calculation. This can be achieved by setting both the
    ``structure`` and ``prev_vasp_dir`` arguments.
 
 These two examples are illustrated in the code below, where we chain a relaxation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,21 +43,6 @@ def clean_dir(debug_mode):
         shutil.rmtree(newpath)
 
 
-@pytest.fixture
-def tmp_dir():
-    """Same as clean_dir but is fresh for every test"""
-    import os
-    import shutil
-    import tempfile
-
-    old_cwd = os.getcwd()
-    newpath = tempfile.mkdtemp()
-    os.chdir(newpath)
-    yield
-    os.chdir(old_cwd)
-    shutil.rmtree(newpath)
-
-
 @pytest.fixture(scope="session")
 def debug_mode():
     return False

--- a/tests/vasp/test_files.py
+++ b/tests/vasp/test_files.py
@@ -9,11 +9,14 @@ import pytest
         ({"additional_vasp_files": ("CHGCAR",)}, ("POSCAR", "INCAR", "CHGCAR")),
     ],
 )
-def test_copy_vasp_outputs_static(vasp_test_dir, tmp_dir, copy_kwargs, files):
+def test_copy_vasp_outputs_static(
+    vasp_test_dir, tmp_path, monkeypatch, copy_kwargs, files
+):
     from pathlib import Path
 
     from atomate2.vasp.files import copy_vasp_outputs
 
+    monkeypatch.chdir(tmp_path)
     path = vasp_test_dir / "Si_band_structure" / "static" / "outputs"
     copy_vasp_outputs(src_dir=path, **copy_kwargs)
 
@@ -29,11 +32,15 @@ def test_copy_vasp_outputs_static(vasp_test_dir, tmp_dir, copy_kwargs, files):
         ({"additional_vasp_files": ("vasp.out",)}, ("POSCAR", "INCAR", "vasp.out")),
     ],
 )
-def test_copy_vasp_outputs_double(vasp_test_dir, tmp_dir, copy_kwargs, files):
+def test_copy_vasp_outputs_double(
+    vasp_test_dir, tmp_path, monkeypatch, copy_kwargs, files
+):
+
     from pathlib import Path
 
     from atomate2.vasp.files import copy_vasp_outputs
 
+    monkeypatch.chdir(tmp_path)
     path = vasp_test_dir / "Si_old_double_relax" / "outputs"
     copy_vasp_outputs(src_dir=path, **copy_kwargs)
 


### PR DESCRIPTION
Closes #103.