### PR TITLE
Update Lobster documentation

### DIFF
--- a/docs/user/codes/vasp.md
+++ b/docs/user/codes/vasp.md
@@ -259,6 +259,8 @@ VASP_CMD: <<VASP_CMD>>
 LOBSTER_CMD: <<LOBSTER_CMD>>
 ```
 
+[FireWorks](https://github.com/materialsproject/fireworks) allows to run the VASP and Lobster jobs with different job scripts. Please check out the [jobflow documentation on FireWorks](https://materialsproject.github.io/jobflow/tutorials/8-fireworks.html#setting-the-manager-configs) for more information.
+
 Outputs from the automatic analysis with LobsterPy can easily be extracted from the database and also plotted:
 
 ```python


### PR DESCRIPTION
## Summary
I would like to refer to the new jobflow tutorials on fireworks addedin https://github.com/materialsproject/jobflow/pull/338 directly in the documentation of the Lobster workflow part. I think it is especially useful there.