### PR TITLE
Use GitHub's `deploy-pages` action to deploy docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,8 +5,15 @@ on:
   push:
     branches: [main]
 
+# set GITHUB_TOKEN permissions to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   build-docs:
+    if: github.repository_owner == 'materialsproject' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:
@@ -31,9 +38,18 @@ jobs:
       - name: Build
         run: sphinx-build docs docs_build
 
-      - name: Deploy
-        if: github.repository_owner == 'materialsproject' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' 
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload build artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: ./docs_build/
+          path: ./docs_build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Closes #454.

## TODO (if any)

Needs a test run to make sure it works.
