### PR TITLE
Add `m3gnet` support to Atomate2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ mp = ["mp-api>=0.27.5"]
 phonons = ["phonopy>=1.10.8", "seekpath"]
 lobster = ["lobsterpy"]
 defects = ["dscribe>=1.2.0", "pymatgen-analysis-defects>=2022.11.30"]
-chgnet = ["chgnet==0.1.3"]
+forcefields = ["chgnet==0.1.3", "matgl==0.5.6"]
 docs = [
     "FireWorks==2.0.3",
     "autodoc_pydantic==1.8.0",
@@ -66,6 +66,7 @@ strict = [
     "emmet-core==0.55.2",
     "jobflow==0.1.11",
     "lobsterpy==0.2.9",
+    "matgl==0.5.6",
     "monty==2023.5.8",
     "mp-api==0.33.3",
     "numpy",

--- a/src/atomate2/common/schemas/elastic.py
+++ b/src/atomate2/common/schemas/elastic.py
@@ -148,6 +148,7 @@ class ElasticDocument(BaseModel):
         order: Optional[int] = None,
         equilibrium_stress: Optional[Matrix3D] = None,
         symprec: float = SETTINGS.SYMPREC,
+        allow_elastically_unstable_materials: bool = True
     ):
         """
         Create an elastic document from strains and stresses.
@@ -177,6 +178,9 @@ class ElasticDocument(BaseModel):
         symprec : float
             Symmetry precision for deriving symmetry equivalent deformations. If
             ``symprec=None``, then no symmetry operations will be applied.
+        allow_elastically_unstable_materials : bool
+            Whether to allow the ElasticDocument to still complete in the event that
+            the structure is elastically unstable.
         """
         if symprec is not None:
             deformations, stresses, uuids, job_dirs = _expand_deformations(
@@ -213,7 +217,14 @@ class ElasticDocument(BaseModel):
         ieee = result.convert_to_ieee(structure)
         property_tensor = ieee if order == 2 else ElasticTensor(ieee[0])
         property_dict = property_tensor.get_structure_property_dict(structure)
-        derived_properties = DerivedProperties(**property_dict)
+
+        if allow_elastically_unstable_materials:
+            try: # try to get Derived Properties
+                derived_properties = DerivedProperties(**property_dict)
+            else: # allow this method to error for elastically unstable structures
+                derived_properties = None
+        else:
+            derived_properties = DerivedProperties(**property_dict)
 
         eq_stress = eq_stress.tolist() if eq_stress is not None else eq_stress
 

--- a/src/atomate2/common/schemas/elastic.py
+++ b/src/atomate2/common/schemas/elastic.py
@@ -221,7 +221,7 @@ class ElasticDocument(BaseModel):
         if allow_elastically_unstable_materials:
             try: # try to get Derived Properties
                 derived_properties = DerivedProperties(**property_dict)
-            else: # allow this method to error for elastically unstable structures
+            except: # allow this method to error for elastically unstable structures
                 derived_properties = None
         else:
             derived_properties = DerivedProperties(**property_dict)

--- a/src/atomate2/forcefields/flows.py
+++ b/src/atomate2/forcefields/flows.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from jobflow import Flow, Maker
 
-from atomate2.forcefields.jobs import CHGNetRelaxMaker
+from atomate2.forcefields.jobs import CHGNetRelaxMaker, M3GNetRelaxMaker
 from atomate2.vasp.jobs.core import RelaxMaker
 
 if TYPE_CHECKING:
@@ -29,7 +29,6 @@ class CHGNetVaspRelaxMaker(Maker):
         Maker to generate a CHGNet relaxation job.
     vasp_maker : .BaseVaspMaker
         Maker to generate a VASP relaxation job.
-
     """
 
     name: str = "CHGNet relax followed by a VASP relax"
@@ -49,7 +48,6 @@ class CHGNetVaspRelaxMaker(Maker):
         -------
         Flow
             A flow containing a CHGNet relaxation followed by a VASP relaxation
-
         """
         chgnet_relax_job = self.chgnet_maker.make(structure)
         chgnet_relax_job.name = "CHGNet pre-relax"
@@ -57,3 +55,44 @@ class CHGNetVaspRelaxMaker(Maker):
         vasp_job = self.vasp_maker.make(chgnet_relax_job.output.structure)
 
         return Flow([chgnet_relax_job, vasp_job], vasp_job.output, name=self.name)
+
+
+@dataclass
+class M3GNetVaspRelaxMaker(Maker):
+    """
+    Maker to (pre)relax a structure using M3GNet and then run VASP.
+
+    Parameters
+    ----------
+    name : str
+        Name of the flow produced by this maker.
+    m3gnet_maker : .M3GNetRelaxMaker
+        Maker to generate a M3GNet relaxation job.
+    vasp_maker : .BaseVaspMaker
+        Maker to generate a VASP relaxation job.
+    """
+
+    name: str = "M3GNet relax followed by a VASP relax"
+    m3gnet_maker: M3GNetRelaxMaker = field(default_factory=M3GNetRelaxMaker)
+    vasp_maker: BaseVaspMaker = field(default_factory=RelaxMaker)
+
+    def make(self, structure: Structure):
+        """
+        Create a flow with a M3GNet (pre)relaxation followed by a VASP relaxation.
+
+        Parameters
+        ----------
+        structure : .Structure
+            A pymatgen structure.
+
+        Returns
+        -------
+        Flow
+            A flow containing a M3GNet relaxation followed by a VASP relaxation
+        """
+        m3gnet_relax_job = self.m3gnet_maker.make(structure)
+        m3gnet_relax_job.name = "M3GNet pre-relax"
+
+        vasp_job = self.vasp_maker.make(m3gnet_relax_job.output.structure)
+
+        return Flow([m3gnet_relax_job, vasp_job], vasp_job.output, name=self.name)

--- a/src/atomate2/forcefields/jobs.py
+++ b/src/atomate2/forcefields/jobs.py
@@ -160,10 +160,12 @@ class M3GNetRelaxMaker(Maker):
         model, d = M3GNet.load("M3GNet-MP-2021.2.8-EFS", include_json=True)
         metadata = d["metadata"]
         data_std = metadata["data_std"]
-        metadata["data_mean"]
+        data_mean = metadata["data_mean"]
         element_refs = metadata["element_refs"]
 
-        ff = Potential(model, data_std=data_std, element_refs=element_refs)
+        ff = Potential(
+            model, data_std=data_std, data_mean=data_mean, element_refs=element_refs
+        )
 
         AseAtomsAdaptor()
 
@@ -187,3 +189,32 @@ class M3GNetRelaxMaker(Maker):
             self.optimizer_kwargs,
             **self.task_document_kwargs,
         )
+
+
+@dataclass
+class M3GNetStaticMaker(M3GNetRelaxMaker):
+    """
+    Maker to calculate forces and stresses using the M3GNet force field.
+
+    Parameters
+    ----------
+    name : str
+        The job name.
+    relax_cell : bool
+        Whether to allow the cell shape/volume to change during relaxation.
+    steps : int
+        Maximum number of ionic steps allowed during relaxation.
+    relax_kwargs : dict
+        Keyword arguments that will get passed to :obj:`Relaxer.relax`.
+    optimizer_kwargs : dict
+        Keyword arguments that will get passed to :obj:`Relaxer()`.
+    task_document_kwargs : dict
+        Additional keyword args passed to :obj:`.ForceFieldTaskDocument()`.
+    """
+
+    name: str = "M3GNet static"
+    relax_cell: bool = False
+    steps: int = 1
+    relax_kwargs: dict = field(default_factory=dict)
+    optimizer_kwargs: dict = field(default_factory=dict)
+    task_document_kwargs: dict = field(default_factory=dict)

--- a/src/atomate2/forcefields/schemas.py
+++ b/src/atomate2/forcefields/schemas.py
@@ -218,6 +218,7 @@ class ForceFieldTaskDocument(StructureMetadata):
 
         import chgnet
 
+        forcefield_name = "CHGNet"
         version = chgnet.__version__
 
         return cls.from_structure(
@@ -225,6 +226,140 @@ class ForceFieldTaskDocument(StructureMetadata):
             structure=output_structure,
             input=input_doc,
             output=output_doc,
-            forcefield_name="CHGNet",
+            forcefield_name=forcefield_name,
+            forcefield_version=version,
+        )
+
+    @classmethod
+    def from_m3gnet_result(
+        cls,
+        result: dict,
+        relax_cell: bool,
+        steps: int,
+        relax_kwargs: dict = None,
+        optimizer_kwargs: dict = None,
+        ionic_step_data: tuple = ("energy", "forces", "magmoms", "stress", "structure"),
+    ):
+        """
+        Create a ForceFieldTaskDocument for a M3GNet Task.
+
+        Parameters
+        ----------
+        result : dict
+            The outputted results from the task.
+        relax_cell : bool
+            Whether the cell shape/volume was allowed to change during the task.
+        steps : int
+            Maximum number of ionic steps allowed during relaxation.
+        relax_kwargs : dict
+            Keyword arguments that will get passed to :obj:`Relaxer.relax`.
+        optimizer_kwargs : dict
+            Keyword arguments that will get passed to :obj:`Relaxer()`.
+        ionic_step_data : tuple
+            Which data to save from each ionic step.
+        """
+        trajectory = result["trajectory"].__dict__
+
+        # NOTE: units for stresses were converted to kbar (* -10 from standard output)
+        # to comply with MP convention
+        for i in range(0, len(trajectory["stresses"])):
+            trajectory["stresses"][i] = trajectory["stresses"][i] * -10
+
+        species = AseAtomsAdaptor.get_structure(trajectory["atoms"]).species
+
+        input_structure = Structure(
+            lattice=trajectory["cells"][0],
+            coords=trajectory["atom_positions"][0],
+            species=species,
+            coords_are_cartesian=True,
+        )
+
+        input_doc = InputDoc(
+            structure=input_structure,
+            relax_cell=relax_cell,
+            steps=steps,
+            relax_kwargs=relax_kwargs,
+            optimizer_kwargs=optimizer_kwargs,
+        )
+
+        # Workaround for cases where the ASE optimizer does not correctly limit the
+        # number of steps for static calculations.
+        if steps <= 1:
+            steps = 1
+            for key in trajectory:
+                trajectory[key] = [trajectory[key][0]]
+            output_structure = input_structure
+        else:
+            output_structure = result["final_structure"]
+
+        final_energy = trajectory["energies"][-1]
+        final_energy_per_atom = trajectory["energies"][-1] / input_structure.num_sites
+        final_forces = trajectory["forces"][-1].tolist()
+        final_stress = trajectory["stresses"][-1].tolist()
+
+        n_steps = len(trajectory["energies"])
+
+        ionic_steps = []
+        for i in range(0, n_steps):
+            cur_energy = (
+                trajectory["energies"][i] if "energy" in ionic_step_data else None
+            )
+            cur_forces = (
+                trajectory["forces"][i].tolist()
+                if "forces" in ionic_step_data
+                else None
+            )
+            cur_magmoms = (
+                trajectory["magmoms"][i].tolist()
+                if "magmoms" in ionic_step_data
+                else None
+            )
+            cur_stress = (
+                trajectory["stresses"][i].tolist()
+                if "stress" in ionic_step_data
+                else None
+            )
+
+            if "structure" in ionic_step_data:
+                cur_structure = Structure(
+                    lattice=trajectory["cells"][i],
+                    coords=trajectory["atom_positions"][i],
+                    species=species,
+                    coords_are_cartesian=True,
+                )
+            else:
+                cur_structure = None
+
+            ionic_steps.append(
+                IonicStep(
+                    energy=cur_energy,
+                    forces=cur_forces,
+                    magmoms=cur_magmoms,
+                    stress=cur_stress,
+                    structure=cur_structure,
+                )
+            )
+
+        output_doc = OutputDoc(
+            structure=output_structure,
+            energy=final_energy,
+            energy_per_atom=final_energy_per_atom,
+            forces=final_forces,
+            stress=final_stress,
+            ionic_steps=ionic_steps,
+            n_steps=n_steps,
+        )
+
+        import matgl
+
+        forcefield_name = "M3GNet"
+        version = matgl.__version__
+
+        return cls.from_structure(
+            meta_structure=output_structure,
+            structure=output_structure,
+            input=input_doc,
+            output=output_doc,
+            forcefield_name=forcefield_name,
             forcefield_version=version,
         )

--- a/src/atomate2/forcefields/schemas.py
+++ b/src/atomate2/forcefields/schemas.py
@@ -238,7 +238,7 @@ class ForceFieldTaskDocument(StructureMetadata):
         steps: int,
         relax_kwargs: dict = None,
         optimizer_kwargs: dict = None,
-        ionic_step_data: tuple = ("energy", "forces", "magmoms", "stress", "structure"),
+        ionic_step_data: tuple = ("energy", "forces", "stress", "structure"),
     ):
         """
         Create a ForceFieldTaskDocument for a M3GNet Task.
@@ -309,11 +309,6 @@ class ForceFieldTaskDocument(StructureMetadata):
                 if "forces" in ionic_step_data
                 else None
             )
-            cur_magmoms = (
-                trajectory["magmoms"][i].tolist()
-                if "magmoms" in ionic_step_data
-                else None
-            )
             cur_stress = (
                 trajectory["stresses"][i].tolist()
                 if "stress" in ionic_step_data
@@ -334,7 +329,6 @@ class ForceFieldTaskDocument(StructureMetadata):
                 IonicStep(
                     energy=cur_energy,
                     forces=cur_forces,
-                    magmoms=cur_magmoms,
                     stress=cur_stress,
                     structure=cur_structure,
                 )

--- a/src/atomate2/vasp/flows/elastic.py
+++ b/src/atomate2/vasp/flows/elastic.py
@@ -66,6 +66,8 @@ class ElasticMaker(Maker):
         Keyword arguments passed to :obj:`generate_elastic_deformations`.
     fit_elastic_tensor_kwargs : dict
         Keyword arguments passed to :obj:`fit_elastic_tensor`.
+    task_document_kwargs : dict
+        Additional keyword args passed to :obj:`.ElasticDocument.from_stresses()`.
     """
 
     name: str = "elastic"
