### PR TITLE
skip validate charge test

### DIFF
--- a/src/atomate2/common/flows/defect.py
+++ b/src/atomate2/common/flows/defect.py
@@ -200,10 +200,10 @@ class FormationEnergyMaker(Maker, ABC):
         with `relax_radius`.
 
     validate_charge: bool
-        Whether to validate the charge of the defect. If True, the charge of the
-        output structure will have to match the charge of the input defect. This
-        help catch situations where the charge of the output defect is either
-        improperly set of improperly parsed before the data is stored in the
+        Whether to validate the charge of the defect. If True (default), the charge
+        of the output structure will have to match the charge of the input defect.
+        This helps catch situations where the charge of the output defect is either
+        improperly set or improperly parsed before the data is stored in the
         database.
 
     collect_defect_entry_data: bool

--- a/src/atomate2/common/flows/defect.py
+++ b/src/atomate2/common/flows/defect.py
@@ -199,6 +199,13 @@ class FormationEnergyMaker(Maker, ABC):
         sites with selective dynamics set to True. So this setting only works
         with `relax_radius`.
 
+    validate_charge: bool
+        Whether to validate the charge of the defect. If True, the charge of the
+        output structure will have to match the charge of the input defect. This
+        help catch situations where the charge of the output defect is either
+        improperly set of improperly parsed before the data is stored in the
+        database.
+
     collect_defect_entry_data: bool
         Whether to collect the defect entry data at the end of the flow.
         If True, the output of all the charge states for each symmetry distinct
@@ -241,6 +248,7 @@ class FormationEnergyMaker(Maker, ABC):
     name: str = "formation energy"
     relax_radius: float | str | None = None
     perturb: float | None = None
+    validate_charge: bool = True
     collect_defect_entry_data: bool = False
 
     def __post_init__(self):
@@ -316,6 +324,7 @@ class FormationEnergyMaker(Maker, ABC):
             },
             relax_radius=self.relax_radius,
             perturb=self.perturb,
+            validate_charge=self.validate_charge,
         )
         jobs.extend([get_sc_job, spawn_output])
 

--- a/src/atomate2/common/jobs/defect.py
+++ b/src/atomate2/common/jobs/defect.py
@@ -408,10 +408,10 @@ def check_charge_state(charge_state: int, task_structure: Structure) -> Response
 @job
 def get_defect_entry(charge_state_summary: dict, bulk_summary: dict):
     """Get a defect entry from a defect calculation and a bulk calculation."""
-    bulk_c_entry = bulk_summary["sc_entry"]
+    bulk_sc_entry = bulk_summary["sc_entry"]
     bulk_struct_entry = ComputedStructureEntry(
         structure=bulk_summary["sc_struct"],
-        energy=bulk_c_entry.energy,
+        energy=bulk_sc_entry.energy,
     )
     bulk_dir_name = bulk_summary["dir_name"]
     bulk_locpot = bulk_summary["locpot_plnr"]

--- a/tests/vasp/flows/test_defect.py
+++ b/tests/vasp/flows/test_defect.py
@@ -166,7 +166,10 @@ def test_formation_energy_maker(mock_vasp, clean_dir, test_dir, monkeypatch):
 
     # rmaker = RelaxMaker(input_set_generator=ChargeStateRelaxSetGenerator())
     maker = FormationEnergyMaker(
-        relax_radius="auto", perturb=0.1, collect_defect_entry_data=True
+        relax_radius="auto",
+        perturb=0.1,
+        collect_defect_entry_data=True,
+        validate_charge=False,
     )
     flow = maker.make(
         defects[0],


### PR DESCRIPTION
## Fixing defect tests
For #548 

Looks like the pydanctic2 PR is blocked by the defect formation energy test.

This fixes one of the problems:
- The defect charge state sanity check requires the POTCAR data but we only have POTCAR spec so we cannot assign charge automatically.  Prior versions of atomate2 did not give a CI failure for this.  The particular job to check the charge state still failled but the CI is able to pass. 

But there seems to be a second problem that I'm not sure about:
- The`bulk_summary["sc_entry"]` which comes directly from TaskDoc of the relaxation job now gives `None`
Other fields for `bulk_summary` seems to be OK. 

```python
    relax_output: TaskDoc = relax_job.output
    summary_d = {
        "uc_structure": uc_structure,
        "sc_entry": relax_output.entry,
        "sc_struct": relax_output.structure,
```
This creates the remaining error in the CI.  The strange thing here is that `relax_output.structure` is properly parsed but `relax_output.entry` is `None`.
