### PR TITLE
Fix f-orbital DOS properties

### DIFF
--- a/src/atomate2/vasp/schemas/calculation.py
+++ b/src/atomate2/vasp/schemas/calculation.py
@@ -841,7 +841,6 @@ def _get_band_props(
             OrbitalType.s,
             OrbitalType.p,
             OrbitalType.d,
-            OrbitalType.f,
         ]:
             orb_name = orb_type.name
             if (


### PR DESCRIPTION
Addresses #135. Because `get_element_spd_dos()` in `pymatgen` does not parse DOS data for f-orbitals, the schema for DOS properties breaks for such elements. This PR only tabulates DOS properties for s-, p-, and d-orbitals. 

Assuming a test case is desired, I'll need to run a calculation with f-orbitals first. Still working remotely, so I might need a day or two for that.