### PR TITLE
allow elastically unstable structures

### DIFF
--- a/src/atomate2/common/schemas/elastic.py
+++ b/src/atomate2/common/schemas/elastic.py
@@ -148,6 +148,7 @@ class ElasticDocument(BaseModel):
         order: Optional[int] = None,
         equilibrium_stress: Optional[Matrix3D] = None,
         symprec: float = SETTINGS.SYMPREC,
+        allow_elastically_unstable_materials: bool = True
     ):
         """
         Create an elastic document from strains and stresses.
@@ -177,6 +178,9 @@ class ElasticDocument(BaseModel):
         symprec : float
             Symmetry precision for deriving symmetry equivalent deformations. If
             ``symprec=None``, then no symmetry operations will be applied.
+        allow_elastically_unstable_materials : bool
+            Whether to allow the ElasticDocument to still complete in the event that
+            the structure is elastically unstable.
         """
         if symprec is not None:
             deformations, stresses, uuids, job_dirs = _expand_deformations(
@@ -213,7 +217,14 @@ class ElasticDocument(BaseModel):
         ieee = result.convert_to_ieee(structure)
         property_tensor = ieee if order == 2 else ElasticTensor(ieee[0])
         property_dict = property_tensor.get_structure_property_dict(structure)
-        derived_properties = DerivedProperties(**property_dict)
+
+        if allow_elastically_unstable_materials:
+            try: # try to get Derived Properties
+                derived_properties = DerivedProperties(**property_dict)
+            else: # allow this method to error for elastically unstable structures
+                derived_properties = None
+        else:
+            derived_properties = DerivedProperties(**property_dict)
 
         eq_stress = eq_stress.tolist() if eq_stress is not None else eq_stress
 

--- a/src/atomate2/common/schemas/elastic.py
+++ b/src/atomate2/common/schemas/elastic.py
@@ -221,7 +221,7 @@ class ElasticDocument(BaseModel):
         if allow_elastically_unstable_materials:
             try: # try to get Derived Properties
                 derived_properties = DerivedProperties(**property_dict)
-            else: # allow this method to error for elastically unstable structures
+            except: # allow this method to error for elastically unstable structures
                 derived_properties = None
         else:
             derived_properties = DerivedProperties(**property_dict)

--- a/src/atomate2/vasp/flows/elastic.py
+++ b/src/atomate2/vasp/flows/elastic.py
@@ -66,6 +66,8 @@ class ElasticMaker(Maker):
         Keyword arguments passed to :obj:`generate_elastic_deformations`.
     fit_elastic_tensor_kwargs : dict
         Keyword arguments passed to :obj:`fit_elastic_tensor`.
+    task_document_kwargs : dict
+        Additional keyword args passed to :obj:`.ElasticDocument.from_stresses()`.
     """
 
     name: str = "elastic"
@@ -78,6 +80,7 @@ class ElasticMaker(Maker):
     elastic_relax_maker: BaseVaspMaker = field(default_factory=ElasticRelaxMaker)
     generate_elastic_deformations_kwargs: dict = field(default_factory=dict)
     fit_elastic_tensor_kwargs: dict = field(default_factory=dict)
+    task_document_kwargs: dict = field(default_factory=dict)
 
     def make(
         self,
@@ -128,6 +131,7 @@ class ElasticMaker(Maker):
             order=self.order,
             symprec=self.symprec if self.sym_reduce else None,
             **self.fit_elastic_tensor_kwargs,
+            **self.task_document_kwargs,
         )
 
         # allow some of the deformations to fail

--- a/src/atomate2/vasp/jobs/elastic.py
+++ b/src/atomate2/vasp/jobs/elastic.py
@@ -240,6 +240,7 @@ def fit_elastic_tensor(
     order: int = 2,
     fitting_method: str = SETTINGS.ELASTIC_FITTING_METHOD,
     symprec: float = SETTINGS.SYMPREC,
+    task_document_kwargs: dict = field(default_factory=dict),
 ):
     """
     Analyze stress/strain data to fit the elastic tensor and related properties.
@@ -265,6 +266,8 @@ def fit_elastic_tensor(
     symprec : float
         Symmetry precision for deriving symmetry equivalent deformations. If
         ``symprec=None``, then no symmetry operations will be applied.
+    task_document_kwargs : dict
+        Additional keyword args passed to :obj:`.ElasticDocument.from_stresses()`.
     """
     stresses = []
     deformations = []
@@ -292,4 +295,5 @@ def fit_elastic_tensor(
         order=order,
         equilibrium_stress=equilibrium_stress,
         symprec=symprec,
+        **task_document_kwargs,
     )

--- a/src/atomate2/vasp/jobs/elastic.py
+++ b/src/atomate2/vasp/jobs/elastic.py
@@ -240,7 +240,7 @@ def fit_elastic_tensor(
     order: int = 2,
     fitting_method: str = SETTINGS.ELASTIC_FITTING_METHOD,
     symprec: float = SETTINGS.SYMPREC,
-    task_document_kwargs: dict = field(default_factory=dict),
+    allow_elastically_unstable_structs: bool = True,
 ):
     """
     Analyze stress/strain data to fit the elastic tensor and related properties.
@@ -266,8 +266,9 @@ def fit_elastic_tensor(
     symprec : float
         Symmetry precision for deriving symmetry equivalent deformations. If
         ``symprec=None``, then no symmetry operations will be applied.
-    task_document_kwargs : dict
-        Additional keyword args passed to :obj:`.ElasticDocument.from_stresses()`.
+    allow_elastically_unstable_structs : bool
+        Whether to allow the ElasticDocument to still complete in the event that
+        the structure is elastically unstable.
     """
     stresses = []
     deformations = []
@@ -295,5 +296,5 @@ def fit_elastic_tensor(
         order=order,
         equilibrium_stress=equilibrium_stress,
         symprec=symprec,
-        **task_document_kwargs,
+        allow_elastically_unstable_structs=allow_elastically_unstable_structs,
     )


### PR DESCRIPTION
## Summary

Introduce a `task_document_kwarg` to the `ElasticDocument` that allows the elastic workflow to still complete in the event that the structure is elastically unstable. This specifically affects the `DerivedProperties` field in the ElasticDocument, which will be set to none in the event that the structure is elastically unstable.

@utf I made it so that elastically unstable structures are, by default, **_allowed_** to complete. Let me know if you think this should be changed.