### PR TITLE
More `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 exclude: '^src/atomate2/vasp/schemas/calc_types/|^.github/'
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.265
+  rev: v0.0.269
   hooks:
   - id: ruff
     args: [--fix]
@@ -46,7 +46,7 @@ repos:
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.2.0
+  rev: v1.3.0
   hooks:
   - id: mypy
     files: ^src/

--- a/docs/user/codes/vasp.md
+++ b/docs/user/codes/vasp.md
@@ -284,7 +284,7 @@ for number, (key, cohp) in enumerate(
     plotter = CohpPlotter()
     cohp = Cohp.from_dict(cohp)
     plotter.add_cohp(key, cohp)
-    plotter.save_plot("plots_all_bonds" + str(number) + ".pdf")
+    plotter.save_plot(f"plots_all_bonds{number}.pdf")
 
 for number, (key, cohp) in enumerate(
     result["output"]["lobsterpy_data_cation_anion"]["cohp_plot_data"].items()
@@ -292,7 +292,7 @@ for number, (key, cohp) in enumerate(
     plotter = CohpPlotter()
     cohp = Cohp.from_dict(cohp)
     plotter.add_cohp(key, cohp)
-    plotter.save_plot("plots_cation_anion_bonds" + str(number) + ".pdf")
+    plotter.save_plot(f"plots_cation_anion_bonds{number}.pdf")
 ```
 
 (modifying_input_sets)=

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ ignore = [
     "PLR",     # pylint-refactor
     "PT006",   # pytest-parametrize-names-wrong-type
     # TODO remove PT011, pytest.raises() should always check err msg
+    "PT004", # pytest-missing-fixture-name-underscore
     "PT011", # pytest-raises-too-broad
     "PT013", # pytest-incorrect-pytest-import
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,14 +156,19 @@ select = [
     "RSE", # flake8-raise
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify
-    "TCH", # flake8-type-checking
     "TID", # tidy imports
     "UP",  # pyupgrade
     "W",   # pycodestyle warning
     "YTT", # flake8-2020
 ]
 ignore = [
-    "PT006", # pytest-parametrize-names-wrong-type
+    "PD011",   # pandas-use-of-dot-values
+    "PLC1901", # compare-to-empty-string
+    "PLR",     # pylint-refactor
+    "PT006",   # pytest-parametrize-names-wrong-type
+    # TODO remove PT011, pytest.raises() should always check err msg
+    "PT011", # pytest-raises-too-broad
+    "PT013", # pytest-incorrect-pytest-import
 ]
 pydocstyle.convention = "numpy"
 isort.known-first-party = ["atomate2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,34 +6,34 @@ build-backend = "setuptools.build_meta"
 name = "atomate2"
 description = "atomate2 is a library of materials science workflows"
 readme = "README.md"
-keywords = ["high-throughput", "automated", "workflow", "dft", "vasp"]
+keywords = ["automated", "dft", "high-throughput", "vasp", "workflow"]
 license = { text = "modified BSD" }
 authors = [{ name = "Alex Ganose", email = "alexganose@gmail.com" }]
 dynamic = ["version"]
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
     "Intended Audience :: System Administrators",
-    "Intended Audience :: Information Technology",
     "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Other/Nonlisted Topic",
     "Topic :: Scientific/Engineering",
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "pymatgen>=2023.1.9",
-    "custodian>=2023.3.10",
-    "pydantic",
-    "monty",
-    "jobflow>=0.1.11",
     "PyYAML",
-    "numpy",
     "click",
+    "custodian>=2023.3.10",
     "emmet-core>=0.51.11",
+    "jobflow>=0.1.11",
+    "monty",
+    "numpy",
+    "pydantic",
+    "pymatgen>=2023.1.9",
 ]
 
 [project.optional-dependencies]
@@ -42,36 +42,36 @@ cclib = ["cclib"]
 mp = ["mp-api>=0.27.5"]
 phonons = ["phonopy>=1.10.8", "seekpath"]
 lobster = ["lobsterpy"]
-defects = ["pymatgen-analysis-defects>=2022.11.30", "dscribe>=1.2.0"]
+defects = ["dscribe>=1.2.0", "pymatgen-analysis-defects>=2022.11.30"]
 docs = [
-    "numpydoc==1.5.0",
-    "ipython==8.13.2",
     "FireWorks==2.0.3",
     "autodoc_pydantic==1.8.0",
-    "myst_parser==1.0.0",
     "furo==2023.03.27",
+    "ipython==8.13.2",
     "jsonschema[format]",
+    "myst_parser==1.0.0",
+    "numpydoc==1.5.0",
     "sphinx_design==0.4.1",
 ]
 dev = ["pre-commit>=2.12.1"]
-tests = ["pytest==7.3.1", "pytest-cov==4.0.0", "FireWorks==2.0.3"]
+tests = ["FireWorks==2.0.3", "pytest-cov==4.0.0", "pytest==7.3.1"]
 strict = [
-    "pydantic==1.10.7",
-    "pymatgen==2023.5.10",
-    "custodian==2023.5.12",
-    "monty==2023.5.8",
-    "jobflow==0.1.11",
-    "click==8.1.3",
     "PyYAML==6.0",
     "cclib==1.7.2",
-    "phonopy==2.19.0",
-    "seekpath==2.0.1",
-    "numpy",
-    "mp-api==0.33.2",
+    "click==8.1.3",
+    "custodian==2023.5.12",
     "dscribe==1.2.2",
-    "pymatgen-analysis-defects==2023.5.8",
+    "emmet-core==0.55.0",
+    "jobflow==0.1.11",
     "lobsterpy==0.2.9",
-    "emmet-core==0.55.0"
+    "monty==2023.5.8",
+    "mp-api==0.33.2",
+    "numpy",
+    "phonopy==2.19.0",
+    "pydantic==1.10.7",
+    "pymatgen-analysis-defects==2023.5.8",
+    "pymatgen==2023.5.10",
+    "seekpath==2.0.1",
 ]
 
 [project.scripts]
@@ -110,9 +110,9 @@ no_strict_optional = true
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:.*POTCAR.*:UserWarning",
-    "ignore:.*magmom.*:UserWarning",
-    "ignore:.*is not gzipped.*:UserWarning",
     "ignore:.*input structure.*:UserWarning",
+    "ignore:.*is not gzipped.*:UserWarning",
+    "ignore:.*magmom.*:UserWarning",
     "ignore::DeprecationWarning",
 ]
 