@@ -78,6 +80,7 @@ class ElasticMaker(Maker):
     elastic_relax_maker: BaseVaspMaker = field(default_factory=ElasticRelaxMaker)
     generate_elastic_deformations_kwargs: dict = field(default_factory=dict)
     fit_elastic_tensor_kwargs: dict = field(default_factory=dict)
+    task_document_kwargs: dict = field(default_factory=dict)
 
     def make(
         self,
@@ -128,6 +131,7 @@ class ElasticMaker(Maker):
             order=self.order,
             symprec=self.symprec if self.sym_reduce else None,
             **self.fit_elastic_tensor_kwargs,
+            **self.task_document_kwargs,
         )
 
         # allow some of the deformations to fail

--- a/src/atomate2/vasp/jobs/elastic.py
+++ b/src/atomate2/vasp/jobs/elastic.py
@@ -240,6 +240,7 @@ def fit_elastic_tensor(
     order: int = 2,
     fitting_method: str = SETTINGS.ELASTIC_FITTING_METHOD,
     symprec: float = SETTINGS.SYMPREC,
+    task_document_kwargs: dict = field(default_factory=dict),
 ):
     """
     Analyze stress/strain data to fit the elastic tensor and related properties.
@@ -265,6 +266,8 @@ def fit_elastic_tensor(
     symprec : float
         Symmetry precision for deriving symmetry equivalent deformations. If
         ``symprec=None``, then no symmetry operations will be applied.
+    task_document_kwargs : dict
+        Additional keyword args passed to :obj:`.ElasticDocument.from_stresses()`.
     """
     stresses = []
     deformations = []
