### PR TITLE
Fix mock_run_vasp to accept args and test docs

### DIFF
--- a/docs/dev/vasp_tests.md
+++ b/docs/dev/vasp_tests.md
@@ -69,9 +69,10 @@ from monty.serialization import dumpfn
 
 # silicon structure
 si_structure = Structure(
-    lattice=[[3.348898, 0.0, 1.933487],
-             [1.116299, 3.157372, 1.933487],
-             [0.0, 0.0, 3.866975],
+    lattice=[
+        [3.348898, 0.0, 1.933487],
+        [1.116299, 3.157372, 1.933487],
+        [0.0, 0.0, 3.866975],
     ],
     species=["Si", "Si"],
     coords=[[0.25, 0.25, 0.25], [0, 0, 0]],

--- a/docs/dev/vasp_tests.md
+++ b/docs/dev/vasp_tests.md
@@ -74,7 +74,7 @@ si_structure = Structure(
              [0.0, 0.0, 3.866975],
     ],
     species=["Si", "Si"],
-    coords=[[0, 0, 0], [0.25, 0.25, 0.25]],
+    coords=[[0.25, 0.25, 0.25], [0, 0, 0]],
 )
 
 # generate the flow and reduce the k-point mesh for the relaxation jobs

--- a/docs/dev/vasp_tests.md
+++ b/docs/dev/vasp_tests.md
@@ -69,16 +69,19 @@ from monty.serialization import dumpfn
 
 # silicon structure
 si_structure = Structure(
-    lattice=[[0, 2.73, 2.73], [2.73, 0, 2.73], [2.73, 2.73, 0]],
+    lattice=[[3.348898, 0.0, 1.933487],
+             [1.116299, 3.157372, 1.933487],
+             [0.0, 0.0, 3.866975],
+    ],
     species=["Si", "Si"],
     coords=[[0, 0, 0], [0.25, 0.25, 0.25]],
 )
 
 # generate the flow and reduce the k-point mesh for the relaxation jobs
 flow = ElasticMaker().make(si_structure)
-update_user_kpoints_settings(flow, {"grid_density": 100}, name_filter="relax")
+flow = update_user_kpoints_settings(flow, {"grid_density": 100}, name_filter="relax")
 
-# run the the workflow using a custom store so that we can easily compile test data
+# run the workflow using a custom store so that we can easily compile test data
 store = JobStore(MemoryStore(), additional_stores={"data": MemoryStore()})
 run_locally(flow, store=store, create_folders=True)
 

--- a/tests/vasp/conftest.py
+++ b/tests/vasp/conftest.py
@@ -65,7 +65,7 @@ def mock_vasp(monkeypatch, vasp_test_dir):
     import atomate2.vasp.run
     from atomate2.vasp.sets.base import VaspInputGenerator
 
-    def mock_run_vasp():
+    def mock_run_vasp(*args, **kwargs):
         from jobflow import CURRENT_JOB
 
         name = CURRENT_JOB.job.name


### PR DESCRIPTION
This PR introduces two fixes related to the test system. 

- Fix `mock_run_vasp` to accept `*args` and `**kwargs` to match the signature of `run_vasp`. Otherwise, if a job maker sets some of these arguments (for example, the coming MD maker will set `handler`), the test will fail.  

- Fix doc on writing tests: changing the unit cell of the Si structure to avoid failing [check_poscar](https://github.com/materialsproject/atomate2/blob/a31b86b1e2f4d1a6665be7764c5cc67673904c91/tests/vasp/conftest.py#L200). In `check_poscar`, the `user` poscar will use a lattice of 
  ```
  3.348898 0.000000 1.933487
  1.116299 3.157372 1.933487
  0.000000 0.000000 3.866975
  ```
  while the `ref` poscar will use whatever lattice provided in the test file. The current doc on test suggests to use 
```
0.000000 2.730000 2.730000
2.730000 0.000000 2.730000
2.730000 2.730000 0.000000
```
 
  A test will fail if the two do not match. Currently, I just update the doc to make the the same. But I believe there should be better ways to do it. For example, what if a new maker do not want to use Si as the test system? Basically, it seems the `user` poscar is hard-coded? I know it is copied from somewhere to a tmpdir (cwd), but I don't know where the copy happens.  



## Additional dependencies introduced (if any)
None

## TODO (if any)
None

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](
  https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by [flake8](
  http://flake8.pycqa.org/en/latest/).
- [NA] Docstrings have been added in the[Numpy docstring format](
  https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [NA] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to
  type check your code.
- [NA] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.