@@ -128,9 +128,9 @@ source = ["src/"]
 skip_covered = true
 show_missing = true
 exclude_lines = [
+    '^\s*@overload( |$)',
     '^\s*assert False(,|$)',
     'if typing.TYPE_CHECKING:',
-    '^\s*@overload( |$)',
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,18 +139,31 @@ select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
     "D",   # pydocstyle
-    "E",   # pycodestyle
+    "E",   # pycodestyle error
+    "EXE", # flake8-executable
     "F",   # pyflakes
+    "FLY", # flynt
     "I",   # isort
-    "PLE", # pylint error
-    "PLW", # pylint warning
+    "ICN", # flake8-import-conventions
+    "ISC", # flake8-implicit-str-concat
+    "PD",  # pandas-vet
+    "PIE", # flake8-pie
+    "PL",  # pylint
+    "PT",  # flake8-pytest-style
+    "PYI", # flakes8-pyi
     "Q",   # flake8-quotes
+    "RET", # flake8-return
+    "RSE", # flake8-raise
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify
+    "TCH", # flake8-type-checking
     "TID", # tidy imports
     "UP",  # pyupgrade
-    "W",   # pycodestyle
+    "W",   # pycodestyle warning
     "YTT", # flake8-2020
+]
+ignore = [
+    "PT006", # pytest-parametrize-names-wrong-type
 ]
 pydocstyle.convention = "numpy"
 isort.known-first-party = ["atomate2"]

--- a/src/atomate2/amset/schemas.py
+++ b/src/atomate2/amset/schemas.py
@@ -225,7 +225,7 @@ def _get_structure() -> Structure:
         from pymatgen.io.vasp import BSVasprun
 
         return BSVasprun(str(vr_files[0])).get_band_structure().structure
-    elif len(bs_files) > 0:
+    if len(bs_files) > 0:
         return loadfn(bs_files[0])["band_structure"].structure
 
     raise ValueError("Could not find amset input in current directory.")

