### PR TITLE
Fix `emmet-core` version in `setup.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "PyYAML",
     "click",
     "custodian>=2023.3.10",
-    "emmet-core>=0.51.11",
+    "emmet-core>=0.51.1",
     "jobflow>=0.1.11",
     "monty",
     "numpy",


### PR DESCRIPTION
Someone (likely me) accidentally set `emmet-core>=0.51.11` instead of `>=0.51.1`. Now fixed.