@@ -292,4 +295,5 @@ def fit_elastic_tensor(
         order=order,
         equilibrium_stress=equilibrium_stress,
         symprec=symprec,
+        **task_document_kwargs,
     )

--- a/src/atomate2/vasp/jobs/elastic.py
+++ b/src/atomate2/vasp/jobs/elastic.py
@@ -240,7 +240,7 @@ def fit_elastic_tensor(
     order: int = 2,
     fitting_method: str = SETTINGS.ELASTIC_FITTING_METHOD,
     symprec: float = SETTINGS.SYMPREC,
-    task_document_kwargs: dict = field(default_factory=dict),
+    allow_elastically_unstable_structs: bool = True,
 ):
     """
     Analyze stress/strain data to fit the elastic tensor and related properties.
@@ -266,8 +266,9 @@ def fit_elastic_tensor(
     symprec : float
         Symmetry precision for deriving symmetry equivalent deformations. If
         ``symprec=None``, then no symmetry operations will be applied.
-    task_document_kwargs : dict
-        Additional keyword args passed to :obj:`.ElasticDocument.from_stresses()`.
+    allow_elastically_unstable_structs : bool
+        Whether to allow the ElasticDocument to still complete in the event that
+        the structure is elastically unstable.
     """
     stresses = []
     deformations = []