--- a/src/atomate2/common/files.py
+++ b/src/atomate2/common/files.py
@@ -356,7 +356,7 @@ def get_zfile(
         found, then ``None`` will be returned.
     """
     for file in directory_listing:
-        if file.name in [base_name, base_name + ".gz", base_name + ".GZ"]:
+        if file.name in [base_name, f"{base_name}.gz", f"{base_name}.GZ"]:
             return file
 
     if allow_missing:

--- a/src/atomate2/common/schemas/defects.py
+++ b/src/atomate2/common/schemas/defects.py
@@ -297,7 +297,7 @@ class CCDDocument(BaseModel):
         sdirs1 = [e.data["dir_name"] for e in s_entries1]
         sdirs2 = [e.data["dir_name"] for e in s_entries2]
 
-        obj = cls(
+        return cls(
             q1=ent_r1.structure.charge,
             q2=ent_r2.structure.charge,
             structure1=ent_r1.structure,
@@ -311,8 +311,6 @@ class CCDDocument(BaseModel):
             relaxed_index1=idx1,
             relaxed_index2=idx2,
         )
-
-        return obj
 
     def get_taskdocs(self):
         """Get the distorted task documents."""

--- a/src/atomate2/cp2k/run.py
+++ b/src/atomate2/cp2k/run.py
@@ -107,7 +107,7 @@ def run_cp2k(
         return_code = subprocess.call(cp2k_cmd, shell=True)
         logger.info(f"{cp2k_cmd} finished running with returncode: {return_code}")
         return
-    elif job_type == JobType.NORMAL:
+    if job_type == JobType.NORMAL:
         jobs = [Cp2kJob(split_cp2k_cmd, **cp2k_job_kwargs)]
     else:
         raise ValueError(f"Unsupported job type: {job_type}")

--- a/src/atomate2/cp2k/schemas/calc_types/utils.py
+++ b/src/atomate2/cp2k/schemas/calc_types/utils.py
@@ -25,10 +25,9 @@ def run_type(inputs: Dict) -> RunType:
         """Determine if two run_types are equal."""
         if isinstance(v1, str) and isinstance(v2, str):
             return v1.strip().upper() == v2.strip().upper()
-        elif isinstance(v1, Iterable) and isinstance(v2, Iterable):
+        if isinstance(v1, Iterable) and isinstance(v2, Iterable):
             return set(v1) == set(v2)
-        else:
-            return v1 == v2
+        return v1 == v2
 
     is_hubbard = "+U" if dft.get("dft_plus_u") else ""
     vdw = f"-{dft.get('vdw')}" if dft.get("vdw") else ""

--- a/src/atomate2/cp2k/sets/base.py
+++ b/src/atomate2/cp2k/sets/base.py
@@ -513,7 +513,7 @@ class Cp2kInputGenerator(InputGenerator):
 
         if base_kpoints and not (added_kpoints or zero_weighted_kpoints):
             return base_kpoints
-        elif added_kpoints and not (base_kpoints or zero_weighted_kpoints):
+        if added_kpoints and not (base_kpoints or zero_weighted_kpoints):
             return added_kpoints
 
         # do some sanity checking
@@ -521,12 +521,12 @@ class Cp2kInputGenerator(InputGenerator):
             raise ValueError(
                 "Cannot combined line_density and zero weighted k-points options"
             )
-        elif zero_weighted_kpoints and not base_kpoints:
+        if zero_weighted_kpoints and not base_kpoints:
             raise ValueError(
                 "Zero weighted k-points must be used with reciprocal_density or "
                 "grid_density options"
             )
-        elif not (base_kpoints or zero_weighted_kpoints or added_kpoints):
+        if not (base_kpoints or zero_weighted_kpoints or added_kpoints):
             return None
 
         return _combine_kpoints(base_kpoints, zero_weighted_kpoints, added_kpoints)

--- a/src/atomate2/cp2k/sets/core.py
+++ b/src/atomate2/cp2k/sets/core.py
@@ -33,8 +33,7 @@ class StaticSetGenerator(Cp2kInputGenerator):
 
     def get_input_updates(self, *args, **kwargs) -> dict:
         """Get updates to the input for a static job."""
-        updates = {"run_type": "ENERGY_FORCE"}
-        return updates
+        return {"run_type": "ENERGY_FORCE"}
 
 
 @dataclass
@@ -48,11 +47,10 @@ class RelaxSetGenerator(Cp2kInputGenerator):
 
     def get_input_updates(self, *args, **kwargs) -> dict:
         """Get updates to the input for a relax job."""
-        updates = {
+        return {
             "run_type": "GEO_OPT",
             "activate_motion": {"optimizer": "BFGS", "trust_radius": 0.1},
         }
-        return updates
 
 
 @dataclass
@@ -65,11 +63,10 @@ class CellOptSetGenerator(Cp2kInputGenerator):
 
     def get_input_updates(self, *args, **kwargs) -> dict:
         """Get updates to the input for a cell opt job."""
-        updates = {
+        return {
             "run_type": "CELL_OPT",
             "activate_motion": {"optimizer": "BFGS", "trust_radius": 0.1},
         }
-        return updates
 
 
 @dataclass
@@ -219,7 +216,7 @@ class NonSCFSetGenerator(Cp2kInputGenerator):
         cp2k_output: Cp2kOutput = None,
     ) -> dict:
         """Get input updates for a non scf calculation."""
-        updates = {
+        return {
             "max_scf": 1,
             "print_bandstructure": True,
             "kpoints_line_density": self.line_density if self.mode == "line" else 1,
@@ -229,8 +226,6 @@ class NonSCFSetGenerator(Cp2kInputGenerator):
             "run_type": "ENERGY_FORCE",
         }
 
-        return updates
-
 
 @dataclass
 class MDSetGenerator(Cp2kInputGenerator):
@@ -238,7 +233,7 @@ class MDSetGenerator(Cp2kInputGenerator):
 
     def get_input_updates(self, structure: Structure, *args, **kwargs) -> dict:
         """Get input updates for running a MD calculation."""
-        updates = {
+        return {
             "run_type": "MD",
             "activate_motion": {
                 "ensemble": "NVT",
@@ -254,5 +249,3 @@ class MDSetGenerator(Cp2kInputGenerator):
             "print_e_density": False,
             "print_mo_cubes": False,
         }
-
-        return updates

--- a/src/atomate2/lobster/run.py
+++ b/src/atomate2/lobster/run.py
@@ -79,7 +79,7 @@ def run_lobster(
         logger.info(f"{lobster_cmd} finished running with returncode: {return_code}")
         return
 
-    elif job_type == JobType.NORMAL:
+    if job_type == JobType.NORMAL:
         jobs = [LobsterJob(split_lobster_cmd, **lobster_job_kwargs)]
     else:
         raise ValueError(f"Unsupported job type: {job_type}")

--- a/src/atomate2/lobster/schemas.py
+++ b/src/atomate2/lobster/schemas.py
@@ -273,25 +273,21 @@ class CondensedBondingAnalysis(BaseModel):
             if save_cohp_plots:
                 describe.plot_cohps(
                     save=True,
-                    filename="automatic_cohp_plots_" + which_bonds + ".pdf",
+                    filename=f"automatic_cohp_plots_{which_bonds}.pdf",
                     skip_show=True,
                     **plot_kwargs,
                 )
                 import json
 
                 with open(
-                    dir_name
-                    / str("condensed_bonding_analysis_" + which_bonds + ".json"),
-                    "w",
+                    dir_name / f"condensed_bonding_analysis_{which_bonds}.json", "w"
                 ) as fp:
                     json.dump(analyse.condensed_bonding_analysis, fp)
                 with open(
-                    dir_name
-                    / str("condensed_bonding_analysis_" + which_bonds + ".txt"),
-                    "w",
+                    dir_name / f"condensed_bonding_analysis_{which_bonds}.txt", "w"
                 ) as fp:
                     for line in describe.text:
-                        fp.write(line + "\n")
+                        fp.write(f"{line}\n")
 
             # Read in strongest icohp values
             sb_icohp, sb_icobi, sb_icoop = _identify_strongest_bonds(
@@ -677,7 +673,7 @@ def _get_strong_bonds(
         bondlist["list_icohp"],
         bondlist["list_length"],
     ):
-        bonds.append(a.rstrip("0123456789") + "-" + b.rstrip("0123456789"))
+        bonds.append(f"{a.rstrip('0123456789')}-{b.rstrip('0123456789')}")
         icohp_all.append(sum(c.values()))
         lengths.append(length)
 

--- a/src/atomate2/lobster/schemas.py
+++ b/src/atomate2/lobster/schemas.py
@@ -248,7 +248,7 @@ class CondensedBondingAnalysis(BaseModel):
             for _iplot, (ication, labels, cohps) in enumerate(
                 zip(set_inequivalent_cations, set_labels_cohps, set_cohps)
             ):
-                label_str = f"{str(struct[ication].specie)}{str(ication + 1)}: "
+                label_str = f"{struct[ication].specie!s}{ication + 1!s}: "
                 for label, cohp in zip(labels, cohps):
                     if label is not None:
                         cba_cohp_plot_data[label_str + label] = cohp

--- a/src/atomate2/lobster/schemas.py
+++ b/src/atomate2/lobster/schemas.py
@@ -137,7 +137,7 @@ class CondensedBondingAnalysis(BaseModel):
 
     formula: str = Field(None, description="Pretty formula of the structure")
     max_considered_bond_length: Any = Field(
-        None, description="Maximum bond length considered " "in bonding analysis"
+        None, description="Maximum bond length considered in bonding analysis"
     )
     limit_icohp: list = Field(
         None, description="ICOHP range considered in co-ordination environment analysis"

--- a/src/atomate2/utils/file_client.py
+++ b/src/atomate2/utils/file_client.py
@@ -135,13 +135,12 @@ class FileClient:
         """
         if host is None:
             return Path(path).exists()
-        else:
-            path = str(self.abspath(path, host=host))
-            try:
-                self.get_sftp(host).stat(path)
-                return True
-            except FileNotFoundError:
-                return False
+        path = str(self.abspath(path, host=host))
+        try:
+            self.get_sftp(host).stat(path)
+            return True
+        except FileNotFoundError:
+            return False
 
     def is_file(self, path: str | Path, host: str | None = None) -> bool:
         """
@@ -161,12 +160,11 @@ class FileClient:
         """
         if host is None:
             return Path(path).is_file()
-        else:
-            path = str(self.abspath(path, host=host))
-            try:
-                return stat.S_ISREG(self.get_sftp(host).lstat(path).st_mode)
-            except FileNotFoundError:
-                return False
+        path = str(self.abspath(path, host=host))
+        try:
+            return stat.S_ISREG(self.get_sftp(host).lstat(path).st_mode)
+        except FileNotFoundError:
+            return False
 
     def is_dir(self, path: str | Path, host: str | None = None) -> bool:
         """
@@ -186,12 +184,11 @@ class FileClient:
         """
         if host is None:
             return Path(path).is_dir()
-        else:
-            path = str(self.abspath(path, host=host))
-            try:
-                return stat.S_ISDIR(self.get_sftp(host).lstat(path).st_mode)
-            except FileNotFoundError:
-                return False
+        path = str(self.abspath(path, host=host))
+        try:
+            return stat.S_ISDIR(self.get_sftp(host).lstat(path).st_mode)
+        except FileNotFoundError:
+            return False
 
     def listdir(self, path: str | Path, host: str | None = None) -> list[Path]:
         """
@@ -213,9 +210,8 @@ class FileClient:
             path = self.abspath(path, host=host)
             return [p.relative_to(path) for p in Path(path).iterdir()]
 
-        else:
-            path = str(self.abspath(path, host=host))
-            return [Path(p) for p in self.get_sftp(host).listdir(path)]
+        path = str(self.abspath(path, host=host))
+        return [Path(p) for p in self.get_sftp(host).listdir(path)]
 
     def copy(
         self,
@@ -323,10 +319,9 @@ class FileClient:
         """
         if host is None:
             return Path(path).absolute()
-        else:
-            ssh = self.get_ssh(host)
-            _, stdout, _ = ssh.exec_command(f"readlink -f {path}")
-            return Path([o.split("\n")[0] for o in stdout][0])
+        ssh = self.get_ssh(host)
+        _, stdout, _ = ssh.exec_command(f"readlink -f {path}")
+        return Path([o.split("\n")[0] for o in stdout][0])
 
     def glob(self, path: str | Path, host: str | None = None) -> list[Path]:
         """

--- a/src/atomate2/utils/file_client.py
+++ b/src/atomate2/utils/file_client.py
@@ -379,11 +379,11 @@ class FileClient:
 
         if str(path).lower().endswith("gz"):
             warnings.warn(f"{path} is already gzipped, skipping...", stacklevel=1)
-            return None
+            return
 
         if self.is_dir(path, host=host):
             warnings.warn(f"{path} is a directory, skipping...", stacklevel=1)
-            return None
+            return
 
         if self.exists(path_gz, host=host) and not force:
             raise FileExistsError(f"{path_gz} file already exists.")
@@ -397,7 +397,7 @@ class FileClient:
             path.unlink()
         else:
             ssh = self.get_ssh(host)
-            _, stdout, _ = ssh.exec_command(f"gzip -f {str(path)}")
+            _, stdout, _ = ssh.exec_command(f"gzip -f {path!s}")
 
     def gunzip(
         self,
@@ -422,7 +422,7 @@ class FileClient:
 
         if not str(path).lower().endswith("gz"):
             warnings.warn(f"{path} is not gzipped, skipping...", stacklevel=2)
-            return None
+            return
 
         if self.exists(path_nongz, host=host) and not force:
             raise FileExistsError(f"{path_nongz} file already exists")
@@ -433,7 +433,7 @@ class FileClient:
             path.unlink()
         else:
             ssh = self.get_ssh(host)
-            _, stdout, _ = ssh.exec_command(f"gunzip -f {str(path)}")
+            _, stdout, _ = ssh.exec_command(f"gunzip -f {path!s}")
 
     def close(self):
         """Close all connections."""

--- a/src/atomate2/vasp/flows/elastic.py
+++ b/src/atomate2/vasp/flows/elastic.py
@@ -130,9 +130,8 @@ class ElasticMaker(Maker):
 
         jobs += [deformations, vasp_deformation_calcs, fit_tensor]
 
-        flow = Flow(
+        return Flow(
             jobs=jobs,
             output=fit_tensor.output,
             name=self.name,
         )
-        return flow

--- a/src/atomate2/vasp/flows/phonons.py
+++ b/src/atomate2/vasp/flows/phonons.py
@@ -338,5 +338,4 @@ class PhononMaker(Maker):
 
         jobs.append(phonon_collect)
         # create a flow including all jobs for a phonon computation
-        flow = Flow(jobs, phonon_collect.output)
-        return flow
+        return Flow(jobs, phonon_collect.output)

--- a/src/atomate2/vasp/jobs/amset.py
+++ b/src/atomate2/vasp/jobs/amset.py
@@ -447,7 +447,7 @@ def _extract_ibands(log: str) -> tuple[list[int], ...]:
             if "up" in result_splits[i + 1]:
                 # up listed first
                 return aibands, bibands
-            else:
+            else:  # noqa: RET505
                 # down listed first
                 return bibands, aibands
     raise ValueError("Could not find ibands in log.")

--- a/src/atomate2/vasp/jobs/elastic.py
+++ b/src/atomate2/vasp/jobs/elastic.py
@@ -277,7 +277,7 @@ def fit_elastic_tensor(
 
     logger.info("Analyzing stress/strain data")
 
-    elastic_doc = ElasticDocument.from_stresses(
+    return ElasticDocument.from_stresses(
         structure,
         stresses,
         deformations,
@@ -288,4 +288,3 @@ def fit_elastic_tensor(
         equilibrium_stress=equilibrium_stress,
         symprec=symprec,
     )
-    return elastic_doc

--- a/src/atomate2/vasp/jobs/lobster.py
+++ b/src/atomate2/vasp/jobs/lobster.py
@@ -124,7 +124,7 @@ def get_basis_infos(
 
     nband_list = []
     for dict_for_basis in list_basis_dict:
-        basis = [key + " " + value for key, value in dict_for_basis.items()]
+        basis = [f"{key} {value}" for key, value in dict_for_basis.items()]
         lobsterin = Lobsterin(settingsdict={"basisfunctions": basis})
         nbands = lobsterin._get_nbands(structure=structure)
         nband_list.append(nbands)

--- a/src/atomate2/vasp/jobs/phonons.py
+++ b/src/atomate2/vasp/jobs/phonons.py
@@ -120,8 +120,7 @@ def get_supercell_size(
             )
             transformation.apply_transformation(structure=structure)
 
-    supercell_matrix = transformation.transformation_matrix.tolist()
-    return supercell_matrix
+    return transformation.transformation_matrix.tolist()
 
 
 @job
@@ -237,7 +236,7 @@ def generate_frequencies_eigenvectors(
         Additional parameters that are passed to PhononBSDOSDoc.from_forces_born
 
     """
-    phonon_doc = PhononBSDOSDoc.from_forces_born(
+    return PhononBSDOSDoc.from_forces_born(
         structure=structure,
         supercell_matrix=supercell_matrix,
         displacement=displacement,
@@ -252,8 +251,6 @@ def generate_frequencies_eigenvectors(
         born=born,
         **kwargs,
     )
-
-    return phonon_doc
 
 
 @job

--- a/src/atomate2/vasp/run.py
+++ b/src/atomate2/vasp/run.py
@@ -140,7 +140,7 @@ def run_vasp(
         logger.info(f"{vasp_cmd} finished running with returncode: {return_code}")
         return
 
-    elif job_type == JobType.NORMAL:
+    if job_type == JobType.NORMAL:
         jobs = [VaspJob(split_vasp_cmd, **vasp_job_kwargs)]
     elif job_type == JobType.DOUBLE_RELAXATION:
         jobs = VaspJob.double_relaxation_run(split_vasp_cmd, **vasp_job_kwargs)

--- a/src/atomate2/vasp/schemas/calc_types/_generate.py
+++ b/src/atomate2/vasp/schemas/calc_types/_generate.py
@@ -49,12 +49,10 @@ class {enum_name}(ValueEnum):
 run_type_enum = get_enum_source(
     "RunType",
     "Vasp calculation run types.",
-    dict(
-        {
+    {
             "_".join(rt.split()).replace("+", "_").replace("-", "_"): rt
             for rt in _RUN_TYPES
-        }
-    ),
+        },
 )
 task_type_enum = get_enum_source(
     "TaskType",

--- a/src/atomate2/vasp/schemas/calc_types/_generate.py
+++ b/src/atomate2/vasp/schemas/calc_types/_generate.py
@@ -49,10 +49,7 @@ class {enum_name}(ValueEnum):
 run_type_enum = get_enum_source(
     "RunType",
     "Vasp calculation run types.",
-    {
-            "_".join(rt.split()).replace("+", "_").replace("-", "_"): rt
-            for rt in _RUN_TYPES
-        },
+    {"_".join(rt.split()).replace("+", "_").replace("-", "_"): rt for rt in _RUN_TYPES},
 )
 task_type_enum = get_enum_source(
     "TaskType",
@@ -63,7 +60,8 @@ calc_type_enum = get_enum_source(
     "CalcType",
     "Vasp calculation types.",
     {
-        f"{'_'.join(rt.split()).replace('+','_').replace('-','_')}_{'_'.join(tt.split())}": f"{rt} {tt}"
+        f"{'_'.join(rt.split()).replace('+','_').replace('-','_')}"
+        f"_{'_'.join(tt.split())}": f"{rt} {tt}"
         for rt, tt in product(_RUN_TYPES, _TASK_TYPES)
     },
 )

--- a/src/atomate2/vasp/schemas/calc_types/enums.py
+++ b/src/atomate2/vasp/schemas/calc_types/enums.py
@@ -377,7 +377,9 @@ class CalcType(ValueEnum):
     R2SCAN_rVV10_DFPT = "R2SCAN-rVV10 DFPT"
     R2SCAN_rVV10_DFPT_Dielectric = "R2SCAN-rVV10 DFPT Dielectric"
     R2SCAN_rVV10_NMR_Nuclear_Shielding = "R2SCAN-rVV10 NMR Nuclear Shielding"
-    R2SCAN_rVV10_NMR_Electric_Field_Gradient = "R2SCAN-rVV10 NMR Electric Field Gradient"
+    R2SCAN_rVV10_NMR_Electric_Field_Gradient = (
+        "R2SCAN-rVV10 NMR Electric Field Gradient"
+    )
     R2SCAN_rVV10_Static = "R2SCAN-rVV10 Static"
     R2SCAN_rVV10_Structure_Optimization = "R2SCAN-rVV10 Structure Optimization"
     R2SCAN_rVV10_Deformation = "R2SCAN-rVV10 Deformation"
@@ -521,7 +523,9 @@ class CalcType(ValueEnum):
     RevPBE_PADE_U_DFPT = "RevPBE+PADE+U DFPT"
     RevPBE_PADE_U_DFPT_Dielectric = "RevPBE+PADE+U DFPT Dielectric"
     RevPBE_PADE_U_NMR_Nuclear_Shielding = "RevPBE+PADE+U NMR Nuclear Shielding"
-    RevPBE_PADE_U_NMR_Electric_Field_Gradient = "RevPBE+PADE+U NMR Electric Field Gradient"
+    RevPBE_PADE_U_NMR_Electric_Field_Gradient = (
+        "RevPBE+PADE+U NMR Electric Field Gradient"
+    )
     RevPBE_PADE_U_Static = "RevPBE+PADE+U Static"
     RevPBE_PADE_U_Structure_Optimization = "RevPBE+PADE+U Structure Optimization"
     RevPBE_PADE_U_Deformation = "RevPBE+PADE+U Deformation"
@@ -749,7 +753,9 @@ class CalcType(ValueEnum):
     R2SCAN_rVV10_U_DFPT = "R2SCAN-rVV10+U DFPT"
     R2SCAN_rVV10_U_DFPT_Dielectric = "R2SCAN-rVV10+U DFPT Dielectric"
     R2SCAN_rVV10_U_NMR_Nuclear_Shielding = "R2SCAN-rVV10+U NMR Nuclear Shielding"
-    R2SCAN_rVV10_U_NMR_Electric_Field_Gradient = "R2SCAN-rVV10+U NMR Electric Field Gradient"
+    R2SCAN_rVV10_U_NMR_Electric_Field_Gradient = (
+        "R2SCAN-rVV10+U NMR Electric Field Gradient"
+    )
     R2SCAN_rVV10_U_Static = "R2SCAN-rVV10+U Static"
     R2SCAN_rVV10_U_Structure_Optimization = "R2SCAN-rVV10+U Structure Optimization"
     R2SCAN_rVV10_U_Deformation = "R2SCAN-rVV10+U Deformation"
@@ -761,7 +767,9 @@ class CalcType(ValueEnum):
     SCAN_rVV10_U_DFPT = "SCAN-rVV10+U DFPT"
     SCAN_rVV10_U_DFPT_Dielectric = "SCAN-rVV10+U DFPT Dielectric"
     SCAN_rVV10_U_NMR_Nuclear_Shielding = "SCAN-rVV10+U NMR Nuclear Shielding"
-    SCAN_rVV10_U_NMR_Electric_Field_Gradient = "SCAN-rVV10+U NMR Electric Field Gradient"
+    SCAN_rVV10_U_NMR_Electric_Field_Gradient = (
+        "SCAN-rVV10+U NMR Electric Field Gradient"
+    )
     SCAN_rVV10_U_Static = "SCAN-rVV10+U Static"
     SCAN_rVV10_U_Structure_Optimization = "SCAN-rVV10+U Structure Optimization"
     SCAN_rVV10_U_Deformation = "SCAN-rVV10+U Deformation"
@@ -773,7 +781,9 @@ class CalcType(ValueEnum):
     optB86b_vdW_U_DFPT = "optB86b-vdW+U DFPT"
     optB86b_vdW_U_DFPT_Dielectric = "optB86b-vdW+U DFPT Dielectric"
     optB86b_vdW_U_NMR_Nuclear_Shielding = "optB86b-vdW+U NMR Nuclear Shielding"
-    optB86b_vdW_U_NMR_Electric_Field_Gradient = "optB86b-vdW+U NMR Electric Field Gradient"
+    optB86b_vdW_U_NMR_Electric_Field_Gradient = (
+        "optB86b-vdW+U NMR Electric Field Gradient"
+    )
     optB86b_vdW_U_Static = "optB86b-vdW+U Static"
     optB86b_vdW_U_Structure_Optimization = "optB86b-vdW+U Structure Optimization"
     optB86b_vdW_U_Deformation = "optB86b-vdW+U Deformation"
@@ -785,7 +795,9 @@ class CalcType(ValueEnum):
     optB88_vdW_U_DFPT = "optB88-vdW+U DFPT"
     optB88_vdW_U_DFPT_Dielectric = "optB88-vdW+U DFPT Dielectric"
     optB88_vdW_U_NMR_Nuclear_Shielding = "optB88-vdW+U NMR Nuclear Shielding"
-    optB88_vdW_U_NMR_Electric_Field_Gradient = "optB88-vdW+U NMR Electric Field Gradient"
+    optB88_vdW_U_NMR_Electric_Field_Gradient = (
+        "optB88-vdW+U NMR Electric Field Gradient"
+    )
     optB88_vdW_U_Static = "optB88-vdW+U Static"
     optB88_vdW_U_Structure_Optimization = "optB88-vdW+U Structure Optimization"
     optB88_vdW_U_Deformation = "optB88-vdW+U Deformation"
@@ -797,7 +809,9 @@ class CalcType(ValueEnum):
     optPBE_vdW_U_DFPT = "optPBE-vdW+U DFPT"
     optPBE_vdW_U_DFPT_Dielectric = "optPBE-vdW+U DFPT Dielectric"
     optPBE_vdW_U_NMR_Nuclear_Shielding = "optPBE-vdW+U NMR Nuclear Shielding"
-    optPBE_vdW_U_NMR_Electric_Field_Gradient = "optPBE-vdW+U NMR Electric Field Gradient"
+    optPBE_vdW_U_NMR_Electric_Field_Gradient = (
+        "optPBE-vdW+U NMR Electric Field Gradient"
+    )
     optPBE_vdW_U_Static = "optPBE-vdW+U Static"
     optPBE_vdW_U_Structure_Optimization = "optPBE-vdW+U Structure Optimization"
     optPBE_vdW_U_Deformation = "optPBE-vdW+U Deformation"
@@ -809,7 +823,9 @@ class CalcType(ValueEnum):
     rev_vdW_DF2_U_DFPT = "rev-vdW-DF2+U DFPT"
     rev_vdW_DF2_U_DFPT_Dielectric = "rev-vdW-DF2+U DFPT Dielectric"
     rev_vdW_DF2_U_NMR_Nuclear_Shielding = "rev-vdW-DF2+U NMR Nuclear Shielding"
-    rev_vdW_DF2_U_NMR_Electric_Field_Gradient = "rev-vdW-DF2+U NMR Electric Field Gradient"
+    rev_vdW_DF2_U_NMR_Electric_Field_Gradient = (
+        "rev-vdW-DF2+U NMR Electric Field Gradient"
+    )
     rev_vdW_DF2_U_Static = "rev-vdW-DF2+U Static"
     rev_vdW_DF2_U_Structure_Optimization = "rev-vdW-DF2+U Structure Optimization"
     rev_vdW_DF2_U_Deformation = "rev-vdW-DF2+U Deformation"
@@ -821,7 +837,9 @@ class CalcType(ValueEnum):
     revPBE_vdW_U_DFPT = "revPBE-vdW+U DFPT"
     revPBE_vdW_U_DFPT_Dielectric = "revPBE-vdW+U DFPT Dielectric"
     revPBE_vdW_U_NMR_Nuclear_Shielding = "revPBE-vdW+U NMR Nuclear Shielding"
-    revPBE_vdW_U_NMR_Electric_Field_Gradient = "revPBE-vdW+U NMR Electric Field Gradient"
+    revPBE_vdW_U_NMR_Electric_Field_Gradient = (
+        "revPBE-vdW+U NMR Electric Field Gradient"
+    )
     revPBE_vdW_U_Static = "revPBE-vdW+U Static"
     revPBE_vdW_U_Structure_Optimization = "revPBE-vdW+U Structure Optimization"
     revPBE_vdW_U_Deformation = "revPBE-vdW+U Deformation"

--- a/src/atomate2/vasp/schemas/calc_types/utils.py
+++ b/src/atomate2/vasp/schemas/calc_types/utils.py
@@ -72,8 +72,8 @@ def task_type(
         try:
             kpt_labels = kpts.get("labels") or []
             num_kpt_labels = len(list(filter(None.__ne__, kpt_labels)))
-        except Exception as e:
-            raise Exception(f"Couldn't identify total number of kpt labels: {e}")
+        except Exception as exc:
+            raise Exception("Couldn't identify total number of kpt labels") from exc
 
         if num_kpt_labels > 0:
             acalc_type.append("NSCF Line")

--- a/src/atomate2/vasp/schemas/calc_types/utils.py
+++ b/src/atomate2/vasp/schemas/calc_types/utils.py
@@ -34,15 +34,14 @@ def run_type(vasp_parameters: Dict) -> RunType:
         """Check two strings equal."""
         if isinstance(v1, str) and isinstance(v2, str):
             return v1.strip().upper() == v2.strip().upper()
-        else:
-            return v1 == v2
+        return v1 == v2
 
     # This is to force an order of evaluation
     for functional_class in ["HF", "VDW", "METAGGA", "GGA"]:
         for special_type, params in _RUN_TYPE_DATA[functional_class].items():
             if all(
                 _variant_equal(vasp_parameters.get(param, None), value)
-                    for param, value in params.items()
+                for param, value in params.items()
             ):
                 return RunType(f"{special_type}{is_hubbard}")
 

--- a/src/atomate2/vasp/schemas/calc_types/utils.py
+++ b/src/atomate2/vasp/schemas/calc_types/utils.py
@@ -41,10 +41,8 @@ def run_type(vasp_parameters: Dict) -> RunType:
     for functional_class in ["HF", "VDW", "METAGGA", "GGA"]:
         for special_type, params in _RUN_TYPE_DATA[functional_class].items():
             if all(
-                [
-                    _variant_equal(vasp_parameters.get(param, None), value)
+                _variant_equal(vasp_parameters.get(param, None), value)
                     for param, value in params.items()
-                ]
             ):
                 return RunType(f"{special_type}{is_hubbard}")
 

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -811,7 +811,7 @@ class VaspInputGenerator(InputGenerator):
 
         if base_kpoints and not (added_kpoints or zero_weighted_kpoints):
             return base_kpoints
-        elif added_kpoints and not (base_kpoints or zero_weighted_kpoints):
+        if added_kpoints and not (base_kpoints or zero_weighted_kpoints):
             return added_kpoints
 
         # do some sanity checking
@@ -819,12 +819,12 @@ class VaspInputGenerator(InputGenerator):
             raise ValueError(
                 "Cannot combined line_density and zero weighted k-points options"
             )
-        elif zero_weighted_kpoints and not base_kpoints:
+        if zero_weighted_kpoints and not base_kpoints:
             raise ValueError(
                 "Zero weighted k-points must be used with reciprocal_density or "
                 "grid_density options"
             )
-        elif not (base_kpoints or zero_weighted_kpoints or added_kpoints):
+        if not (base_kpoints or zero_weighted_kpoints or added_kpoints):
             raise ValueError(
                 "Invalid k-point generation algo. Supported Keys are 'grid_density' "
                 "for Kpoints.automatic_density generation, 'reciprocal_density' for "
@@ -882,24 +882,22 @@ def _get_u_param(lda_param, lda_config, structure):
     if hasattr(structure[0], lda_param.lower()):
         m = {site.specie.symbol: getattr(site, lda_param.lower()) for site in structure}
         return [m[sym] for sym in poscar.site_symbols]
-    elif isinstance(lda_config.get(most_electroneg, 0), dict):
+    if isinstance(lda_config.get(most_electroneg, 0), dict):
         # lookup specific LDAU if specified for most_electroneg atom
         return [lda_config[most_electroneg].get(sym, 0) for sym in poscar.site_symbols]
-    else:
-        return [
-            lda_config.get(sym, 0)
-            if isinstance(lda_config.get(sym, 0), (float, int))
-            else 0
-            for sym in poscar.site_symbols
-        ]
+    return [
+        lda_config.get(sym, 0)
+        if isinstance(lda_config.get(sym, 0), (float, int))
+        else 0
+        for sym in poscar.site_symbols
+    ]
 
 
 def _get_ediff(param, value, structure, incar_settings):
     """Get EDIFF."""
     if incar_settings.get("EDIFF", None) is None and param == "EDIFF_PER_ATOM":
         return float(value) * structure.num_sites
-    else:
-        return float(incar_settings["EDIFF"])
+    return float(incar_settings["EDIFF"])
 
 
 def _set_u_params(incar, incar_settings, structure):
@@ -1020,7 +1018,7 @@ def _get_ispin(vasprun: Vasprun | None, outcar: Outcar | None):
         # Turn off spin when magmom for every site is smaller than 0.02.
         site_magmom = np.array([i["tot"] for i in outcar.magnetization])
         return 2 if np.any(np.abs(site_magmom) > 0.02) else 1
-    elif vasprun is not None:
+    if vasprun is not None:
         return 2 if vasprun.is_spin else 1
     return 2
 

--- a/src/atomate2/vasp/sets/core.py
+++ b/src/atomate2/vasp/sets/core.py
@@ -260,7 +260,7 @@ class NonSCFSetGenerator(VaspInputGenerator):
         if self.mode == "line":
             return {"line_density": self.line_density}
 
-        elif self.mode == "boltztrap":
+        if self.mode == "boltztrap":
             return {"explicit": True, "reciprocal_density": self.reciprocal_density}
 
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def clean_dir(debug_mode):
         shutil.rmtree(newpath)
 
 
-@pytest.fixture
+@pytest.fixture()
 def tmp_dir():
     """Same as clean_dir but is fresh for every test"""
     import os
@@ -77,7 +77,7 @@ def lpad(database, debug_mode):
             lpad.db[coll].drop()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def memory_jobstore():
     from jobflow import JobStore
     from maggma.stores import MemoryStore
@@ -95,7 +95,7 @@ def log_to_stdout_auto_use():
     initialize_logger()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def si_structure(test_dir):
     from pymatgen.core import Structure
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def test_dir():
 
 
 @pytest.fixture(scope="session")
-def _log_to_stdout():
+def log_to_stdout():
     import logging
     import sys
 
@@ -27,7 +27,7 @@ def _log_to_stdout():
 
 
 @pytest.fixture(scope="session")
-def _clean_dir(debug_mode):
+def clean_dir(debug_mode):
     import os
     import shutil
     import tempfile
@@ -44,7 +44,7 @@ def _clean_dir(debug_mode):
 
 
 @pytest.fixture()
-def _tmp_dir():
+def tmp_dir():
     """Same as clean_dir but is fresh for every test"""
     import os
     import shutil
@@ -89,7 +89,7 @@ def memory_jobstore():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _log_to_stdout_auto_use():
+def log_to_stdout_auto_use():
     from atomate2.utils.log import initialize_logger
 
     initialize_logger()
@@ -103,7 +103,7 @@ def si_structure(test_dir):
 
 
 @pytest.fixture(autouse=True)
-def _mock_jobflow_settings(memory_jobstore):
+def mock_jobflow_settings(memory_jobstore):
     """Mock the jobflow settings to use our specific jobstore (with data store)."""
     from unittest import mock
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def test_dir():
 
 
 @pytest.fixture(scope="session")
-def log_to_stdout():
+def _log_to_stdout():
     import logging
     import sys
 
@@ -27,7 +27,7 @@ def log_to_stdout():
 
 
 @pytest.fixture(scope="session")
-def clean_dir(debug_mode):
+def _clean_dir(debug_mode):
     import os
     import shutil
     import tempfile
@@ -44,7 +44,7 @@ def clean_dir(debug_mode):
 
 
 @pytest.fixture()
-def tmp_dir():
+def _tmp_dir():
     """Same as clean_dir but is fresh for every test"""
     import os
     import shutil
@@ -89,7 +89,7 @@ def memory_jobstore():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def log_to_stdout_auto_use():
+def _log_to_stdout_auto_use():
     from atomate2.utils.log import initialize_logger
 
     initialize_logger()
@@ -103,7 +103,7 @@ def si_structure(test_dir):
 
 
 @pytest.fixture(autouse=True)
-def mock_jobflow_settings(memory_jobstore):
+def _mock_jobflow_settings(memory_jobstore):
     """Mock the jobflow settings to use our specific jobstore (with data store)."""
     from unittest import mock
 

--- a/tests/cp2k/conftest.py
+++ b/tests/cp2k/conftest.py
@@ -13,7 +13,7 @@ _FAKE_RUN_CP2K_KWARGS = {}
 
 
 @pytest.fixture(autouse=True)
-def patch_settings(monkeypatch, test_dir):
+def _patch_settings(monkeypatch, test_dir):
     settings = {
         "PMG_CP2K_DATA_DIR": Path(test_dir / "cp2k/data"),
         "PMG_DEFAULT_CP2K_FUNCTIONAL": "PBE",

--- a/tests/cp2k/conftest.py
+++ b/tests/cp2k/conftest.py
@@ -13,7 +13,7 @@ _FAKE_RUN_CP2K_KWARGS = {}
 
 
 @pytest.fixture(autouse=True)
-def _patch_settings(monkeypatch, test_dir):
+def patch_settings(monkeypatch, test_dir):
     settings = {
         "PMG_CP2K_DATA_DIR": Path(test_dir / "cp2k/data"),
         "PMG_DEFAULT_CP2K_FUNCTIONAL": "PBE",

--- a/tests/cp2k/conftest.py
+++ b/tests/cp2k/conftest.py
@@ -51,7 +51,7 @@ def cp2k_test_outputs(test_dir):
     return Path(test_dir / "cp2k").glob("*/outputs")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def mock_cp2k(monkeypatch, cp2k_test_dir):
     """
     This fixture allows one to mock (fake) running CP2K.
@@ -164,7 +164,7 @@ def fake_run_cp2k(
     logger.info("Generated fake cp2k outputs")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def check_input():
     def _check_input(ref_path, user_input):
         from pymatgen.io.cp2k.inputs import Cp2kInput

--- a/tests/vasp/conftest.py
+++ b/tests/vasp/conftest.py
@@ -184,12 +184,12 @@ def check_kpoints(ref_path: Union[str, Path]):
             "atomate2 generated a KPOINTS file but the reference calculation is using "
             "KSPACING"
         )
-    elif not user_kpoints_exists and ref_kpoints_exists:
+    if not user_kpoints_exists and ref_kpoints_exists:
         raise ValueError(
             "atomate2 is using KSPACING but the reference calculation is using "
             "a KPOINTS file"
         )
-    elif user_kpoints_exists and ref_kpoints_exists:
+    if user_kpoints_exists and ref_kpoints_exists:
         user = Kpoints.from_file("KPOINTS")
         ref = Kpoints.from_file(ref_path / "inputs" / "KPOINTS")
         if user.style != ref.style or user.num_kpts != ref.num_kpts:

--- a/tests/vasp/conftest.py
+++ b/tests/vasp/conftest.py
@@ -21,7 +21,7 @@ def lobster_test_dir(test_dir):
     return test_dir / "lobster"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def mock_vasp(monkeypatch, vasp_test_dir):
     """
     This fixture allows one to mock (fake) running VASP.

--- a/tests/vasp/flows/test_defect.py
+++ b/tests/vasp/flows/test_defect.py
@@ -1,8 +1,14 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from atomate2.common.schemas.defects import CCDDocument
+    from atomate2.vasp.schemas.defect import FiniteDifferenceDocument
+
+
 def test_ccd_maker(mock_vasp, clean_dir, test_dir):
     from jobflow import run_locally
     from pymatgen.core import Structure
 
-    from atomate2.common.schemas.defects import CCDDocument
     from atomate2.vasp.flows.defect import ConfigurationCoordinateMaker
 
     # mapping from job name to directory containing test files
@@ -65,7 +71,6 @@ def test_nonrad_maker(mock_vasp, clean_dir, test_dir, monkeypatch):
         ConfigurationCoordinateMaker,
         NonRadiativeMaker,
     )
-    from atomate2.vasp.schemas.defect import FiniteDifferenceDocument
 
     # mapping from job name to directory containing test files
     ref_paths = {

--- a/tests/vasp/flows/test_phonon.py
+++ b/tests/vasp/flows/test_phonon.py
@@ -444,21 +444,20 @@ def test_phonon_wf_only_displacements_add_inputs_raises(mock_vasp, clean_dir):
     ]
     total_dft_energy_per_formula_unit = -5
 
+    job = PhononMaker(
+        min_length=3.0,
+        bulk_relax_maker=None,
+        static_energy_maker=None,
+        born_maker=None,
+        use_symmetrized_structure="primitive",
+        generate_frequencies_eigenvectors_kwargs={"tstep": 100},
+    ).make(
+        structure=structure,
+        total_dft_energy_per_formula_unit=total_dft_energy_per_formula_unit,
+        born=born,
+        epsilon_static=epsilon_static,
+    )
     with pytest.raises(RuntimeError):
-        job = PhononMaker(
-            min_length=3.0,
-            bulk_relax_maker=None,
-            static_energy_maker=None,
-            born_maker=None,
-            use_symmetrized_structure="primitive",
-            generate_frequencies_eigenvectors_kwargs={"tstep": 100},
-        ).make(
-            structure=structure,
-            total_dft_energy_per_formula_unit=total_dft_energy_per_formula_unit,
-            born=born,
-            epsilon_static=epsilon_static,
-        )
-
         run_locally(job, create_folders=True, ensure_success=True)
 
 

--- a/tests/vasp/lobster/conftest.py
+++ b/tests/vasp/lobster/conftest.py
@@ -17,7 +17,7 @@ def lobster_test_dir(test_dir):
     return test_dir / "lobster"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def mock_lobster(monkeypatch, lobster_test_dir):
     """
     This fixture allows one to mock (fake) running LOBSTER.


### PR DESCRIPTION
Mostly unexciting changes. I left on TODO: there are currently 3 tests that use `pytest.raises()` to that only check the error type. These are flagged by `ruff` as too broad (recommendation is to also check the error message). [I ignored these lints](https://github.com/materialsproject/atomate2/compare/more-ruff?expand=1#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R169) but would be better to add `match="expected err msg"`.