### PR TITLE
Correct calcs_reversed to real reverse order

### DIFF
--- a/src/atomate2/vasp/schemas/task.py
+++ b/src/atomate2/vasp/schemas/task.py
@@ -52,7 +52,9 @@ class AnalysisSummary(BaseModel):
     errors: List[str] = Field(None, description="Errors from the VASP drone")
 
     @classmethod
-    def from_vasp_calc_docs(cls, calcs_reversed: List[Calculation]) -> "AnalysisSummary":
+    def from_vasp_calc_docs(
+        cls, calcs_reversed: List[Calculation]
+    ) -> "AnalysisSummary":
         """
         Create analysis summary from VASP calculation documents.
 

--- a/tests/vasp/schemas/conftest.py
+++ b/tests/vasp/schemas/conftest.py
@@ -56,7 +56,7 @@ class SiOptimizeDouble(SchemaTestData):
             "contcar_file": "CONTCAR.relax1.gz",
         },
     }
-    objects = {"relax1": []}
+    objects = {"relax2": []}
     task_doc = {
         "calcs_reversed": [
             {

--- a/tests/vasp/schemas/conftest.py
+++ b/tests/vasp/schemas/conftest.py
@@ -61,16 +61,16 @@ class SiOptimizeDouble(SchemaTestData):
         "calcs_reversed": [
             {
                 "output": {
-                    "vbm": 5.6149,
-                    "cbm": 6.2649,
-                    "bandgap": 0.65,
+                    "vbm": 5.6147,
+                    "cbm": 6.2652,
+                    "bandgap": 0.6505,
                     "is_gap_direct": False,
                     "is_metal": False,
                     "transition": "(0.000,0.000,0.000)-(0.375,0.375,0.000)",
                     "direct_gap": 2.5561,
                     "run_stats": {
                         "average_memory": 0,
-                        "max_memory": 28640.0,
+                        "max_memory": 28096.0,
                         "cores": 16,
                     },
                 },

--- a/tests/vasp/schemas/conftest.py
+++ b/tests/vasp/schemas/conftest.py
@@ -43,17 +43,17 @@ class SchemaTestData:
 class SiOptimizeDouble(SchemaTestData):
     folder = "Si_old_double_relax"
     task_files = {
-        "relax1": {
-            "vasprun_file": "vasprun.xml.relax1.gz",
-            "outcar_file": "OUTCAR.relax1.gz",
-            "volumetric_files": ["CHGCAR.relax1.gz"],
-            "contcar_file": "CONTCAR.relax1.gz",
-        },
         "relax2": {
             "vasprun_file": "vasprun.xml.relax2.gz",
             "outcar_file": "OUTCAR.relax2.gz",
             "volumetric_files": ["CHGCAR.relax2.gz"],
             "contcar_file": "CONTCAR.relax2.gz",
+        },
+        "relax1": {
+            "vasprun_file": "vasprun.xml.relax1.gz",
+            "outcar_file": "OUTCAR.relax1.gz",
+            "volumetric_files": ["CHGCAR.relax1.gz"],
+            "contcar_file": "CONTCAR.relax1.gz",
         },
     }
     objects = {"relax1": []}

--- a/tests/vasp/schemas/test_calculation.py
+++ b/tests/vasp/schemas/test_calculation.py
@@ -55,7 +55,7 @@ def test_calculation_input(vasp_test_dir, object_name, task_name):
 @pytest.mark.parametrize(
     "object_name,task_name",
     [
-        pytest.param("SiOptimizeDouble", "relax1", id="SiOptimizeDouble"),
+        pytest.param("SiOptimizeDouble", "relax2", id="SiOptimizeDouble"),
         pytest.param("SiStatic", "standard", id="SiStatic"),
         pytest.param("SiNonSCFUniform", "standard", id="SiNonSCFUniform"),
     ],
@@ -133,7 +133,7 @@ def test_run_statistics(vasp_test_dir, object_name, task_name):
 @pytest.mark.parametrize(
     "object_name,task_name",
     [
-        pytest.param("SiOptimizeDouble", "relax1", id="SiOptimizeDouble"),
+        pytest.param("SiOptimizeDouble", "relax2", id="SiOptimizeDouble"),
         pytest.param("SiStatic", "standard", id="SiStatic"),
         pytest.param("SiNonSCFUniform", "standard", id="SiNonSCFUniform"),
     ],

--- a/tests/vasp/schemas/test_task.py
+++ b/tests/vasp/schemas/test_task.py
@@ -20,12 +20,14 @@ def test_analysis_summary(vasp_test_dir, object_name):
     test_object = get_test_object(object_name)
     dir_name = vasp_test_dir / test_object.folder / "outputs"
 
-    calcs_docs = []
+    calcs_reversed = []
     for task_name, files in test_object.task_files.items():
         doc, _ = Calculation.from_vasp_files(dir_name, task_name, **files)
-        calcs_docs.append(doc)
+        calcs_reversed.append(doc)
+        ## The 2 tasks of double-relaxation have been reversed in "/atomate2/tests/vasp/schemas/conftest.py" for "SiOptimizeDouble"
+        ## task_files are in the order of {"relax2","relax1"}
 
-    test_doc = AnalysisSummary.from_vasp_calc_docs(calcs_docs)
+    test_doc = AnalysisSummary.from_vasp_calc_docs(calcs_reversed)
     valid_doc = test_object.task_doc["analysis"]
     assert_schemas_equal(test_doc, valid_doc)
 


### PR DESCRIPTION
## Summary

Follow-up PR from Issue <https://github.com/materialsproject/atomate2/issues/171>:

* Correct `calcs_reversed` in reverse order and make it unified throughout in 
* Unify `calcs_reversed` throughout and drop the positive order docs of `calc_docs`
* Fix tests


