### PR TITLE
clean up doc, remove left-overs from amset example

### DIFF
--- a/src/atomate2/lobster/schemas.py
+++ b/src/atomate2/lobster/schemas.py
@@ -1,4 +1,4 @@
-"""Module defining amset document schemas."""
+"""Module defining lobster document schemas."""
 
 import logging
 import time


### PR DESCRIPTION
## Summary

Tiny documentation change. As you can see, the amset schema led the development of the lobster schema.