### PR TITLE
Clean up VASP powerups, correct params in MP flows, test for `_set_u_params`, test for `_set_kspacing`, fix `_get_incar` method of `VaspInputSet`

### DIFF
--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -312,6 +312,8 @@ class VaspInputGenerator(InputGenerator):
     force_gamma: bool = True
     symprec: float = SETTINGS.SYMPREC
     vdw: str = None
+    # copy _BASE_VASP_SET to ensure each class instance has its own copy
+    # otherwise in-place changes can affect other instances
     config_dict: dict = field(default_factory=lambda: _BASE_VASP_SET)
     inherit_incar: bool = None
 

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -692,6 +692,7 @@ class VaspInputGenerator(InputGenerator):
         elif isinstance(self.auto_kspacing, float):
             # interpret auto_kspacing as bandgap and set KSPACING based on user input
             bandgap = self.auto_kspacing
+
         _set_kspacing(incar, incar_settings, self.user_incar_settings, bandgap, kpoints)
 
         # apply updates from auto options, careful not to override user_incar_settings
@@ -1112,7 +1113,8 @@ def _set_kspacing(
 
     elif "KSPACING" in user_incar_settings:
         incar["KSPACING"] = user_incar_settings["KSPACING"]
-    elif incar_settings.get("KSPACING") and isinstance(bandgap, float):
+
+    elif incar_settings.get("KSPACING") and isinstance(bandgap, (int, float)):
         # will always default to 0.22 in first run as one
         # cannot be sure if one treats a metal or
         # semiconductor/insulator
@@ -1120,6 +1122,7 @@ def _set_kspacing(
         # This should default to ISMEAR=0 if band gap is not known (first computation)
         # if not from_prev:
         #     # be careful to not override user_incar_settings
+
     elif incar_settings.get("KSPACING"):
         incar["KSPACING"] = incar_settings["KSPACING"]
 

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -1079,7 +1079,7 @@ def _get_kspacing(bandgap: float, tol: float = 1e-4) -> float:
     kspacing = 2 * np.pi * 1.0265 / (rmin - 1.0183)  # Eq. 29
 
     # cap kspacing at a max of 0.44, per internal benchmarking
-    return kspacing if 0.22 < kspacing < 0.44 else 0.44
+    return min(kspacing, 0.44)
 
 
 def _set_kspacing(

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -165,3 +165,61 @@ def test_set_u_params(structure, request) -> None:
         # if no sites have a nonzero U value in the config_dict,
         # ensure that no keys starting with LDAU are in the INCAR
         assert len([key for key in incar if key.startswith("LDAU")]) == 0
+
+
+@pytest.mark.parametrize(
+    "structure, bandgap, expected_params",
+    [
+        (
+            "struct_no_magmoms",
+            0,
+            {"KSPACING": 0.22, "ISMEAR": 2, "SIGMA": 0.2},
+        ),
+        (
+            "struct_no_magmoms",
+            0.1,
+            {"KSPACING": 0.2697, "ISMEAR": 0, "SIGMA": 0.05},
+        ),
+        (
+            "struct_no_magmoms",
+            1,
+            {"KSPACING": 0.30235, "ISMEAR": 0, "SIGMA": 0.05},
+        ),
+        (
+            "struct_no_magmoms",
+            2,
+            {"KSPACING": 0.34936, "ISMEAR": 0, "SIGMA": 0.05},
+        ),
+        (
+            "struct_no_magmoms",
+            5,
+            {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05},
+        ),
+        (
+            "struct_no_magmoms",
+            10,
+            {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05},
+        ),
+    ],
+)
+def test_set_kspacing(structure, bandgap, expected_params, request):
+    keys_to_check = {"KSPACING", "ISMEAR", "SIGMA"}
+    tol = 1.0e-5
+
+    structure = request.getfixturevalue(structure)
+
+    static_set = StaticSetGenerator(auto_ismear=False)
+    static_set.config_dict["INCAR"][
+        "KSPACING"
+    ] = 0.1  # need to indicate to atomate2 to use KSPACING
+
+    incar = static_set._get_incar(
+        structure=structure,
+        kpoints=None,
+        previous_incar=None,
+        incar_updates={},
+        bandgap=bandgap,
+    )
+    assert all(
+        abs(incar.get(key, None) - expected_params[key] < tol) for key in keys_to_check
+    )

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -131,13 +131,7 @@ def test_incar_magmoms_precedence(structure, user_incar_settings, request) -> No
         ]
 
 
-@pytest.mark.parametrize(
-    "structure",
-    [
-        "struct_no_magmoms",
-        "struct_no_u_params",
-    ],
-)
+@pytest.mark.parametrize("structure", ["struct_no_magmoms", "struct_no_u_params"])
 def test_set_u_params(structure, request) -> None:
     structure = request.getfixturevalue(structure)
     input_gen = StaticSetGenerator()
@@ -171,17 +165,17 @@ def test_set_u_params(structure, request) -> None:
     "bandgap, expected_params",
     [
         (0, {"KSPACING": 0.22, "ISMEAR": 2, "SIGMA": 0.2}),
-        (0.1, {"KSPACING": 0.269695615, "ISMEAR": 0, "SIGMA": 0.05}),
-        (1, {"KSPACING": 0.302352354, "ISMEAR": 0, "SIGMA": 0.05}),
-        (2, {"KSPACING": 0.349355136, "ISMEAR": 0, "SIGMA": 0.05}),
-        (5, {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05}),
-        (10, {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05}),
+        (0.1, {"KSPACING": 0.269695615, "ISMEAR": -5, "SIGMA": 0.05}),
+        (1, {"KSPACING": 0.302352354, "ISMEAR": -5, "SIGMA": 0.05}),
+        (2, {"KSPACING": 0.349355136, "ISMEAR": -5, "SIGMA": 0.05}),
+        (5, {"KSPACING": 0.44, "ISMEAR": -5, "SIGMA": 0.05}),
+        (10, {"KSPACING": 0.44, "ISMEAR": -5, "SIGMA": 0.05}),
     ],
 )
-def test_set_kspacing(struct_no_magmoms, bandgap, expected_params):
-    static_set = StaticSetGenerator(auto_ismear=False)
+def test_set_kspacing_and_auto_ismear(struct_no_magmoms, bandgap, expected_params):
+    static_set = StaticSetGenerator(auto_ismear=True, auto_kspacing=True)
     # need to indicate to atomate2 to use KSPACING instead of KPOINTS
-    static_set.config_dict["INCAR"]["KSPACING"] = 0.1
+    static_set.config_dict["INCAR"]["KSPACING"] = 42  # dummy value
 
     incar = static_set._get_incar(
         structure=struct_no_magmoms,

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -171,9 +171,9 @@ def test_set_u_params(structure, request) -> None:
     "bandgap, expected_params",
     [
         (0, {"KSPACING": 0.22, "ISMEAR": 2, "SIGMA": 0.2}),
-        (0.1, {"KSPACING": 0.2697, "ISMEAR": 0, "SIGMA": 0.05}),
-        (1, {"KSPACING": 0.30235, "ISMEAR": 0, "SIGMA": 0.05}),
-        (2, {"KSPACING": 0.34936, "ISMEAR": 0, "SIGMA": 0.05}),
+        (0.1, {"KSPACING": 0.269695615, "ISMEAR": 0, "SIGMA": 0.05}),
+        (1, {"KSPACING": 0.302352354, "ISMEAR": 0, "SIGMA": 0.05}),
+        (2, {"KSPACING": 0.349355136, "ISMEAR": 0, "SIGMA": 0.05}),
         (5, {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05}),
         (10, {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05}),
     ],

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -2,6 +2,7 @@ import pytest
 from pymatgen.core import Lattice, Species, Structure
 
 from atomate2.vasp.sets.core import StaticSetGenerator
+from atomate2.vasp.sets.mp import MPMetaGGARelaxSetGenerator
 
 
 @pytest.fixture(scope="module")
@@ -172,10 +173,10 @@ def test_set_u_params(structure, request) -> None:
         (10, {"KSPACING": 0.44, "ISMEAR": -5, "SIGMA": 0.05}),
     ],
 )
