### PR TITLE
fix auto ismear 0 sigma value

### DIFF
--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -668,7 +668,7 @@ class VaspInputGenerator(InputGenerator):
             if bandgap is None:
                 # don't know if we are a metal or insulator so set ISMEAR and SIGMA to
                 # be safe with the most general settings
-                auto_updates.update({"ISMEAR": 0, "SIGMA": 0.2})
+                auto_updates.update({"ISMEAR": 0, "SIGMA": 0.05})
             elif bandgap == 0:
                 auto_updates.update({"ISMEAR": 2, "SIGMA": 0.2})  # metal
             else:


### PR DESCRIPTION
`auto_ismear`, when no previous calc's bandgap is available, sets ISMEAR = 0 (already being done, all is well there). According to the VASP wiki, a SIGMA of 0.03-0.05 should be used in such cases (not being done).

This changes the SIGMA in such cases from 0.2 to 0.05.