### PR TITLE
Fix a crash if `~/.atomate2.yaml` is present but blank

### DIFF
--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -158,5 +158,8 @@ class Atomate2Settings(BaseSettings):
         if Path(config_file_path).expanduser().exists():
             new_values.update(loadfn(Path(config_file_path).expanduser()))
 
+        if not new_values:
+            return {}
+
         new_values.update(values)
         return new_values


### PR DESCRIPTION
If the user has a `~/.atomate2.yaml` file and it's blank, the following error is raised:

```
exit()Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/rosen/software/miniconda/envs/quacc/lib/python3.10/site-packages/atomate2/__init__.py", line 6, in <module>
    SETTINGS = Atomate2Settings()
  File "pydantic/env_settings.py", line 39, in pydantic.env_settings.BaseSettings.__init__
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Atomate2Settings
__root__
  'NoneType' object is not iterable (type=type_error)
```

A blank dictionary should be returned for `new_values` instead of `None`. I'm happy to add a simple test but am going to need a day or so (apologies! ping me if I forget!).

Note: It's possible the same change may need to be made in Jobflow.