-def test_set_kspacing_and_auto_ismear(struct_no_magmoms, bandgap, expected_params):
-    static_set = StaticSetGenerator(auto_ismear=True, auto_kspacing=True)
-    # need to indicate to atomate2 to use KSPACING instead of KPOINTS
-    static_set.config_dict["INCAR"]["KSPACING"] = 42  # dummy value
+def test_set_kspacing_and_auto_ismear(
+    struct_no_magmoms, bandgap, expected_params, monkeypatch
+):
+    static_set = MPMetaGGARelaxSetGenerator(auto_ismear=True, auto_kspacing=True)
 
     incar = static_set._get_incar(
         structure=struct_no_magmoms,

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -168,58 +168,28 @@ def test_set_u_params(structure, request) -> None:
 
 
 @pytest.mark.parametrize(
-    "structure, bandgap, expected_params",
+    "bandgap, expected_params",
     [
-        (
-            "struct_no_magmoms",
-            0,
-            {"KSPACING": 0.22, "ISMEAR": 2, "SIGMA": 0.2},
-        ),
-        (
-            "struct_no_magmoms",
-            0.1,
-            {"KSPACING": 0.2697, "ISMEAR": 0, "SIGMA": 0.05},
-        ),
-        (
-            "struct_no_magmoms",
-            1,
-            {"KSPACING": 0.30235, "ISMEAR": 0, "SIGMA": 0.05},
-        ),
-        (
-            "struct_no_magmoms",
-            2,
-            {"KSPACING": 0.34936, "ISMEAR": 0, "SIGMA": 0.05},
-        ),
-        (
-            "struct_no_magmoms",
-            5,
-            {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05},
-        ),
-        (
-            "struct_no_magmoms",
-            10,
-            {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05},
-        ),
+        (0, {"KSPACING": 0.22, "ISMEAR": 2, "SIGMA": 0.2}),
+        (0.1, {"KSPACING": 0.2697, "ISMEAR": 0, "SIGMA": 0.05}),
+        (1, {"KSPACING": 0.30235, "ISMEAR": 0, "SIGMA": 0.05}),
+        (2, {"KSPACING": 0.34936, "ISMEAR": 0, "SIGMA": 0.05}),
+        (5, {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05}),
+        (10, {"KSPACING": 0.44, "ISMEAR": 0, "SIGMA": 0.05}),
     ],
 )
-def test_set_kspacing(structure, bandgap, expected_params, request):
-    keys_to_check = {"KSPACING", "ISMEAR", "SIGMA"}
-    tol = 1.0e-5
-
-    structure = request.getfixturevalue(structure)
-
+def test_set_kspacing(struct_no_magmoms, bandgap, expected_params):
     static_set = StaticSetGenerator(auto_ismear=False)
-    static_set.config_dict["INCAR"][
-        "KSPACING"
-    ] = 0.1  # need to indicate to atomate2 to use KSPACING
+    # need to indicate to atomate2 to use KSPACING instead of KPOINTS
+    static_set.config_dict["INCAR"]["KSPACING"] = 0.1
 
     incar = static_set._get_incar(
-        structure=structure,
+        structure=struct_no_magmoms,
         kpoints=None,
         previous_incar=None,
         incar_updates={},
         bandgap=bandgap,
     )
-    assert all(
-        abs(incar.get(key, None) - expected_params[key] < tol) for key in keys_to_check
-    )
+
+    actual = {key: incar[key] for key in expected_params}
+    assert actual == pytest.approx(expected_params)


### PR DESCRIPTION
Closes #465.

## Summary

A few key changes:
- Added new function, `update_vasp_input_generators` to `vasp.powerups` to remove repeated code. All subsequent functions, such as `update_user_incar_settings` now rely on this base function
- Fixed broken logic in `VaspInputGenerator._get_incar`: in `_get_incar`, `_set_kspacing` was called with `previous_incar is None` which is never true, because `previous_incar = previous_incar or {}` at the top of `_get_incar`. More, this would imply that no previous incar was found, which means `from_prev` in `_set_kspacing` was its inverse. Should be `previous_incar != {}` to indicate the presence of a previous calc
- After some discussion with @Andrew-S-Rosen , we noticed that `vasp.sets.base._get_kspacing` should return `min(kspacing, 0.44)`, to ensure that if kspacing <= 0.22, it would not be increased to 0.44
- Also from discussion with @Andrew-S-Rosen , `vasp.sets.base._set_kspacing` should default to Gaussian smearing (ISMEAR = 0) rather than tetrahedron (ISMEAR = -5) for a gapped material. While the forces should be consistent between these smearing methods for an insulator, my benchmarking has shown they can differ for semi-metals / narrow gapped systems. Gaussian is probably a safer choice overall
- Added a unit test `test_set_u_params` to `tests.vasp.test_sets` to close issue [#465](https://github.com/materialsproject/atomate2/issues/465)
- Added a unit test `test_set_kspacing` to `tests.vasp.test_sets`