### PR TITLE
Add missing `molecule` field to cclib `TaskDocument`

### DIFF
--- a/src/atomate2/common/schemas/cclib.py
+++ b/src/atomate2/common/schemas/cclib.py
@@ -249,6 +249,7 @@ class TaskDocument(MoleculeMetadata):
             attributes=attributes,
             metadata=metadata,
         )
+        doc["molecule"] = final_molecule
         doc = doc.copy(update=additional_fields)
         return doc
 

--- a/src/atomate2/common/schemas/cclib.py
+++ b/src/atomate2/common/schemas/cclib.py
@@ -248,7 +248,7 @@ class TaskDocument(MoleculeMetadata):
             attributes=attributes,
             metadata=metadata,
         )
-        doc["molecule"] = final_molecule
+        doc.molecule = final_molecule
         doc = doc.copy(update=additional_fields)
         return doc
 

--- a/src/atomate2/common/schemas/cclib.py
+++ b/src/atomate2/common/schemas/cclib.py
@@ -200,7 +200,6 @@ class TaskDocument(MoleculeMetadata):
         initial_molecule = molecules[0]
         final_molecule = molecules[-1]
         attributes["molecule_initial"] = initial_molecule
-        attributes["molecule_final"] = final_molecule
         if store_trajectory:
             attributes["trajectory"] = molecules
 

--- a/tests/common/schemas/test_cclib.py
+++ b/tests/common/schemas/test_cclib.py
@@ -36,6 +36,7 @@ def test_cclib_taskdoc(test_dir):
     assert doc["attributes"]["molecule_final"][0].coords == pytest.approx(
         [0.397382, 0.0, 0.0]
     )
+    assert doc["molecule"] == doc["attributes"]["molecule_final"]
     assert doc["last_updated"] is not None
     assert doc["attributes"]["homo_energies"] == pytest.approx(
         [-7.054007346511501, -11.618445074798501]
@@ -86,6 +87,7 @@ def test_cclib_taskdoc(test_dir):
     assert len(doc["attributes"]["trajectory"]) == 7
     assert doc["attributes"]["trajectory"][0] == doc["attributes"]["molecule_initial"]
     assert doc["attributes"]["trajectory"][-1] == doc["attributes"]["molecule_final"]
+    assert doc["molecule"] == doc["attributes"]["molecule_final"]
 
     # Make sure additional fields can be stored
     doc = TaskDocument.from_logfile(p, ".log", additional_fields={"test": "hi"})

--- a/tests/common/schemas/test_cclib.py
+++ b/tests/common/schemas/test_cclib.py
@@ -33,10 +33,9 @@ def test_cclib_taskdoc(test_dir):
     assert doc.get("metadata", None) is not None
     assert doc["metadata"]["success"] is True
     assert doc["attributes"]["molecule_initial"][0].coords == pytest.approx([0, 0, 0])
-    assert doc["attributes"]["molecule_final"][0].coords == pytest.approx(
+    assert doc["molecule"][0].coords == pytest.approx(
         [0.397382, 0.0, 0.0]
     )
-    assert doc["molecule"] == doc["attributes"]["molecule_final"]
     assert doc["last_updated"] is not None
     assert doc["attributes"]["homo_energies"] == pytest.approx(
         [-7.054007346511501, -11.618445074798501]
@@ -86,8 +85,7 @@ def test_cclib_taskdoc(test_dir):
     doc = TaskDocument.from_logfile(p, ".log", store_trajectory=True).dict()
     assert len(doc["attributes"]["trajectory"]) == 7
     assert doc["attributes"]["trajectory"][0] == doc["attributes"]["molecule_initial"]
-    assert doc["attributes"]["trajectory"][-1] == doc["attributes"]["molecule_final"]
-    assert doc["molecule"] == doc["attributes"]["molecule_final"]
+    assert doc["attributes"]["trajectory"][-1] == doc["molecule"]
 
     # Make sure additional fields can be stored
     doc = TaskDocument.from_logfile(p, ".log", additional_fields={"test": "hi"})

--- a/tests/common/schemas/test_cclib.py
+++ b/tests/common/schemas/test_cclib.py
@@ -33,9 +33,7 @@ def test_cclib_taskdoc(test_dir):
     assert doc.get("metadata", None) is not None
     assert doc["metadata"]["success"] is True
     assert doc["attributes"]["molecule_initial"][0].coords == pytest.approx([0, 0, 0])
-    assert doc["molecule"][0].coords == pytest.approx(
-        [0.397382, 0.0, 0.0]
-    )
+    assert doc["molecule"][0].coords == pytest.approx([0.397382, 0.0, 0.0])
     assert doc["last_updated"] is not None
     assert doc["attributes"]["homo_energies"] == pytest.approx(
         [-7.054007346511501, -11.618445074798501]


### PR DESCRIPTION
Closes #342.