### PR TITLE
fix _get_strong_bonds function

### DIFF
--- a/src/atomate2/lobster/schemas.py
+++ b/src/atomate2/lobster/schemas.py
@@ -706,13 +706,24 @@ def _get_strong_bonds(
             rel_bnd_list = rel_bnd.split("-")
             rel_bnd_list.sort()
             if label == rel_bnd_list:
-                index = np.argmin(sep_icohp[i])
-                bond_dict.update(
-                    {
-                        rel_bnd: {
-                            prop: min(sep_icohp[i]),
-                            "length": sep_lengths[i][index],
+                if prop == "ICOHP":
+                    index = np.argmin(sep_icohp[i])
+                    bond_dict.update(
+                        {
+                            rel_bnd: {
+                                prop: min(sep_icohp[i]),
+                                "length": sep_lengths[i][index],
+                            }
                         }
-                    }
-                )
+                    )
+                else:
+                    index = np.argmax(sep_icohp[i])
+                    bond_dict.update(
+                        {
+                            rel_bnd: {
+                                prop: max(sep_icohp[i]),
+                                "length": sep_lengths[i][index],
+                            }
+                        }
+                    )
     return bond_dict

--- a/tests/vasp/lobster/schemas/test_lobster.py
+++ b/tests/vasp/lobster/schemas/test_lobster.py
@@ -30,10 +30,10 @@ def test_LobsterTaskDocument(lobster_test_dir):
         doc.strongest_bonds_icohp.strongest_bonds["As-Ga"]["ICOHP"], -4.32971
     )
     assert np.isclose(
-        doc.strongest_bonds_icobi.strongest_bonds["As-Ga"]["ICOBI"], 0.8269299999999999
+        doc.strongest_bonds_icobi.strongest_bonds["As-Ga"]["ICOBI"], 0.82707
     )
     assert np.isclose(
-        doc.strongest_bonds_icoop.strongest_bonds["As-Ga"]["ICOOP"], 0.31381
+        doc.strongest_bonds_icoop.strongest_bonds["As-Ga"]["ICOOP"], 0.31405
     )
     assert np.isclose(
         doc.strongest_bonds_icohp.strongest_bonds["As-Ga"]["length"], 2.4899
@@ -53,11 +53,11 @@ def test_LobsterTaskDocument(lobster_test_dir):
     )
     assert np.isclose(
         doc.strongest_bonds_icobi_cation_anion.strongest_bonds["As-Ga"]["ICOBI"],
-        0.8269299999999999,
+        0.82707,
     )
     assert np.isclose(
         doc.strongest_bonds_icoop_cation_anion.strongest_bonds["As-Ga"]["ICOOP"],
-        0.31381,
+        0.31405,
     )
     assert np.isclose(
         doc.strongest_bonds_icohp_cation_anion.strongest_bonds["As-Ga"]["length"],


### PR DESCRIPTION
## Strongest bonds for ICOBI and ICOBI were incorrect


* Fixes introduced in the associated `_get_strong_bonds` function in schema.