@@ -295,5 +296,5 @@ def fit_elastic_tensor(
         order=order,
         equilibrium_stress=equilibrium_stress,
         symprec=symprec,
-        **task_document_kwargs,
+        allow_elastically_unstable_structs=allow_elastically_unstable_structs,
     )

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -1,7 +1,7 @@
 from pytest import approx
 
 
-def test_static_maker(si_structure):
+def test_chgnet_static_maker(si_structure):
     from jobflow import run_locally
 
     from atomate2.forcefields.jobs import CHGNetStaticMaker
@@ -23,7 +23,7 @@ def test_static_maker(si_structure):
     assert output1.output.n_steps == 1
 
 
-def test_relax_maker(si_structure):
+def test_chgnet_relax_maker(si_structure):
     from jobflow import run_locally
 
     from atomate2.forcefields.jobs import CHGNetRelaxMaker
@@ -46,3 +46,46 @@ def test_relax_maker(si_structure):
         0.002112872898578644, rel=1e-4
     )
     assert output1.output.n_steps == 12
+
+
+def test_m3gnet_static_maker(si_structure):
+    from jobflow import run_locally
+
+    from atomate2.forcefields.jobs import M3GNetStaticMaker
+    from atomate2.forcefields.schemas import ForceFieldTaskDocument
+
+    task_doc_kwargs = {"ionic_step_data": ("structure", "energy")}
+
+    # generate job
+    job = M3GNetStaticMaker(task_document_kwargs=task_doc_kwargs).make(si_structure)
+
+    # run the flow or job and ensure that it finished running successfully
+    responses = run_locally(job, ensure_success=True)
+
+    # validation the outputs of the job
+    output1 = responses[job.uuid][1].output
+    assert isinstance(output1, ForceFieldTaskDocument)
+    assert output1.output.energy == approx(-10.711267471313477, rel=1e-4)
+    assert output1.output.n_steps == 1
+
+
+def test_m3gnet_relax_maker(si_structure):
+    from jobflow import run_locally
+
+    from atomate2.forcefields.jobs import M3GNetRelaxMaker
+    from atomate2.forcefields.schemas import ForceFieldTaskDocument
+
+    # translate one atom to ensure a small number of relaxation steps are taken
+    si_structure.translate_sites(0, [0, 0, 0.1])
+
+    # generate job
+    job = M3GNetRelaxMaker(steps=25).make(si_structure)
+
+    # run the flow or job and ensure that it finished running successfully
+    responses = run_locally(job, ensure_success=True)
+
+    # validating the outputs of the job
+    output1 = responses[job.uuid][1].output
+    assert isinstance(output1, ForceFieldTaskDocument)
+    assert output1.output.energy == approx(-10.710836410522461, rel=1e-4)
+    assert output1.output.n_steps == 14


### PR DESCRIPTION
## Summary

* Add `M3GNet` support from the [matgl repository](https://github.com/materialsvirtuallab/matgl) to Atomate2 forcefields.

## Additional dependencies introduced

* matgl

## Notes

* I do not plan to add support for MEGNet (as it seems to be inferior to M3GNet according to [matbench discovery](https://matbench-discovery.materialsproject.org/models)). Let me know if MEGNet has considerable demand too.