### PR TITLE
Enforce magmom precedence in INCAR creation

### DIFF
--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -627,7 +627,9 @@ class VaspInputGenerator(InputGenerator):
         for k, v in incar_settings.items():
             if k == "MAGMOM":
                 incar[k] = _get_magmoms(
-                    structure, config_magmoms=config_magmoms, magmoms=v
+                    structure,
+                    magmoms=self.user_incar_settings.get("MAGMOMS", {}),
+                    config_magmoms=config_magmoms,
                 )
             elif k in ("LDAUU", "LDAUJ", "LDAUL") and incar_settings.get("LDAU", False):
                 incar[k] = _get_u_param(k, v, structure)

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -30,7 +30,7 @@ def struct_with_spin() -> Structure:
 
 @pytest.fixture(scope="module")
 def struct_with_magmoms(struct_no_magmoms) -> Structure:
-    """Dummy FeO structure with magnetic moments defined."""
+    """Dummy FeO structure with magmoms defined."""
     struct = struct_no_magmoms.copy()
     struct.add_site_property("magmom", [4.7, 0.0])
     return struct
@@ -86,7 +86,7 @@ def test_user_incar_settings():
         ("struct_with_spin", {"MAGMOM": [3.7, 0.8]}),
     ],
 )
-def test_incar_magmoms_precedence(structure, user_incar_settings, request):
+def test_incar_magmoms_precedence(structure, user_incar_settings, request) -> None:
     """
     According to VaspInputGenerator._get_magmoms, the magmoms for a new input set are
     determined given the following precedence:
@@ -97,9 +97,8 @@ def test_incar_magmoms_precedence(structure, user_incar_settings, request):
     4. job config dict
     5. set all magmoms to 0.6
 
-    Here, we use the StaticSetGenerator as an example,
-    but any input generator that has an implemented get_incar_updates() method could be
-    used.
+    Here, we use the StaticSetGenerator as an example, but any input generator that has
+    an implemented get_incar_updates() method could be used.
     """
     structure = request.getfixturevalue(structure)
 

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -20,12 +20,11 @@ def struct_with_spin() -> Structure:
     fe = Species("Fe2+", spin=4)
     o = Species("O2-", spin=0.63)
 
-    struct = Structure(
+    return Structure(
         lattice=Lattice.cubic(3),
         species=[fe, o],
         coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
     )
-    return struct
 
 
 @pytest.fixture(scope="module")

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -1,6 +1,39 @@
-from pymatgen.core import Structure
+import pytest
+from pymatgen.core import Lattice, Species, Structure
 
 from atomate2.vasp.sets.core import StaticSetGenerator
+
+
+@pytest.fixture(scope="module")
+def struct_no_magmoms() -> Structure:
+    """Dummy FeO structure with no magnetic moments defined."""
+    return Structure(
+        lattice=Lattice.cubic(3),
+        species=["Fe", "O"],
+        coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
+    )
+
+
+@pytest.fixture(scope="module")
+def struct_with_spin() -> Structure:
+    """Dummy FeO structure with spins defined."""
+    fe = Species("Fe2+", spin=4)
+    o = Species("O2-", spin=0.63)
+
+    struct = Structure(
+        lattice=Lattice.cubic(3),
+        species=[fe, o],
+        coords=[[0, 0, 0], [0.5, 0.5, 0.5]],
+    )
+    return struct
+
+
+@pytest.fixture(scope="module")
+def struct_with_magmoms(struct_no_magmoms) -> Structure:
+    """Dummy FeO structure with magnetic moments defined."""
+    struct = struct_no_magmoms.copy()
+    struct.add_site_property("magmom", [4.7, 0.0])
+    return struct
 
 
 def test_user_incar_settings():
@@ -40,3 +73,51 @@ def test_user_incar_settings():
             assert incar[key].lower() == uis[key].lower()
         else:
             assert incar[key] == uis[key]
+
+
+@pytest.mark.parametrize(
+    "structure,user_incar_settings",
+    [
+        ("struct_no_magmoms", {}),
+        ("struct_with_magmoms", {}),
+        ("struct_with_spin", {}),
+        ("struct_no_magmoms", {"MAGMOM": [3.7, 0.8]}),
+        ("struct_with_magmoms", {"MAGMOM": [3.7, 0.8]}),
+        ("struct_with_spin", {"MAGMOM": [3.7, 0.8]}),
+    ],
+)
+def test_incar_magmoms_precedence(structure, user_incar_settings, request):
+    """
+    According to VaspInputGenerator._get_magmoms, the magmoms for a new input set are
+    determined given the following precedence:
+
+    1. user incar settings
+    2. magmoms in input struct
+    3. spins in input struct
+    4. job config dict
+    5. set all magmoms to 0.6
+
+    Here, we use the StaticSetGenerator as an example,
+    but any input generator that has an implemented get_incar_updates() method could be
+    used.
+    """
+    structure = request.getfixturevalue(structure)
+
+    input_gen = StaticSetGenerator(user_incar_settings=user_incar_settings)
+    incar = input_gen.get_input_set(structure, potcar_spec=True).incar
+    incar_magmom = incar["MAGMOM"]
+
+    has_struct_magmom = structure.site_properties.get("magmom")
+    has_struct_spin = getattr(structure.species[0], "spin", None) is not None
+
+    if user_incar_settings:  # case 1
+        assert incar_magmom == user_incar_settings["MAGMOM"]
+    elif has_struct_magmom:  # case 2
+        assert incar_magmom == structure.site_properties["magmom"]
+    elif has_struct_spin:  # case 3
+        assert incar_magmom == [s.spin for s in structure.species]
+    else:  # case 4 and 5
+        assert incar_magmom == [
+            input_gen.config_dict["INCAR"]["MAGMOM"].get(str(s), 0.6)
+            for s in structure.species
+        ]


### PR DESCRIPTION
## Summary

* Fixes issue in #505. Incar MAGMOM setting precedence now follows prescribed order.
* Adds test for `StaticSetGenerator` to catch this (method is in base class so should apply to other generators)

## TODO (if any)

* [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [black](https://black.readthedocs.io/en/stable/index.html) on your new code. This will
  automatically reformat your code to PEP8 conventions and removes most issues. Then run
  [ruff](https://ruff.rs).
* [x] Docstrings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [x] All linting and tests pass.
