### PR TITLE
[WIP] Added waveder support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ docs/reference/atomate2.*
 .vscode/
 
 .DS_Store
+
+env/

--- a/src/atomate2/vasp/jobs/base.py
+++ b/src/atomate2/vasp/jobs/base.py
@@ -16,7 +16,7 @@ from pymatgen.electronic_structure.bandstructure import (
     BandStructureSymmLine,
 )
 from pymatgen.electronic_structure.dos import DOS, CompleteDos, Dos
-from pymatgen.io.vasp import Chgcar, Locpot, Wavecar
+from pymatgen.io.vasp import Chgcar, Locpot, Wavecar, Waveder
 
 from atomate2.vasp.files import copy_vasp_outputs, write_vasp_input_set
 from atomate2.vasp.run import run_vasp, should_stop_children
@@ -35,6 +35,7 @@ _DATA_OBJECTS = [
     Locpot,
     Chgcar,
     Wavecar,
+    Waveder,
     Trajectory,
     "force_constants",
     "normalmode_eigenvecs",

--- a/src/atomate2/vasp/schemas/calculation.py
+++ b/src/atomate2/vasp/schemas/calculation.py
@@ -25,6 +25,7 @@ from pymatgen.io.vasp import (
     PotcarSingle,
     Vasprun,
     VolumetricData,
+    Waveder,
 )
 
 from atomate2 import SETTINGS
@@ -80,6 +81,7 @@ class VaspObject(ValueEnum):
     LOCPOT = "locpot"
     OPTIC = "optic"
     PROCAR = "proj"
+    WAVEDER = "waveder"
 
 
 class PotcarSpec(BaseModel):
@@ -598,6 +600,7 @@ class Calculation(BaseModel):
             Tuple[str]
         ] = SETTINGS.VASP_STORE_VOLUMETRIC_DATA,
         store_trajectory: bool = False,
+        store_waveder: bool = False,
         vasprun_kwargs: Optional[Dict] = None,
     ) -> Tuple["Calculation", Dict[VaspObject, Dict]]:
         """
@@ -653,6 +656,9 @@ class Calculation(BaseModel):
             This can help reduce the size of DOS objects in systems with many atoms.
         store_volumetric_data
             Which volumetric files to store.
+        store_waveder
+            Whether to store the contents of the binary WAVEDER file.
+            Which is used to compute frequency dependent dielectric functions.
         store_trajectory
             Whether to store the ionic steps in a pymatgen Trajectory object. if `True`,
             :obj:'.CalculationOutput.ionic_steps' is set to None to reduce duplicating
@@ -724,6 +730,12 @@ class Calculation(BaseModel):
                 constant_lattice=False,
             )
             vasp_objects[VaspObject.TRAJECTORY] = traj  # type: ignore
+
+        if store_waveder:
+            wavder = _parse_waveder(dir_name)
+            if wavder is None:
+                raise RuntimeError(f"WAVEDER file not found in directory {dir_name}.")
+            vasp_objects[VaspObject.WAVEDER] = wavder  # type: ignore
 
         # MD run
         if vasprun.parameters.get("IBRION", -1) == 0:
@@ -817,6 +829,26 @@ def _get_volumetric_data(
         except Exception:
             raise ValueError(f"Failed to parse {file_type} at {file}.")
     return volumetric_data
+
+
+def _parse_waveder(dir_name: Path) -> Optional[Waveder]:
+    """
+    Parse the WAVEDER file.
+
+    Parameters
+    ----------
+    dir_name
+        The directory containing the WAVEDER file.
+
+    Returns
+    -------
+    Optional[Waveder]
+        The WAVEDER data.
+    """
+    try:
+        return Waveder.from_binary(dir_name / "WAVEDER")
+    except Exception:
+        return None
 
 
 def _parse_dos(parse_mode: Union[str, bool], vasprun: Vasprun) -> Optional[Dos]:


### PR DESCRIPTION
## Added support to store Wavder objects in pymatgen

The `Wavder` object is helpful for a host of optical analysis functions so I'm trying to figure out how to store it properly.
I'm of the opinion that by default people will not want to use it for general optical workflows but will like to have it for special cases.

@utf do you think just adding a basic parser like this is OK, also do you have any opinion on how test files should be added?
These files are quite large so I was thinking about spoofing something in the current optics test folders.

