### PR TITLE
Move all type-hint only imports behind `if TYPE_CHECKING`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ tests = ["FireWorks==2.0.3", "pytest-cov==4.0.0", "pytest==7.3.1"]
 strict = [
     "PyYAML==6.0",
     "cclib==1.7.2",
+    "chgnet==0.1.3",
     "click==8.1.3",
     "custodian==2023.5.12",
     "dscribe==2.0.0",
@@ -73,7 +74,6 @@ strict = [
     "pymatgen-analysis-defects==2023.5.8",
     "pymatgen==2023.5.10",
     "seekpath==2.1.0",
-    "chgnet==0.1.3",
     "typing-extensions==4.5.0",
 ]
 
@@ -159,7 +159,9 @@ select = [
     "RSE", # flake8-raise
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify
+    "TCH", # flake8-type-checking
     "TID", # tidy imports
+    "TID", # flake8-tidy-imports
     "UP",  # pyupgrade
     "W",   # pycodestyle warning
     "YTT", # flake8-2020
@@ -168,9 +170,9 @@ ignore = [
     "PD011",   # pandas-use-of-dot-values
     "PLC1901", # compare-to-empty-string
     "PLR",     # pylint-refactor
+    "PT004",   # pytest-missing-fixture-name-underscore
     "PT006",   # pytest-parametrize-names-wrong-type
     # TODO remove PT011, pytest.raises() should always check err msg
-    "PT004", # pytest-missing-fixture-name-underscore
     "PT011", # pytest-raises-too-broad
     "PT013", # pytest-incorrect-pytest-import
 ]

--- a/src/atomate2/amset/files.py
+++ b/src/atomate2/amset/files.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from monty.serialization import loadfn
 
@@ -11,6 +11,9 @@ from atomate2 import SETTINGS
 from atomate2.common.files import copy_files, get_zfile, gunzip_files, rename_files
 from atomate2.utils.file_client import FileClient, auto_fileclient
 from atomate2.utils.path import strip_hostname
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 __all__ = ["copy_amset_files"]
 

--- a/src/atomate2/common/flows/defect.py
+++ b/src/atomate2/common/flows/defect.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import numpy.typing as npt
 from jobflow import Flow, Job, Maker, OutputReference
-from pymatgen.analysis.defects.core import Defect
-from pymatgen.core.structure import Structure
 
 from atomate2.common.jobs.defect import (
     bulk_supercell_calculation,
@@ -20,6 +17,13 @@ from atomate2.common.jobs.defect import (
     spawn_defect_q_jobs,
     spawn_energy_curve_calcs,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import numpy.typing as npt
+    from pymatgen.analysis.defects.core import Defect
+    from pymatgen.core.structure import Structure
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/common/jobs/defect.py
+++ b/src/atomate2/common/jobs/defect.py
@@ -3,15 +3,11 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from typing import Callable, Iterable
+from typing import TYPE_CHECKING, Callable, Iterable
 
 import numpy as np
-from emmet.core.tasks import TaskDoc
 from jobflow import Flow, Response, job
-from numpy.typing import NDArray
 from pydantic import BaseModel
-from pymatgen.analysis.defects.core import Defect
 from pymatgen.analysis.defects.supercells import (
     get_matched_structure_mapping,
     get_sc_fromstruct,
@@ -19,7 +15,15 @@ from pymatgen.analysis.defects.supercells import (
 from pymatgen.core import Lattice, Structure
 
 from atomate2.common.schemas.defects import CCDDocument
-from atomate2.vasp.jobs.core import RelaxMaker, StaticMaker
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from emmet.core.tasks import TaskDoc
+    from numpy.typing import NDArray
+    from pymatgen.analysis.defects.core import Defect
+
+    from atomate2.vasp.jobs.core import RelaxMaker, StaticMaker
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/common/jobs/utils.py
+++ b/src/atomate2/common/jobs/utils.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from jobflow import Response, job
-from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from atomate2 import SETTINGS
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
 
 __all__ = [
     "structure_to_primitive",

--- a/src/atomate2/common/utils.py
+++ b/src/atomate2/common/utils.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import re
 from importlib import import_module
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from monty.serialization import loadfn
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def get_transformations(

--- a/src/atomate2/cp2k/files.py
+++ b/src/atomate2/cp2k/files.py
@@ -5,16 +5,19 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
-from pymatgen.core import Structure
 from pymatgen.io.cp2k.outputs import Cp2kOutput
 
 from atomate2 import SETTINGS
 from atomate2.common.files import copy_files, get_zfile, gunzip_files, rename_files
-from atomate2.cp2k.sets.base import Cp2kInputGenerator
 from atomate2.utils.file_client import FileClient, auto_fileclient
 from atomate2.utils.path import strip_hostname
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
+
+    from atomate2.cp2k.sets.base import Cp2kInputGenerator
 
 __all__ = ["copy_cp2k_outputs", "write_cp2k_input_set"]
 

--- a/src/atomate2/cp2k/flows/core.py
+++ b/src/atomate2/cp2k/flows/core.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from jobflow import Flow, Job, Maker
-from pymatgen.core.structure import Structure
 
-from atomate2.cp2k.jobs.base import BaseCp2kMaker
 from atomate2.cp2k.jobs.core import (
     HybridCellOptMaker,
     HybridRelaxMaker,
@@ -20,6 +18,13 @@ from atomate2.cp2k.jobs.core import (
 )
 from atomate2.cp2k.schemas.calculation import Cp2kObject
 from atomate2.cp2k.sets.base import recursive_update
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pymatgen.core.structure import Structure
+
+    from atomate2.cp2k.jobs.base import BaseCp2kMaker
 
 __all__ = [
     "DoubleRelaxMaker",

--- a/src/atomate2/cp2k/jobs/base.py
+++ b/src/atomate2/cp2k/jobs/base.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from jobflow import Maker, Response, job
 from monty.serialization import dumpfn
 from monty.shutil import gzip_dir
 from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.alchemy.transmuters import StandardTransmuter
-from pymatgen.core import Structure
 from pymatgen.core.trajectory import Trajectory
 from pymatgen.electronic_structure.bandstructure import (
     BandStructure,
@@ -29,6 +28,9 @@ from atomate2.cp2k.files import (
 from atomate2.cp2k.run import run_cp2k, should_stop_children
 from atomate2.cp2k.schemas.task import TaskDocument
 from atomate2.cp2k.sets.base import Cp2kInputGenerator
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
 
 __all__ = ["BaseCp2kMaker", "cp2k_job"]
 

--- a/src/atomate2/cp2k/jobs/core.py
+++ b/src/atomate2/cp2k/jobs/core.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from custodian.cp2k.handlers import (
     AbortHandler,
@@ -15,11 +15,9 @@ from custodian.cp2k.handlers import (
 )
 from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.alchemy.transmuters import StandardTransmuter
-from pymatgen.core.structure import Structure
 
 from atomate2.common.utils import get_transformations
 from atomate2.cp2k.jobs.base import BaseCp2kMaker, cp2k_job
-from atomate2.cp2k.sets.base import Cp2kInputGenerator
 from atomate2.cp2k.sets.core import (
     CellOptSetGenerator,
     HybridCellOptSetGenerator,
@@ -30,6 +28,14 @@ from atomate2.cp2k.sets.core import (
     RelaxSetGenerator,
     StaticSetGenerator,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pymatgen.core.structure import Structure
+
+    from atomate2.cp2k.sets.base import Cp2kInputGenerator
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/cp2k/run.py
+++ b/src/atomate2/cp2k/run.py
@@ -6,7 +6,7 @@ import logging
 import shlex
 import subprocess
 from os.path import expandvars
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from custodian import Custodian
 from custodian.cp2k.handlers import (
@@ -21,11 +21,14 @@ from custodian.cp2k.handlers import (
 )
 from custodian.cp2k.jobs import Cp2kJob
 from custodian.cp2k.validators import Cp2kOutputValidator
-from custodian.custodian import ErrorHandler, Validator
 from jobflow.utils import ValueEnum
 
 from atomate2 import SETTINGS
-from atomate2.cp2k.schemas.task import TaskDocument
+
+if TYPE_CHECKING:
+    from custodian.custodian import ErrorHandler, Validator
+
+    from atomate2.cp2k.schemas.task import TaskDocument
 
 __all__ = [
     "JobType",

--- a/src/atomate2/cp2k/sets/core.py
+++ b/src/atomate2/cp2k/sets/core.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from pymatgen.core import Structure
-from pymatgen.io.cp2k.inputs import Cp2kInput
-from pymatgen.io.cp2k.outputs import Cp2kOutput
 from pymatgen.io.cp2k.utils import get_truncated_coulomb_cutoff
 
 from atomate2.cp2k.sets.base import Cp2kInputGenerator
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
+    from pymatgen.io.cp2k.inputs import Cp2kInput
+    from pymatgen.io.cp2k.outputs import Cp2kOutput
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/forcefields/flows.py
+++ b/src/atomate2/forcefields/flows.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from jobflow import Flow, Maker
-from pymatgen.core.structure import Structure
 
 from atomate2.forcefields.jobs import CHGNetRelaxMaker
-from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.jobs.core import RelaxMaker
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
+
+    from atomate2.vasp.jobs.base import BaseVaspMaker
 
 
 @dataclass

--- a/src/atomate2/forcefields/jobs.py
+++ b/src/atomate2/forcefields/jobs.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from jobflow import Maker, job
-from pymatgen.core.structure import Structure
 
 from atomate2.forcefields.schemas import ForceFieldTaskDocument
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/lobster/files.py
+++ b/src/atomate2/lobster/files.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from atomate2.common.files import copy_files, get_zfile, gunzip_files
 from atomate2.utils.file_client import FileClient, auto_fileclient
 from atomate2.utils.path import strip_hostname
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 LOBSTEROUTPUT_FILES = [
     "lobsterout",

--- a/src/atomate2/lobster/run.py
+++ b/src/atomate2/lobster/run.py
@@ -6,15 +6,17 @@ import logging
 import shlex
 import subprocess
 from os.path import expandvars
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from custodian import Custodian
-from custodian.custodian import Validator
 from custodian.lobster.handlers import EnoughBandsValidator, LobsterFilesValidator
 from custodian.lobster.jobs import LobsterJob
 from jobflow.utils import ValueEnum
 
 from atomate2 import SETTINGS
+
+if TYPE_CHECKING:
+    from custodian.custodian import Validator
 
 __all__ = ["JobType", "run_lobster"]
 

--- a/src/atomate2/vasp/builders/elastic.py
+++ b/src/atomate2/vasp/builders/elastic.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 from itertools import chain
+from typing import TYPE_CHECKING
 
 import numpy as np
 from maggma.builders import Builder
-from maggma.core import Store
 from pydash import get
 from pymatgen.analysis.elasticity import Deformation, Stress
 
 from atomate2 import SETTINGS
 from atomate2.common.schemas.elastic import ElasticDocument
+
+if TYPE_CHECKING:
+    from maggma.core import Store
 
 
 class ElasticBuilder(Builder):

--- a/src/atomate2/vasp/files.py
+++ b/src/atomate2/vasp/files.py
@@ -5,15 +5,17 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import Sequence
-
-from pymatgen.core import Structure
+from typing import TYPE_CHECKING, Sequence
 
 from atomate2 import SETTINGS
 from atomate2.common.files import copy_files, get_zfile, gunzip_files, rename_files
 from atomate2.utils.file_client import FileClient, auto_fileclient
 from atomate2.utils.path import strip_hostname
-from atomate2.vasp.sets.base import VaspInputGenerator
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
+
+    from atomate2.vasp.sets.base import VaspInputGenerator
 
 __all__ = ["copy_vasp_outputs", "get_largest_relax_extension"]
 

--- a/src/atomate2/vasp/flows/amset.py
+++ b/src/atomate2/vasp/flows/amset.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 from jobflow import Flow, Maker, job
-from pymatgen.core.structure import Structure
 
 from atomate2 import SETTINGS
 from atomate2.amset.jobs import AmsetMaker
@@ -24,7 +23,6 @@ from atomate2.vasp.jobs.amset import (
     generate_wavefunction_coefficients,
     run_amset_deformations,
 )
-from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.jobs.core import (
     DielectricMaker,
     HSEBSMaker,
@@ -34,6 +32,13 @@ from atomate2.vasp.jobs.core import (
     TightRelaxMaker,
 )
 from atomate2.vasp.sets.core import HSEBSSetGenerator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pymatgen.core.structure import Structure
+
+    from atomate2.vasp.jobs.base import BaseVaspMaker
 
 __all__ = ["VaspAmsetMaker", "DeformationPotentialMaker", "HSEVaspAmsetMaker"]
 

--- a/src/atomate2/vasp/flows/core.py
+++ b/src/atomate2/vasp/flows/core.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from emmet.core.vasp.calculation import VaspObject
 from jobflow import Flow, Maker
-from pymatgen.core.structure import Structure
 
-from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.jobs.core import (
     HSEBSMaker,
     HSEStaticMaker,
@@ -19,6 +17,14 @@ from atomate2.vasp.jobs.core import (
     StaticMaker,
 )
 from atomate2.vasp.sets.core import HSEBSSetGenerator, NonSCFSetGenerator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pymatgen.core.structure import Structure
+
+    from atomate2.vasp.jobs.base import BaseVaspMaker
+
 
 __all__ = [
     "DoubleRelaxMaker",

--- a/src/atomate2/vasp/flows/defect.py
+++ b/src/atomate2/vasp/flows/defect.py
@@ -5,18 +5,16 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from jobflow import Flow, Maker, OutputReference
 from jobflow.core.maker import recursive_call
-from pymatgen.core.structure import Structure
 from pymatgen.io.vasp.outputs import Vasprun
 
 from atomate2.common.files import get_zfile
 from atomate2.common.flows import defect as defect_flows
-from atomate2.common.schemas.defects import CCDDocument
 from atomate2.utils.file_client import FileClient
 from atomate2.vasp.flows.core import DoubleRelaxMaker
-from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.jobs.core import RelaxMaker, StaticMaker
 from atomate2.vasp.jobs.defect import calculate_finite_diff
 from atomate2.vasp.sets.defect import (
@@ -25,6 +23,12 @@ from atomate2.vasp.sets.defect import (
     ChargeStateStaticSetGenerator,
     HSEChargeStateRelaxSetGenerator,
 )
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import Structure
+
+    from atomate2.common.schemas.defects import CCDDocument
+    from atomate2.vasp.jobs.base import BaseVaspMaker
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/vasp/flows/elastic.py
+++ b/src/atomate2/vasp/flows/elastic.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-from emmet.core.math import Matrix3D
 from jobflow import Flow, Maker, OnMissing
-from pymatgen.core.structure import Structure
 
 from atomate2 import SETTINGS
 from atomate2.vasp.flows.core import DoubleRelaxMaker
-from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.jobs.core import TightRelaxMaker
 from atomate2.vasp.jobs.elastic import (
     ElasticRelaxMaker,
@@ -19,6 +16,14 @@ from atomate2.vasp.jobs.elastic import (
     generate_elastic_deformations,
     run_elastic_deformations,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from emmet.core.math import Matrix3D
+    from pymatgen.core.structure import Structure
+
+    from atomate2.vasp.jobs.base import BaseVaspMaker
 
 __all__ = ["ElasticMaker"]
 

--- a/src/atomate2/vasp/flows/elph.py
+++ b/src/atomate2/vasp/flows/elph.py
@@ -4,17 +4,15 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from jobflow import Flow, Maker, OnMissing
-from pymatgen.core import Structure
 
 from atomate2.vasp.flows.core import (
     DoubleRelaxMaker,
     HSEUniformBandStructureMaker,
     UniformBandStructureMaker,
 )
-from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.jobs.core import (
     HSEBSMaker,
     HSEStaticMaker,
@@ -35,6 +33,14 @@ from atomate2.vasp.sets.core import (
     NonSCFSetGenerator,
     StaticSetGenerator,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pymatgen.core import Structure
+
+    from atomate2.vasp.jobs.base import BaseVaspMaker
+
 
 __all__ = ["ElectronPhononMaker"]
 

--- a/src/atomate2/vasp/flows/lobster.py
+++ b/src/atomate2/vasp/flows/lobster.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from jobflow import Flow, Maker
-from pymatgen.core import Structure
 
 from atomate2.lobster.jobs import LobsterMaker
 from atomate2.vasp.flows.core import DoubleRelaxMaker, UniformBandStructureMaker
-from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.jobs.core import NonSCFMaker, RelaxMaker, StaticMaker
 from atomate2.vasp.jobs.lobster import (
     delete_lobster_wavecar,
@@ -19,6 +17,13 @@ from atomate2.vasp.jobs.lobster import (
     update_user_incar_settings_maker,
 )
 from atomate2.vasp.sets.core import NonSCFSetGenerator, StaticSetGenerator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pymatgen.core import Structure
+
+    from atomate2.vasp.jobs.base import BaseVaspMaker
 
 __all__ = ["VaspLobsterMaker"]
 

--- a/src/atomate2/vasp/flows/phonons.py
+++ b/src/atomate2/vasp/flows/phonons.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-from emmet.core.math import Matrix3D
 from jobflow import Flow, Maker
-from pymatgen.core.structure import Structure
 
 from atomate2.common.jobs.utils import structure_to_conventional, structure_to_primitive
 from atomate2.vasp.flows.core import DoubleRelaxMaker
-from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.jobs.core import DielectricMaker, StaticMaker, TightRelaxMaker
 from atomate2.vasp.jobs.phonons import (
     PhononDisplacementMaker,
@@ -21,6 +18,15 @@ from atomate2.vasp.jobs.phonons import (
     get_total_energy_per_cell,
     run_phonon_displacements,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from emmet.core.math import Matrix3D
+    from pymatgen.core.structure import Structure
+
+    from atomate2.vasp.jobs.base import BaseVaspMaker
+
 
 __all__ = ["PhononMaker"]
 

--- a/src/atomate2/vasp/jobs/amset.py
+++ b/src/atomate2/vasp/jobs/amset.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 from click.testing import CliRunner
-from emmet.core.math import Vector3D
 from jobflow import Flow, Response, job
-from pymatgen.core import Structure
 from pymatgen.core.tensors import symmetry_reduce
 from pymatgen.transformations.standard_transformations import (
     DeformStructureTransformation,
@@ -21,13 +20,18 @@ from atomate2.utils.file_client import FileClient
 from atomate2.utils.path import strip_hostname
 from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.jobs.core import HSEBSMaker, NonSCFMaker
-from atomate2.vasp.sets.base import VaspInputGenerator
 from atomate2.vasp.sets.core import (
     HSEBSSetGenerator,
     HSEStaticSetGenerator,
     NonSCFSetGenerator,
     StaticSetGenerator,
 )
+
+if TYPE_CHECKING:
+    from emmet.core.math import Vector3D
+    from pymatgen.core import Structure
+
+    from atomate2.vasp.sets.base import VaspInputGenerator
 
 __all__ = [
     "DenseUniformMaker",

--- a/src/atomate2/vasp/jobs/base.py
+++ b/src/atomate2/vasp/jobs/base.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from shutil import which
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from emmet.core.tasks import TaskDoc
 from jobflow import Maker, Response, job
 from monty.serialization import dumpfn
 from monty.shutil import gzip_dir
-from pymatgen.core import Structure
 from pymatgen.core.trajectory import Trajectory
 from pymatgen.electronic_structure.bandstructure import (
     BandStructure,
@@ -24,6 +23,9 @@ from atomate2 import SETTINGS
 from atomate2.vasp.files import copy_vasp_outputs, write_vasp_input_set
 from atomate2.vasp.run import run_vasp, should_stop_children
 from atomate2.vasp.sets.base import VaspInputGenerator
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
 
 __all__ = ["BaseVaspMaker", "vasp_job"]
 

--- a/src/atomate2/vasp/jobs/core.py
+++ b/src/atomate2/vasp/jobs/core.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from custodian.vasp.handlers import (
     FrozenJobErrorHandler,
@@ -17,11 +17,9 @@ from custodian.vasp.handlers import (
 )
 from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.alchemy.transmuters import StandardTransmuter
-from pymatgen.core.structure import Structure
 
 from atomate2.common.utils import get_transformations
 from atomate2.vasp.jobs.base import BaseVaspMaker, vasp_job
-from atomate2.vasp.sets.base import VaspInputGenerator
 from atomate2.vasp.sets.core import (
     HSEBSSetGenerator,
     HSERelaxSetGenerator,
@@ -33,6 +31,14 @@ from atomate2.vasp.sets.core import (
     StaticSetGenerator,
     TightRelaxSetGenerator,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pymatgen.core.structure import Structure
+
+    from atomate2.vasp.sets.base import VaspInputGenerator
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/vasp/jobs/elastic.py
+++ b/src/atomate2/vasp/jobs/elastic.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
-from emmet.core.math import Matrix3D
 from jobflow import Flow, Response, job
 from pymatgen.alchemy.materials import TransformedStructure
 from pymatgen.analysis.elasticity import Deformation, Strain, Stress
-from pymatgen.core.structure import Structure
 from pymatgen.core.tensors import symmetry_reduce
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.transformations.standard_transformations import (
@@ -22,8 +20,15 @@ from atomate2 import SETTINGS
 from atomate2.common.analysis.elastic import get_default_strain_states
 from atomate2.common.schemas.elastic import ElasticDocument
 from atomate2.vasp.jobs.base import BaseVaspMaker
-from atomate2.vasp.sets.base import VaspInputGenerator
 from atomate2.vasp.sets.core import StaticSetGenerator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from emmet.core.math import Matrix3D
+    from pymatgen.core.structure import Structure
+
+    from atomate2.vasp.sets.base import VaspInputGenerator
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/vasp/jobs/elph.py
+++ b/src/atomate2/vasp/jobs/elph.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 from jobflow import Flow, Response, job
-from pymatgen.core import Structure
-from pymatgen.electronic_structure.bandstructure import BandStructure
 
 from atomate2.vasp.jobs.base import BaseVaspMaker, vasp_job
 from atomate2.vasp.jobs.core import TransmuterMaker
 from atomate2.vasp.schemas.elph import ElectronPhononRenormalisationDoc
 from atomate2.vasp.sets.core import ElectronPhononSetGenerator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pymatgen.core import Structure
+    from pymatgen.electronic_structure.bandstructure import BandStructure
 
 __all__ = [
     "DEFAULT_ELPH_TEMPERATURES",

--- a/src/atomate2/vasp/jobs/lobster.py
+++ b/src/atomate2/vasp/jobs/lobster.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from jobflow import Flow, Response, job
-from pymatgen.core import Structure
 from pymatgen.io.lobster import Lobsterin
 
 from atomate2.common.files import delete_files
@@ -16,8 +14,15 @@ from atomate2.lobster.jobs import LobsterMaker
 from atomate2.utils.path import strip_hostname
 from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.powerups import update_user_incar_settings
-from atomate2.vasp.sets.base import VaspInputGenerator
 from atomate2.vasp.sets.core import StaticSetGenerator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pymatgen.core import Structure
+
+    from atomate2.vasp.sets.base import VaspInputGenerator
+
 
 __all__ = [
     "LobsterStaticMaker",

--- a/src/atomate2/vasp/jobs/phonons.py
+++ b/src/atomate2/vasp/jobs/phonons.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
-import numpy as np
-from emmet.core.math import Matrix3D
 from jobflow import Flow, Response, job
 from phonopy import Phonopy
 from phonopy.units import VaspToTHz
-from pymatgen.core import Structure
 from pymatgen.io.phonopy import get_phonopy_structure, get_pmg_structure
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.dos import PhononDos
@@ -20,8 +18,14 @@ from pymatgen.transformations.advanced_transformations import (
 
 from atomate2.vasp.jobs.base import BaseVaspMaker
 from atomate2.vasp.schemas.phonons import PhononBSDOSDoc
-from atomate2.vasp.sets.base import VaspInputGenerator
 from atomate2.vasp.sets.core import StaticSetGenerator
+
+if TYPE_CHECKING:
+    import numpy as np
+    from emmet.core.math import Matrix3D
+    from pymatgen.core import Structure
+
+    from atomate2.vasp.sets.base import VaspInputGenerator
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/vasp/run.py
+++ b/src/atomate2/vasp/run.py
@@ -12,10 +12,9 @@ import logging
 import shlex
 import subprocess
 from os.path import expandvars
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from custodian import Custodian
-from custodian.custodian import ErrorHandler, Validator
 from custodian.vasp.handlers import (
     FrozenJobErrorHandler,
     IncorrectSmearingHandler,
@@ -31,10 +30,14 @@ from custodian.vasp.handlers import (
 )
 from custodian.vasp.jobs import VaspJob
 from custodian.vasp.validators import VaspFilesValidator, VasprunXMLValidator
-from emmet.core.tasks import TaskDoc
 from jobflow.utils import ValueEnum
 
 from atomate2 import SETTINGS
+
+if TYPE_CHECKING:
+    from custodian.custodian import ErrorHandler, Validator
+    from emmet.core.tasks import TaskDoc
+
 
 __all__ = [
     "JobType",

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -9,13 +9,12 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from itertools import groupby
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from monty.io import zopen
 from monty.serialization import loadfn
 from pkg_resources import resource_filename
-from pymatgen.core import Structure
 from pymatgen.electronic_structure.core import Magmom
 from pymatgen.io.core import InputGenerator, InputSet
 from pymatgen.io.vasp import Incar, Kpoints, Outcar, Poscar, Potcar, Vasprun
@@ -28,6 +27,10 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.symmetry.bandstructure import HighSymmKpath
 
 from atomate2 import SETTINGS
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
+
 
 _BASE_VASP_SET = loadfn(resource_filename("atomate2.vasp.sets", "BaseVaspSet.yaml"))
 

--- a/src/atomate2/vasp/sets/core.py
+++ b/src/atomate2/vasp/sets/core.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from emmet.core.math import Vector3D
-from pymatgen.core import Structure
 from pymatgen.core.periodic_table import Element
-from pymatgen.io.vasp import Outcar, Vasprun
 
 from atomate2.vasp.sets.base import VaspInputGenerator
+
+if TYPE_CHECKING:
+    from emmet.core.math import Vector3D
+    from pymatgen.core import Structure
+    from pymatgen.io.vasp import Outcar, Vasprun
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/vasp/sets/defect.py
+++ b/src/atomate2/vasp/sets/defect.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
-from pymatgen.core import Structure
-from pymatgen.io.vasp import Outcar, Vasprun
 from pymatgen.io.vasp.inputs import Kpoints, Kpoints_supported_modes
 
 from atomate2.vasp.sets.base import VaspInputGenerator
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
+    from pymatgen.io.vasp import Outcar, Vasprun
 
 SPECIAL_KPOINT = Kpoints(
     comment="special k-point",


### PR DESCRIPTION
## Summary

 1ab9e8fd ruff enable flake8-type-checking (TCH)
 2f54128a move all type-hint only imports behind if TYPE_CHECKING

Related PR: https://github.com/materialsproject/pymatgen/pull/2992

4 main motivations for this change:

1. reduces chance of circular imports
2. can help contributors run tests without installing extra deps like `pymatgen.analysis.defects` if they were previously in a test's import stack but only used for type hints
3. helps with readability by clearly separating type-only imports
4. can increase startup time since `TYPE_CHECKING=False` at run time means some modules won't have to be imported. somewhat negated by the annoyingly long import time of the std lib `typing` module itself but that has been steadily coming down with newer Python versions.