### PR TITLE
CP2K use `calcs_reversed[0]` instead of `calcs_reversed[-1]` to not reverse again

### DIFF
--- a/src/atomate2/cp2k/schemas/task.py
+++ b/src/atomate2/cp2k/schemas/task.py
@@ -391,7 +391,6 @@ class TaskDocument(StructureMetadata, MoleculeMetadata):
             }
 
         doc = getattr(cls, attr)(**dat)
-        ddict = doc.dict()
         data = {
             "structure": calcs_reversed[0].output.structure,
             "meta_structure": calcs_reversed[0].output.structure,
@@ -414,7 +413,7 @@ class TaskDocument(StructureMetadata, MoleculeMetadata):
             "cp2k_objects": cp2k_objects,
             "included_objects": included_objects,
         }
-        doc = cls(**ddict)
+        doc = cls(**doc.dict())
         doc = doc.copy(update=data)
         return doc.copy(update=additional_fields)
 

--- a/src/atomate2/cp2k/schemas/task.py
+++ b/src/atomate2/cp2k/schemas/task.py
@@ -374,27 +374,27 @@ class TaskDocument(StructureMetadata, MoleculeMetadata):
         if cp2k_objects:
             included_objects = list(cp2k_objects)
 
-        if isinstance(calcs_reversed[-1].output.structure, Structure):
+        if isinstance(calcs_reversed[0].output.structure, Structure):
             attr = "from_structure"
             dat = {
-                "structure": calcs_reversed[-1].output.structure,
-                "meta_structure": calcs_reversed[-1].output.structure,
+                "structure": calcs_reversed[0].output.structure,
+                "meta_structure": calcs_reversed[0].output.structure,
                 "include_structure": True,
             }
-        elif isinstance(calcs_reversed[-1].output.structure, Molecule):
+        elif isinstance(calcs_reversed[0].output.structure, Molecule):
             attr = "from_molecule"
             dat = {
-                "structure": calcs_reversed[-1].output.structure,
-                "meta_structure": calcs_reversed[-1].output.structure,
-                "molecule": calcs_reversed[-1].output.structure,
+                "structure": calcs_reversed[0].output.structure,
+                "meta_structure": calcs_reversed[0].output.structure,
+                "molecule": calcs_reversed[0].output.structure,
                 "include_molecule": True,
             }
 
         doc = getattr(cls, attr)(**dat)
         ddict = doc.dict()
         data = {
-            "structure": calcs_reversed[-1].output.structure,
-            "meta_structure": calcs_reversed[-1].output.structure,
+            "structure": calcs_reversed[0].output.structure,
+            "meta_structure": calcs_reversed[0].output.structure,
             "dir_name": dir_name,
             "calcs_reversed": calcs_reversed,
             "analysis": analysis,
@@ -405,9 +405,9 @@ class TaskDocument(StructureMetadata, MoleculeMetadata):
             "icsd_id": icsd_id,
             "tags": tags,
             "author": author,
-            "completed_at": calcs_reversed[-1].completed_at,
+            "completed_at": calcs_reversed[0].completed_at,
             "input": InputSummary.from_cp2k_calc_doc(calcs_reversed[0]),
-            "output": OutputSummary.from_cp2k_calc_doc(calcs_reversed[-1]),
+            "output": OutputSummary.from_cp2k_calc_doc(calcs_reversed[0]),
             "state": _get_state(calcs_reversed, analysis),
             "entry": cls.get_entry(calcs_reversed),
             "run_stats": _get_run_stats(calcs_reversed),

--- a/src/atomate2/forcefields/jobs.py
+++ b/src/atomate2/forcefields/jobs.py
@@ -41,7 +41,7 @@ class ForceFieldRelaxMaker(Maker):
     name : str
         The job name.
     force_field_name : str
-        The name of the forcefield.
+        The name of the force field.
     relax_cell : bool
         Whether to allow the cell shape/volume to change during relaxation.
     steps : int
@@ -65,7 +65,7 @@ class ForceFieldRelaxMaker(Maker):
     @job(output_schema=ForceFieldTaskDocument)
     def make(self, structure: Structure):
         """
-        Perform a relaxation of a structure using a forcefield.
+        Perform a relaxation of a structure using a force field.
 
         Parameters
         ----------
@@ -116,7 +116,7 @@ class ForceFieldStaticMaker(ForceFieldRelaxMaker):
     @job(output_schema=ForceFieldTaskDocument)
     def make(self, structure: Structure):
         """
-        Perform a static evaluation using a forcefield.
+        Perform a static evaluation using a force field.
 
         Parameters
         ----------
@@ -153,7 +153,7 @@ class CHGNetRelaxMaker(ForceFieldRelaxMaker):
     Parameters
     ----------
     force_field_name : str
-        The name of the forcefield.
+        The name of the force field.
     relax_cell : bool
         Whether to allow the cell shape/volume to change during relaxation.
     steps : int
@@ -217,7 +217,7 @@ class M3GNetRelaxMaker(ForceFieldRelaxMaker):
     name : str
         The job name.
     force_field_name : str
-        The name of the forcefield.
+        The name of the force field.
     relax_cell : bool
         Whether to allow the cell shape/volume to change during relaxation.
     steps : int
@@ -269,7 +269,7 @@ class M3GNetStaticMaker(ForceFieldStaticMaker):
     name : str
         The job name.
     force_field_name : str
-        The name of the forcefield.
+        The name of the force field.
     task_document_kwargs : dict
         Additional keyword args passed to :obj:`.ForceFieldTaskDocument()`.
     """
@@ -307,7 +307,7 @@ class GAPRelaxMaker(ForceFieldRelaxMaker):
     name : str
         The job name.
     force_field_name : str
-        The name of the forcefield.
+        The name of the force field.
     relax_cell : bool
         Whether to allow the cell shape/volume to change during relaxation.
     steps : int
@@ -359,7 +359,7 @@ class GAPStaticMaker(ForceFieldStaticMaker):
     name : str
         The job name.
     force_field_name : str
-        The name of the forcefield.
+        The name of the force field.
     task_document_kwargs : dict
         Additional keyword args passed to :obj:`.ForceFieldTaskDocument()`.
     potential_args_str: str

--- a/src/atomate2/forcefields/schemas.py
+++ b/src/atomate2/forcefields/schemas.py
@@ -117,7 +117,7 @@ class ForceFieldTaskDocument(StructureMetadata):
         Parameters
         ----------
         forcefield_name : str
-            Name of the forcefield used.
+            Name of the force field used.
         result : dict
             The outputted results from the task.
         relax_cell : bool

--- a/tests/cp2k/jobs/test_core.py
+++ b/tests/cp2k/jobs/test_core.py
@@ -68,6 +68,9 @@ def test_relax_maker(tmp_path, mock_cp2k, basis_and_potential, si_structure):
     assert isinstance(output1, TaskDocument)
     assert output1.output.energy == approx(-193.39161102270234)
     assert len(output1.calcs_reversed[0].output.ionic_steps) == 1
+    assert output1.calcs_reversed[0].output.structure.lattice.abc == approx(
+        si_structure.lattice.abc
+    )
 
 
 def test_transmuter(tmp_path, mock_cp2k, basis_and_potential, si_structure):


### PR DESCRIPTION
Closes #533.