### PR TITLE
Point pre-commit to the correct flake8 repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   rev: 5.10.1
   hooks:
   - id: isort
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,17 +27,17 @@ repos:
   hooks:
   - id: isort
 - repo: https://github.com/pycqa/flake8
-  rev: 3.9.2
+  rev: 5.0.4
   hooks:
   - id: flake8
     entry: pflake8
     files: ^src/
     additional_dependencies:
-    - pyproject-flake8==v0.0.1a4
-    - flake8-bugbear==22.4.25
-    - flake8-typing-imports==1.10.1
+    - pyproject-flake8==5.0.4
+    - flake8-bugbear==22.10.27
+    - flake8-typing-imports==1.14.0
     - flake8-docstrings==1.6.0
-    - flake8-rst-docstrings==0.2.3
+    - flake8-rst-docstrings==0.3.0
     - flake8-rst==0.8.0
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.9.0


### PR DESCRIPTION
Flake8 has finished migrating to GitHub and the old GitLab repo has been removed ([see this video](https://www.youtube.com/watch?v=1FIgj9Q5e6A) for some fun context...), which currently breaks anyone installing the hooks in a fresh environment (i.e., the CI). 

This PR simply points the pre-commit hook to the correct repo, and also bumps the flake8 and plugin versions.

~As the flake8 GitLab had not been receiving new releases, the version of flake8 used by pre-commit here is now 2 major versions behind (3.9 vs 5.0). I tried simply updating it, but there is clearly some incompatibility with the other flake8 plugins that needs to be resolved. I imagine this is more easily fixed in a pre-commit update PRs (like #202).~

Wasn't too difficult in the end, there are however some outstanding errors about line-length that were not picked up with the previous version for flake8 for some reason (presumably will be visible in the CI once this workflow runs).


## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

- [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](
  https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [pycodestyle](https://pycodestyle.readthedocs.io/en/latest/), followed by [flake8](
  http://flake8.pycqa.org/en/latest/).
- [x] Docstrings have been added in the[Numpy docstring format](
  https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [pydocstyle](http://www.pydocstyle.org/en/2.1.1/index.html) on your code.
- [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org/) to
  type check your code.
- [x] Tests have been added for any new functionality or bug fixes.
- [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
