### PR TITLE
Add Alex Bonkowski to contributors list

### DIFF
--- a/docs/about/contributors.md
+++ b/docs/about/contributors.md
@@ -102,3 +102,10 @@ University of Arizona
 
 [tpurcell90]: https://github.com/tpurcell90
 [0000-0003-4564-7206]: https://orcid.org/0000-0003-4564-7206
+
+**Alexander Bonkowski** [![gh]][ab5424] [![orc]][0000-0002-0525-4742] \
+PhD student in Chemistry \
+RWTH Aachen University
+
+[ab5424]: https://github.com/ab5424
+[0000-0002-0525-4742]: https://orcid.org/0000-0002-0525-4742


### PR DESCRIPTION
## Summary

As mentioned in https://github.com/materialsproject/atomate2/pull/137, Alexander Bonkowski (@ab5424) has contributed to the phonon workflow in atomate2. I based the implementation in atomate2 partially on work from his Master thesis. Therefore, I would like to add him to the list of contributors of atomate2.