### PR TITLE
[BUG FIX] Edge case for Magmoms

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,7 @@ jobs:
         run: sphinx-build docs docs_build
 
       - name: Deploy
+        if: github.repository_owner == 'materialsproject' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' 
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ forcefields = ["chgnet==0.2.0", "matgl==0.7.1"]
 docs = [
     "FireWorks==2.0.3",
     "autodoc_pydantic==1.9.0",
-    "furo==2023.5.20",
+    "furo==2023.7.26",
     "ipython==8.14.0",
     "jsonschema[format]",
     "myst_parser==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ strict = [
     "phonopy==2.20.0",
     "pydantic==1.10.9",
     "pymatgen-analysis-defects==2023.7.31",
-    "pymatgen==2023.5.31",
+    "pymatgen==2023.7.20",
     "seekpath==2.1.0",
     "typing-extensions==4.7.1",
 ]

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -888,7 +888,7 @@ def _get_magmoms(
             mag.append(magmoms.get(specie))
         elif hasattr(site, "magmom"):
             mag.append(site.magmom)
-        elif hasattr(site.specie, "spin"):
+        elif hasattr(site.specie, "spin") and site.specie.spin is not None:
             mag.append(site.specie.spin)
         elif specie in config_magmoms:
             if site.specie.symbol == "Co" and config_magmoms[specie] <= 1.0:

--- a/src/atomate2/vasp/sets/defect.py
+++ b/src/atomate2/vasp/sets/defect.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from pymatgen.io.vasp.inputs import Kpoints, Kpoints_supported_modes
+from pymatgen.io.vasp.inputs import Kpoints, KpointsSupportedModes
 
 from atomate2.vasp.sets.base import VaspInputGenerator
 
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 SPECIAL_KPOINT = Kpoints(
     comment="special k-point",
     num_kpts=1,
-    style=Kpoints_supported_modes.Reciprocal,
+    style=KpointsSupportedModes.Reciprocal,
     kpts=((0.25, 0.25, 0.25),),
     kpts_shift=(0, 0, 0),
     kpts_weights=[1],
@@ -25,7 +25,7 @@ SPECIAL_KPOINT = Kpoints(
 SPECIAL_KPOINT_GAMMA = Kpoints(
     comment="special k-point",
     num_kpts=2,
-    style=Kpoints_supported_modes.Reciprocal,
+    style=KpointsSupportedModes.Reciprocal,
     kpts=((0.25, 0.25, 0.25), (0.0, 0.0, 0.0)),
     kpts_shift=(0, 0, 0),
     kpts_weights=[1, 0],

--- a/tests/vasp/test_base.py
+++ b/tests/vasp/test_base.py
@@ -34,3 +34,19 @@ def test_get_magmoms(
         if magmoms is None:
             assert len(warns) == 1
             assert str(warns[0].message).startswith(msg)
+
+
+def test_get_magmoms_with_specie() -> None:
+    # Setting the species to Co2+ and Fe3+ will change the `site.specie` to
+    # `Specie` instead of `Element`.  This will allow us to test the part of
+    # the code that checks for `Specie.spin`.
+    struct = Structure(
+        lattice=Lattice.cubic(3),
+        species=["Co2+", "Fe3+"],
+        coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
+    )
+    site = struct.sites[0]
+    assert not hasattr(site, "magmom")
+    assert struct[0].specie.spin is None
+    out = _get_magmoms(struct)
+    assert out == [0.6, 0.6]

--- a/tests/vasp/test_base.py
+++ b/tests/vasp/test_base.py
@@ -40,6 +40,7 @@ def test_get_magmoms_with_specie() -> None:
     # Setting the species to Co2+ and Fe3+ will change the `site.specie` to
     # `Specie` instead of `Element`.  This will allow us to test the part of
     # the code that checks for `Specie.spin`.
+    # @jmmshn
     struct = Structure(
         lattice=Lattice.cubic(3),
         species=["Co2+", "Fe3+"],


### PR DESCRIPTION
There's a strange interaction between charge-decorated structures and magmoms. 

Charge-decorated structures can `site.species.spin == None` which would lead to a result of `[None, ....]` for the `_get_magmoms` function and then lead to failure when writing the INCAR