### PR TITLE
Skip test if `MP_API_KEY` environment variable not set

### DIFF
--- a/tests/common/test_jobs.py
+++ b/tests/common/test_jobs.py
@@ -1,4 +1,6 @@
-from pytest import approx
+import os
+
+from pytest import approx, mark
 
 
 def test_structure_to_primitive(si_structure):
@@ -27,7 +29,7 @@ def test_structure_to_conventional(si_structure):
     assert output.lattice.alpha == approx(90)
 
 
-@pytest.mark.skipif(not os.environ.get("MP_API_KEY"))
+@mark.skipif(not os.environ.get("MP_API_KEY"))
 def test_retrieve_structure_from_materials_project():
     from datetime import datetime
 

--- a/tests/common/test_jobs.py
+++ b/tests/common/test_jobs.py
@@ -29,7 +29,10 @@ def test_structure_to_conventional(si_structure):
     assert output.lattice.alpha == approx(90)
 
 
-@mark.skipif(not os.environ.get("MP_API_KEY"))
+@mark.skipif(
+    not os.environ.get("MP_API_KEY"),
+    reason="Materials Project API key not set in environment.",
+)
 def test_retrieve_structure_from_materials_project():
     from datetime import datetime
 

--- a/tests/common/test_jobs.py
+++ b/tests/common/test_jobs.py
@@ -27,6 +27,7 @@ def test_structure_to_conventional(si_structure):
     assert output.lattice.alpha == approx(90)
 
 
+@pytest.mark.skipif(not os.environ.get("MP_API_KEY"))
 def test_retrieve_structure_from_materials_project():
     from datetime import datetime
 


### PR DESCRIPTION
Fix for test running via PRs. See discussion in #177. Hopefully this will do it!