### PR TITLE
fixed gzipping of files like `WSWQ.1`

### DIFF
--- a/src/atomate2/common/files.py
+++ b/src/atomate2/common/files.py
@@ -307,7 +307,7 @@ def find_and_filter_files(
 
     if include_files is None:
         files = file_client.listdir(directory, host=host)
-        files = [f for f in files if file_client.is_file(f, host=host)]
+        files = [f for f in files if file_client.is_file(directory / f, host=host)]
     else:
         files = []
         for file in include_files:

--- a/src/atomate2/utils/file_client.py
+++ b/src/atomate2/utils/file_client.py
@@ -375,7 +375,7 @@ class FileClient:
             Overwrite gzipped file if it already exists.
         """
         path = self.abspath(path, host=host)
-        path_gz = path.with_suffix(".gz")
+        path_gz = path.parent / (f"{path.name}.gz")
 
         if str(path).lower().endswith("gz"):
             warnings.warn(f"{path} is already gzipped, skipping...")

--- a/src/atomate2/utils/file_client.py
+++ b/src/atomate2/utils/file_client.py
@@ -375,7 +375,7 @@ class FileClient:
             Overwrite gzipped file if it already exists.
         """
         path = self.abspath(path, host=host)
-        path_gz = path.parent / (f"{path.name}.gz")
+        path_gz = path.parent / f"{path.name}.gz"
 
         if str(path).lower().endswith("gz"):
             warnings.warn(f"{path} is already gzipped, skipping...")


### PR DESCRIPTION
## Summary

The current behavior will copy all files with a suffix `WSWQ.1` `WSWQ.2` to a single `WSWQ.gz` file since `path.with_suffix` just replaces the suffix.
I think gzipping should always keep the original suffix.

Also think the line in `find_and_filter_files` is a typo.