### PR TITLE
Small change to `gunzip` to allow better restarting

### DIFF
--- a/src/atomate2/utils/file_client.py
+++ b/src/atomate2/utils/file_client.py
@@ -369,7 +369,7 @@ class FileClient:
         force : bool
             How to handle writing a gzipped file if it already exists. Accepts
             either a string or bool:
-            
+
             - `"force"` or `True`: Overwrite gzipped file if it already exists.
             - `"raise"` or `False`: Raise an error if file already exists.
             - `"skip"` Skip file if it already exists.
@@ -430,7 +430,7 @@ class FileClient:
         force : bool
             How to handle writing a non-gzipped file if it already exists. Accepts
             either a string or bool:
-            
+
             - `"force"` or `True`: Overwrite non-gzipped file if it already exists.
             - `"raise"` or `False`: Raise an error if file already exists.
             - `"skip"` Skip file if it already exists.

--- a/src/atomate2/vasp/files.py
+++ b/src/atomate2/vasp/files.py
@@ -56,7 +56,7 @@ def copy_vasp_outputs(
     force_overwrite : bool or str
         How to handle overwriting existing files during the copy step. Accepts
         either a string or bool:
-            
+
             - `"force"` or `True`: Overwrite existing files if they already exist.
             - `"raise"` or `False`: Raise an error if files already exist.
             - `"skip"` Skip files they already exist.

--- a/src/atomate2/vasp/files.py
+++ b/src/atomate2/vasp/files.py
@@ -29,7 +29,7 @@ def copy_vasp_outputs(
     src_host: str | None = None,
     additional_vasp_files: Sequence[str] = (),
     contcar_to_poscar: bool = True,
-    force_overwrite: bool = False,
+    force_overwrite: bool | str = False,
     file_client: FileClient | None = None,
 ):
     """
@@ -53,8 +53,10 @@ def copy_vasp_outputs(
         Additional files to copy, e.g. ["CHGCAR", "WAVECAR"].
     contcar_to_poscar : bool
         Move CONTCAR to POSCAR (original POSCAR is not copied).
-    force_overwrite : bool
-        If True, overwrite existing files during the copy step.
+    force_overwrite : bool or str
+        If True, overwrite existing files during the copy step. Alternatively, a string
+        can be given to specify "raise" (same as False), "force" (same as True)
+        / or "skip" which will not overwrite existing files and will not raise an error.
     file_client : .FileClient
         A file client to use for performing file operations.
     """

--- a/src/atomate2/vasp/files.py
+++ b/src/atomate2/vasp/files.py
@@ -54,9 +54,12 @@ def copy_vasp_outputs(
     contcar_to_poscar : bool
         Move CONTCAR to POSCAR (original POSCAR is not copied).
     force_overwrite : bool or str
-        If True, overwrite existing files during the copy step. Alternatively, a string
-        can be given to specify "raise" (same as False), "force" (same as True)
-        / or "skip" which will not overwrite existing files and will not raise an error.
+        How to handle overwriting existing files during the copy step. Accepts
+        either a string or bool:
+            
+            - `"force"` or `True`: Overwrite existing files if they already exist.
+            - `"raise"` or `False`: Raise an error if files already exist.
+            - `"skip"` Skip files they already exist.
     file_client : .FileClient
         A file client to use for performing file operations.
     """

--- a/tests/common/test_files.py
+++ b/tests/common/test_files.py
@@ -1,0 +1,30 @@
+def test_gunzip_force_overwrites(tmp_path):
+    from atomate2.common.files import gunzip_files, gzip_files
+
+    files = ["file1", "file2", "file3"]
+    for fname in files:
+        f = tmp_path / fname
+        f.write_text(fname)
+    gzip_files(tmp_path)
+
+    for fname in files:
+        f = tmp_path / fname
+        f.write_text(f"{fname} overwritten")
+    # "file1" in the zipped files and "file1 overwritten" in the unzipped files
+    gunzip_files(tmp_path, force=True)
+
+    for fname in files:
+        f = tmp_path / fname
+        assert f.read_text() == fname
+
+    gzip_files(tmp_path)
+
+    for fname in files:
+        f = tmp_path / fname
+        f.write_text(f"{fname} overwritten")
+
+    # "file1" in the zipped files and "file1 overwritten" in the unzipped files
+    gunzip_files(tmp_path, force="skip")
+    for fname in files:
+        f = tmp_path / fname
+        assert f.read_text() == f"{fname} overwritten"


### PR DESCRIPTION
# Small change to `gunzip` to allow better restarting

Proposed change to make resuming of long-running calculations easier

If we want to resume a calculation
`VaspJob` in `custodian` has an `auto_continue` argument.  This makes sure that `CONTCAR` is copied to `POSCAR` whenever possible.
https://github.com/materialsproject/custodian/blame/26bf28a4b15b1253c955f3f8d6bd427bbc398e3a/custodian/vasp/jobs.py#L209-L229

So setting something like this at job creation or setting it in a restart script/CLI will be useful.
For a given maker:
```python 
BaseVaspMaker.run_vasp_kwargs = {"vasp_job_kwargs" : {"auto_continue" : True}}
```
However, most of the  VASP jobs in `atomate2` will copy from `prev_dir` first and thus overwrite the current state of the directory.  In most cases, this will just error out because `force_overwrite=False` by default.
For proper restarting: the `copy_vasp_files` function should make sure it does not overwrite existing files.
This is currently not possible.  This PR changes the `gunzip` function to accept `force="skip"` as an argument.

