### PR TITLE
[WIP] Atom-Level schemas for basis sets and pseudopotentials

### DIFF
--- a/src/atomate2/common/schemas/atoms/__init__.py
+++ b/src/atomate2/common/schemas/atoms/__init__.py
@@ -1,0 +1,1 @@
+"Schemas for atom-level descriptions in DFT calculations"

--- a/src/atomate2/common/schemas/atoms/basis.py
+++ b/src/atomate2/common/schemas/atoms/basis.py
@@ -1,0 +1,53 @@
+"""Schemas for basis set repreesntations"""
+
+from typing import Dict, Sequence
+from pydantic import BaseModel, Field
+from jobflow.utils import ValueEnum
+from pymatgen.core import Element
+
+class BasisType(ValueEnum):
+
+    GTO = "Gaussian Type Orbitals"
+    LCAO = "Linear Combination of Atomic Orbitals"
+    PW = "Plane Waves"
+    SLATER = "Slater Type Orbitals"
+
+class BasisCardinality(ValueEnum):
+
+    SZV = "SZV"
+    SZVP = "SZVP"
+    DZV = "DZV"
+    DZVP = "DZVP"
+    TZV = "TZV"
+    TZVP = "TZVP"
+    TZV2P = "TZV2P"
+    QZVP = "QZVP"
+    QZV2P = "QZV2P"
+
+class BasisSet(BaseModel):
+
+    element: Element = Field(None, description="Element for this basis set (if local)")
+    basis_type: BasisType = Field(None, description="Type of basis set")
+    name: str = Field(None, description="Name of this basis set")
+    alias_names: Sequence = Field(None, description="Optional aliases for this basis set")
+    filename: str = Field(None, description="Name of the file containing this basis")
+    version: str = Field(None, description="Version for this basis set")
+
+class GaussianTypeOrbitalBasisSet(BasisSet):
+
+    basis_type = BasisType.GTO
+    cardinality: BasisCardinality = Field(None, description="Cardinality of this basis") 
+    nset: int = Field(None, description="Number of exponent sets")
+    n: int = Field(None, description="Principle quantum number")
+    lmax: int = Field(None, description="Maximum angular momentum quantum number")
+    lmin: int = Field(None, description="Minimum angular momentum quantum number")
+    nshell: Sequence = Field(None, description="Number of shells for angular momentum quantum number from lmin to lmax")
+    exponents: Sequence = Field(None, description="Exponents")
+    coefficients: Dict[int, Dict[int, Dict[int, float]]] = Field(None, description="Contraction coefficients Dict[exp->l->shell]")
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @property
+    def nexp(self):
+        return len(self.exponents)

--- a/src/atomate2/common/schemas/atoms/psuedo.py
+++ b/src/atomate2/common/schemas/atoms/psuedo.py
@@ -1,0 +1,32 @@
+from typing import Dict, Sequence
+from pydantic import BaseModel, Field
+from jobflow.utils import ValueEnum
+from pymatgen.electronic_structure.core import Orbital, OrbitalType
+
+class PseudoPotentialType(ValueEnum):
+
+    PAW = "Projector Augmented Wave"
+    NC = "Norm Conserving"
+    US = "Ultra Soft"
+    GTH = "Goedecker-Teter-Hutter Norm Conserving"
+
+class PseudoPotential(BaseModel):
+
+    pseudopotential_type: PseudoPotentialType = Field(None, description="Type of pseudopotential")
+    name: str = Field(None, description="Name of this pseudopotential")
+    filename: str = Field(None, description="Name of the file containing this pseudopotential")
+    functional: str = Field(None, description="Specific functional for which this pseudopotential was optimized")
+    version: str = Field(None, description="Version for this pseudopotential")
+
+class GthPseudopotential(PseudoPotential):
+
+    pseudopotential_type = PseudoPotentialType.GTH
+
+    n_elecs: Dict[int, int] = Field(None, description="Number of electrons for each quantum number n")
+    r_loc: float = Field(None, description="Radius for the local part defined by the Gaussian function exponent alpha_erf")
+    nexp_ppl: int = Field(None, description="Number of the local pseudopotential functions")
+    c_exp_ppl: Sequence = Field(None, description="Coefficients of the local pseudopotential functions")
+    r: float = Field(None, description="Radius of the nonlocal part for angular momentum quantum number l defined by the Gaussian function exponents alpha_prj_ppnl")
+    nprj_ppnl: Dict[int, int] = Field(None, description="Number of the non-local projectors for the angular momentum quantum number l")
+    hprj_ppnl: Dict[int, Sequence] = Field(None, description="Coefficients of the non-local projector functions")
+    


### PR DESCRIPTION
This PR is to get the ball rolling on an idea I have for defining basis sets and pseudopotentials as pydantic objects in atomate2. I was planning on putting this in my new cp2k module to help with versioning and tracking all the different basis sets and pseudopotentials that cp2k outputs, but it could also be useful for other DFT codes so I'd like to share.

Definitely a WIP so any thoughts would be appreciated.