### PR TITLE
fix lso dos of lobster being not saved in schema

### DIFF
--- a/src/atomate2/lobster/schemas.py
+++ b/src/atomate2/lobster/schemas.py
@@ -536,7 +536,7 @@ class LobsterTaskDocument(BaseModel):
 
         # Read in LSO DOS
         lso_dos = None
-        doscar_lso_path = dir_name / "DOSCAR.LSO.lobster"
+        doscar_lso_path = dir_name / "DOSCAR.LSO.lobster.gz"
         if store_lso_dos and doscar_lso_path.exists():
             doscar_lso_lobster = Doscar(
                 doscar=doscar_lso_path, structure_file=structure_path


### PR DESCRIPTION
## Summary

Schema update
Issue -  LSO DOSCAR from lobster did not get added due to a missing file extension
Fix - update the schema to fix this issue