### PR TITLE
Configure CI to use `setup-python`'s built-in `pip` caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/docs_manual.yml
+++ b/.github/workflows/docs_manual.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -38,37 +40,32 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v3
-      with:
-        python-version:  ${{ matrix.python-version }}
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/setup.py') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.python-version }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+            pip install .[strict]
+            pip install .[tests]
+            pip install .[docs]
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-          pip install .[strict]
-          pip install .[tests]
-          pip install .[docs]
+      - name: Test
+        run: pytest --cov=atomate2 --cov-report=xml
 
-    - name: Test
-      run: pytest --cov=atomate2 --cov-report=xml
-
-    - uses: codecov/codecov-action@v1
-      if: matrix.python-version == '3.10' && github.repository == 'materialsproject/atomate2'
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+      - uses: codecov/codecov-action@v1
+        if: matrix.python-version == '3.10' && github.repository == 'materialsproject/atomate2'
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
 
   docs:
     runs-on: ubuntu-latest
@@ -79,6 +76,8 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: '3.10'
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
`setup-python` has [built-in `pip` dependency caching](https://github.blog/changelog/2021-11-23-github-actions-setup-python-now-supports-dependency-caching).

Note caching was not working before as it [used the hash of non-existent `setup.py` as the cache key](https://github.com/materialsproject/atomate2/compare/main...janosh:ci-deps-caching?expand=1#diff-7dc87d4394e1756c519dbfd0b80d3b31377f643f0bc25d3ed807ce8a3794023dL53).

Equivalent PR to pymatgen: https://github.com/materialsproject/pymatgen/pull/2401

Also moves `codespell` pre-commit config to `setup.cfg`. I noticed `setup.cfg` was emptied in b82138e so I tried adding it to `pyproject.toml` instead but found that's not supported yet. Tracking issue: https://github.com/codespell-project/codespell/issues/2055

Curious why did you decide to [keep `setup.cfg` around](https://stackoverflow.com/a/34111495)?