### PR TITLE
Use `numpy.testing.assert_allclose` over assert `np.(all|is)close`

### DIFF
--- a/src/atomate2/cli/dev.py
+++ b/src/atomate2/cli/dev.py
@@ -143,13 +143,12 @@ def test_my_flow(mock_vasp, clean_dir, si_structure):
     # automatically use fake VASP and write POTCAR.spec during the test
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # !!! Generate job
     job = MyMaker().make(si_structure)
 
     # run the flow or job and ensure that it finished running successfully
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
-    # !!! validation on the outputs
+    # validate the outputs
     output1 = responses[job.uuid][1].output
     assert isinstance(output1, TaskDoc)
     assert output1.output.energy == pytest.approx(-10.85037078)

--- a/src/atomate2/cp2k/schemas/calc_types/utils.py
+++ b/src/atomate2/cp2k/schemas/calc_types/utils.py
@@ -103,7 +103,7 @@ def task_type(inputs: dict) -> TaskType:
     elif cp2k_run_type.upper() in ["GEO_OPT", "GEOMETRY_OPTIMIZATION", "CELL_OPT"]:
         calc_type.append("Structure Optimization")
 
-    elif cp2k_run_type.upper() in ["BAND"]:
+    elif cp2k_run_type.upper() == "BAND":
         calc_type.append("Band")
 
     elif cp2k_run_type.upper() in ["MOLECULAR_DYNAMICS", "MD"]:
@@ -121,7 +121,7 @@ def task_type(inputs: dict) -> TaskType:
     elif cp2k_run_type.upper() in ["ELECTRONIC_SPECTRA", "SPECTRA"]:
         calc_type.append("Electronic Spectra")
 
-    elif cp2k_run_type.upper() in ["NEGF"]:
+    elif cp2k_run_type.upper() == "NEGF":
         calc_type.append("Non-equilibrium Green's Function")
 
     elif cp2k_run_type.upper() in ["PINT", "DRIVER"]:
@@ -130,13 +130,13 @@ def task_type(inputs: dict) -> TaskType:
     elif cp2k_run_type.upper() in ["RT_PROPAGATION", "EHRENFEST_DYN"]:
         calc_type.append("Real-time propagation")
 
-    elif cp2k_run_type.upper() in ["BSSE"]:
+    elif cp2k_run_type.upper() == "BSSE":
         calc_type.append("Base set superposition error")
 
-    elif cp2k_run_type.upper() in ["DEBUG"]:
+    elif cp2k_run_type.upper() == "DEBUG":
         calc_type.append("Debug analysis")
 
-    elif cp2k_run_type.upper() in ["NONE"]:
+    elif cp2k_run_type.upper() == "NONE":
         calc_type.append("None")
 
     return TaskType(" ".join(calc_type))

--- a/tests/forcefields/flows/test_phonon.py
+++ b/tests/forcefields/flows/test_phonon.py
@@ -21,7 +21,6 @@ def test_phonon_wf(clean_dir):
         coords=[[0, 0, 0], [0.25, 0.25, 0.25]],
     )
 
-    # !!! Generate job
     job = PhononMaker(
         use_symmetrized_structure="conventional",
         create_thermal_displacements=False,
@@ -33,7 +32,7 @@ def test_phonon_wf(clean_dir):
     # run the flow or job and ensure that it finished running successfully
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
-    # !!! validation on the outputs
+    # validate the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
     assert_allclose(

--- a/tests/forcefields/flows/test_phonon.py
+++ b/tests/forcefields/flows/test_phonon.py
@@ -1,4 +1,4 @@
-import numpy as np
+from numpy.testing import assert_allclose
 from pymatgen.core.structure import Structure
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.dos import PhononDos
@@ -36,19 +36,10 @@ def test_phonon_wf(clean_dir):
     # !!! validation on the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
-    assert np.allclose(
-        np.array(responses[job.jobs[-1].uuid][1].output.free_energies) / 1000.0,
-        np.array(
-            [
-                5058.45217527524,
-                4907.495751683517,
-                3966.5493299635937,
-                2157.8178928940474,
-                -357.5054580420707,
-            ]
-        )
-        / 1000.0,
-        2,
+    assert_allclose(
+        responses[job.jobs[-1].uuid][1].output.free_energies,
+        [5058.4521752, 4907.4957516, 3966.5493299, 2157.8178928, -357.5054580],
+        rtol=0.08,
     )
 
     assert isinstance(
@@ -58,28 +49,25 @@ def test_phonon_wf(clean_dir):
     assert isinstance(responses[job.jobs[-1].uuid][1].output.phonon_dos, PhononDos)
     assert responses[job.jobs[-1].uuid][1].output.thermal_displacement_data is None
     assert isinstance(responses[job.jobs[-1].uuid][1].output.structure, Structure)
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.temperatures, [0, 100, 200, 300, 400]
     )
     assert responses[job.jobs[-1].uuid][1].output.force_constants is None
     assert isinstance(responses[job.jobs[-1].uuid][1].output.jobdirs, PhononJobDirs)
     assert isinstance(responses[job.jobs[-1].uuid][1].output.uuids, PhononUUIDs)
-    assert np.isclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.total_dft_energy, -5.372457981109619, 4
     )
     assert responses[job.jobs[-1].uuid][1].output.born is None
     assert responses[job.jobs[-1].uuid][1].output.epsilon_static is None
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.supercell_matrix,
         [[4.0, 0.0, 0.0], [0.0, 4.0, 0.0], [0.0, 0.0, 4.0]],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.primitive_matrix,
-        (
-            (0, 0.5000000000000001, 0.5000000000000001),
-            (0.5000000000000001, 0.0, 0.5000000000000001),
-            (0.5000000000000001, 0.5000000000000001, 0.0),
-        ),
+        ((0, 0.5, 0.5), (0.5, 0.0, 0.5), (0.5, 0.5, 0.0)),
+        atol=1e-8,
     )
     assert responses[job.jobs[-1].uuid][1].output.code == "vasp"
     assert isinstance(
@@ -95,40 +83,19 @@ def test_phonon_wf(clean_dir):
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
         == 7000
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
-        [
-            0.0,
-            4.783939817386235,
-            13.993186953791708,
-            21.88641334781562,
-            28.19110667148253,
-        ],
-        3,
+        [0.0, 4.7839398173, 13.993186953, 21.886413347, 28.191106671],
+        rtol=0.05,
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
-        [
-            0.0,
-            8.860605865667427,
-            17.55758943495313,
-            21.089039169564796,
-            22.625872713428905,
-        ],
-        3,
+        [0.0, 8.8606058656, 17.557589434, 21.089039169, 22.625872713],
+        rtol=0.05,
     )
 
-    assert np.allclose(
-        np.array(responses[job.jobs[-1].uuid][1].output.internal_energies) / 1000.0,
-        np.array(
-            [
-                5058.441587914012,
-                5385.880585798466,
-                6765.198541655172,
-                8723.78588089732,
-                10919.019940938391,
-            ]
-        )
-        / 1000.0,
-        3,
+    assert_allclose(
+        responses[job.jobs[-1].uuid][1].output.internal_energies,
+        [5058.44158791, 5385.88058579, 6765.19854165, 8723.78588089, 10919.0199409],
+        rtol=0.05,
     )

--- a/tests/vasp/flows/test_elastic.py
+++ b/tests/vasp/flows/test_elastic.py
@@ -1,6 +1,6 @@
 def test_elastic(mock_vasp, clean_dir, si_structure):
-    import numpy as np
     from jobflow import run_locally
+    from numpy.testing import assert_allclose
     from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
     from atomate2.common.schemas.elastic import ElasticDocument
@@ -51,7 +51,7 @@ def test_elastic(mock_vasp, clean_dir, si_structure):
     # validation on the outputs
     elastic_output = responses[flow.jobs[-1].uuid][1].output
     assert isinstance(elastic_output, ElasticDocument)
-    assert np.allclose(
+    assert_allclose(
         elastic_output.elastic_tensor.ieee_format,
         [
             [155.7923, 54.8871, 54.8871, 0.0, 0.0, 0.0],

--- a/tests/vasp/flows/test_elph.py
+++ b/tests/vasp/flows/test_elph.py
@@ -68,5 +68,5 @@ def test_elph_renormalisation(mock_vasp, clean_dir, si_structure):
     # validation on the outputs
     renorm_output = responses[flow.output.uuid][1].output
     assert isinstance(renorm_output, ElectronPhononRenormalisationDoc)
-    assert set(renorm_output.delta_band_gaps) == pytest.approx({-0.4889, -0.4885}, 1e-4)
+    assert renorm_output.delta_band_gaps == pytest.approx([-0.4889, -0.4885], 1e-4)
     assert renorm_output.chemsys == "Si"

--- a/tests/vasp/flows/test_elph.py
+++ b/tests/vasp/flows/test_elph.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_elph_renormalisation(mock_vasp, clean_dir, si_structure):
     from jobflow import run_locally
 
@@ -65,8 +68,5 @@ def test_elph_renormalisation(mock_vasp, clean_dir, si_structure):
     # validation on the outputs
     renorm_output = responses[flow.output.uuid][1].output
     assert isinstance(renorm_output, ElectronPhononRenormalisationDoc)
-    assert set(renorm_output.delta_band_gaps) == {
-        -0.488900000000001,
-        -0.48850000000000104,
-    }
+    assert set(renorm_output.delta_band_gaps) == pytest.approx({-0.4889, -0.4885}, 1e-4)
     assert renorm_output.chemsys == "Si"

--- a/tests/vasp/flows/test_elph.py
+++ b/tests/vasp/flows/test_elph.py
@@ -68,5 +68,5 @@ def test_elph_renormalisation(mock_vasp, clean_dir, si_structure):
     # validation on the outputs
     renorm_output = responses[flow.output.uuid][1].output
     assert isinstance(renorm_output, ElectronPhononRenormalisationDoc)
-    assert renorm_output.delta_band_gaps == pytest.approx([-0.4889, -0.4885], 1e-4)
+    assert renorm_output.delta_band_gaps == pytest.approx([-0.4889, -0.4885], rel=1e-3)
     assert renorm_output.chemsys == "Si"

--- a/tests/vasp/flows/test_phonons.py
+++ b/tests/vasp/flows/test_phonons.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 from pymatgen.core.structure import Structure
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.dos import PhononDos
@@ -56,15 +57,9 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
     # !!! validation on the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
-        [
-            5774.603553771463,
-            5616.334060911681,
-            4724.766198084037,
-            3044.208072582665,
-            696.3373193497828,
-        ],
+        [5774.60355377, 5616.33406091, 4724.76619808, 3044.20807258, 696.337319349],
     )
 
     assert isinstance(
@@ -74,29 +69,26 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
     assert isinstance(responses[job.jobs[-1].uuid][1].output.phonon_dos, PhononDos)
     assert responses[job.jobs[-1].uuid][1].output.thermal_displacement_data is None
     assert isinstance(responses[job.jobs[-1].uuid][1].output.structure, Structure)
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.temperatures, [0, 100, 200, 300, 400]
     )
     assert responses[job.jobs[-1].uuid][1].output.has_imaginary_modes is False
     assert responses[job.jobs[-1].uuid][1].output.force_constants is None
     assert isinstance(responses[job.jobs[-1].uuid][1].output.jobdirs, PhononJobDirs)
     assert isinstance(responses[job.jobs[-1].uuid][1].output.uuids, PhononUUIDs)
-    assert np.isclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.total_dft_energy, -5.74555232
     )
     assert responses[job.jobs[-1].uuid][1].output.born is None
     assert responses[job.jobs[-1].uuid][1].output.epsilon_static is None
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.supercell_matrix,
         [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.primitive_matrix,
-        (
-            (0, 0.5000000000000001, 0.5000000000000001),
-            (0.5000000000000001, 0.0, 0.5000000000000001),
-            (0.5000000000000001, 0.5000000000000001, 0.0),
-        ),
+        ((0, 0.5, 0.5), (0.5, 0, 0.5), (0.5, 0.5, 0)),
+        atol=1e-8,
     )
     assert responses[job.jobs[-1].uuid][1].output.code == "vasp"
     assert isinstance(
@@ -112,7 +104,7 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
         == 7000
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
         [
             0.0,
@@ -122,7 +114,7 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
             26.39830736008501,
         ],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
         [
             0.0,
@@ -133,7 +125,7 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
         ],
     )
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.internal_energies,
         [
             5774.603553771463,
@@ -191,7 +183,7 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
     # !!! validation on the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [
             5774.566996471001,
@@ -201,7 +193,7 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
             696.3435315493462,
         ],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
         [
             0.0,
@@ -211,7 +203,7 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
             26.398072464162844,
         ],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
         [
             0.0,
@@ -222,7 +214,7 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
         ],
     )
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.internal_energies,
         [
             5774.566996471001,
@@ -240,23 +232,23 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
     assert isinstance(responses[job.jobs[-1].uuid][1].output.phonon_dos, PhononDos)
     assert responses[job.jobs[-1].uuid][1].output.thermal_displacement_data is None
     assert isinstance(responses[job.jobs[-1].uuid][1].output.structure, Structure)
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.temperatures, [0, 100, 200, 300, 400]
     )
     assert responses[job.jobs[-1].uuid][1].output.has_imaginary_modes is False
     assert responses[job.jobs[-1].uuid][1].output.force_constants is None
     assert isinstance(responses[job.jobs[-1].uuid][1].output.jobdirs, PhononJobDirs)
     assert isinstance(responses[job.jobs[-1].uuid][1].output.uuids, PhononUUIDs)
-    assert np.isclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.total_dft_energy, -5.74525804
     )
     assert responses[job.jobs[-1].uuid][1].output.born is None
     assert responses[job.jobs[-1].uuid][1].output.epsilon_static is None
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.supercell_matrix,
         ((-1.0, 1.0, 1.0), (1.0, -1.0, 1.0), (1.0, 1.0, -1.0)),
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.primitive_matrix,
         (
             (1.0000000000000002, 0.0, 0.0),
@@ -278,7 +270,7 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
         == 7000
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
         [
             0.0,
@@ -288,7 +280,7 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
             26.398072464162844,
         ],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
         [
             0.0,
@@ -299,7 +291,7 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
         ],
     )
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.internal_energies,
         [
             5774.566996471001,
@@ -351,7 +343,7 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpathscheme):
     # print(type(responses))
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [
             5776.1499503440455,
@@ -372,11 +364,11 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpathscheme):
         ThermalDisplacementData,
     )
     assert isinstance(responses[job.jobs[-1].uuid][1].output.structure, Structure)
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.temperatures, [0, 100, 200, 300, 400]
     )
     assert responses[job.jobs[-1].uuid][1].output.has_imaginary_modes is False
-    assert np.isclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.force_constants.force_constants[0][0][0][
             0
         ],
@@ -387,13 +379,14 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpathscheme):
     assert responses[job.jobs[-1].uuid][1].output.total_dft_energy is None
     assert responses[job.jobs[-1].uuid][1].output.born is None
     assert responses[job.jobs[-1].uuid][1].output.epsilon_static is None
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.supercell_matrix,
         [[-1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0]],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.primitive_matrix,
         [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        atol=1e-8,
     )
     assert responses[job.jobs[-1].uuid][1].output.code == "vasp"
     assert isinstance(
@@ -436,14 +429,14 @@ def test_phonon_wf_only_displacements_add_inputs_raises(mock_vasp, clean_dir):
         [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.1]],
     ]
     epsilon_static = [
-        [5.25, 0.0, 0.0],
-        [0.0, 5.25, -0.0],
-        [0.0, 0.0, 5.25],
+        [5.25, 0, 0],
+        [0, 5.25, -0],
+        [0, 0, 5.25],
     ]
     total_dft_energy_per_formula_unit = -5
 
     job = PhononMaker(
-        min_length=3.0,
+        min_length=3,
         bulk_relax_maker=None,
         static_energy_maker=None,
         born_maker=None,
@@ -479,17 +472,17 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
     born = [
-        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+        [[0.0, 0, 0], [0, 0, 0], [0, 0, 0]],
+        [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
     ]
     epsilon_static = [
-        [5.25, 0.0, 0.0],
-        [0.0, 5.25, -0.0],
-        [0.0, 0.0, 5.25],
+        [5.25, 0, 0],
+        [0, 5.25, -0],
+        [0, 0, 5.25],
     ]
     total_dft_energy_per_formula_unit = -5
     job = PhononMaker(
-        min_length=3.0,
+        min_length=3,
         bulk_relax_maker=None,
         static_energy_maker=None,
         born_maker=None,
@@ -509,7 +502,7 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
     # print(type(responses))
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [
             5776.1499503440455,
@@ -530,11 +523,11 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
         ThermalDisplacementData,
     )
     assert isinstance(responses[job.jobs[-1].uuid][1].output.structure, Structure)
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.temperatures, [0, 100, 200, 300, 400]
     )
     assert responses[job.jobs[-1].uuid][1].output.has_imaginary_modes is False
-    assert np.isclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.force_constants.force_constants[0][0][0][
             0
         ],
@@ -542,21 +535,22 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
     )
     assert isinstance(responses[job.jobs[-1].uuid][1].output.jobdirs, PhononJobDirs)
     assert isinstance(responses[job.jobs[-1].uuid][1].output.uuids, PhononUUIDs)
-    assert np.allclose(responses[job.jobs[-1].uuid][1].output.born, born)
-    assert np.isclose(
+    assert_allclose(responses[job.jobs[-1].uuid][1].output.born, born)
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.total_dft_energy,
         total_dft_energy_per_formula_unit,
     )
-    assert np.allclose(
-        responses[job.jobs[-1].uuid][1].output.epsilon_static, epsilon_static
+    assert_allclose(
+        responses[job.jobs[-1].uuid][1].output.epsilon_static, epsilon_static, atol=1e-8
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.supercell_matrix,
-        [[-1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0]],
+        [[-1, 1, 1], [1, -1, 1], [1, 1, -1]],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.primitive_matrix,
         [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        atol=1e-8,
     )
     assert responses[job.jobs[-1].uuid][1].output.code == "vasp"
     assert isinstance(
@@ -595,7 +589,7 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
 
     # !!! Generate job
     job = PhononMaker(
-        min_length=3.0,
+        min_length=3,
         bulk_relax_maker=None,
         static_energy_maker=None,
         born_maker=None,
@@ -612,7 +606,7 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
     # !!! validation on the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [
             5776.1499503440455,
@@ -622,17 +616,17 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
             694.4907835517783,
         ],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
         [
-            0.0,
+            0,
             4.790668183967239,
             13.034706214127153,
             20.374002842560785,
             26.414254898744545,
         ],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
         [
             0.0,
@@ -643,7 +637,7 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
         ],
     )
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.internal_energies,
         [
             5776.1499503440455,
@@ -661,7 +655,7 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
     assert isinstance(responses[job.jobs[-1].uuid][1].output.phonon_dos, PhononDos)
     assert responses[job.jobs[-1].uuid][1].output.thermal_displacement_data is None
     assert isinstance(responses[job.jobs[-1].uuid][1].output.structure, Structure)
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.temperatures, [0, 100, 200, 300, 400]
     )
     assert responses[job.jobs[-1].uuid][1].output.has_imaginary_modes is False
@@ -671,13 +665,14 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
     assert responses[job.jobs[-1].uuid][1].output.total_dft_energy is None
     assert responses[job.jobs[-1].uuid][1].output.born is None
     assert responses[job.jobs[-1].uuid][1].output.epsilon_static is None
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.supercell_matrix,
         [[-1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0]],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.primitive_matrix,
         [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        atol=1e-8,
     )
     assert responses[job.jobs[-1].uuid][1].output.code == "vasp"
     assert isinstance(
@@ -738,7 +733,7 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
     # !!! validation on the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [
             5853.741503991992,
@@ -759,11 +754,11 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
         ThermalDisplacementData,
     )
     assert isinstance(responses[job.jobs[-1].uuid][1].output.structure, Structure)
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.temperatures, [0, 100, 200, 300, 400]
     )
     assert responses[job.jobs[-1].uuid][1].output.has_imaginary_modes is False
-    assert np.isclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.force_constants.force_constants[0][0][0][
             0
         ],
@@ -771,22 +766,20 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
     )
     assert isinstance(responses[job.jobs[-1].uuid][1].output.jobdirs, PhononJobDirs)
     assert isinstance(responses[job.jobs[-1].uuid][1].output.uuids, PhononUUIDs)
-    assert np.allclose(
-        responses[job.jobs[-1].uuid][1].output.born,
-        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-    )
-    assert np.isclose(
+    assert_allclose(responses[job.jobs[-1].uuid][1].output.born, np.zeros((2, 3, 3)))
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.total_dft_energy, -5.746290585
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.epsilon_static,
         ((13.19242034, -0.0, 0.0), (-0.0, 13.19242034, 0.0), (0.0, 0.0, 13.19242034)),
+        atol=1e-8,
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.supercell_matrix,
         [[-1.0, 1.0, 1.0], [1.0, -1.0, 1.0], [1.0, 1.0, -1.0]],
     )
-    assert np.allclose(
+    assert_allclose(
         responses[job.jobs[-1].uuid][1].output.primitive_matrix,
         [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
     )
@@ -928,7 +921,7 @@ def test_phonon_wf_all_steps_na_cl(mock_vasp, clean_dir):
 
     # !!! validation on the outputs
     assert isinstance(responses[phonon_flow.jobs[-1].uuid][1].output, PhononBSDOSDoc)
-    assert np.allclose(
+    assert_allclose(
         responses[phonon_flow.jobs[-1].uuid][1].output.born,
         [
             ((1.1033, 0.0, 0.0), (0.0, 1.1033, -0.0), (0.0, 0.0, 1.1033)),

--- a/tests/vasp/flows/test_phonons.py
+++ b/tests/vasp/flows/test_phonons.py
@@ -39,7 +39,6 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
     # automatically use fake VASP and write POTCAR.spec during the test
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # !!! Generate job
     job = PhononMaker(
         min_length=3.0,
         bulk_relax_maker=None,
@@ -54,7 +53,7 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
     # run the flow or job and ensure that it finished running successfully
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
-    # !!! validation on the outputs
+    # validate the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
     assert_allclose(
@@ -165,7 +164,6 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
     # automatically use fake VASP and write POTCAR.spec during the test
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # !!! Generate job
     job = PhononMaker(
         min_length=3.0,
         bulk_relax_maker=None,
@@ -180,7 +178,7 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
     # run the flow or job and ensure that it finished running successfully
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
-    # !!! validation on the outputs
+    # validate the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
     assert_allclose(
@@ -305,9 +303,9 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
 
 # this will test all kpath schemes in combination with primitive cell
 @pytest.mark.parametrize(
-    "kpathscheme", ["seekpath", "hinuma", "setyawan_curtarolo", "latimer_munro"]
+    "kpath_scheme", ["seekpath", "hinuma", "setyawan_curtarolo", "latimer_munro"]
 )
-def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpathscheme):
+def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpath_scheme):
     from jobflow import run_locally
 
     structure = Structure(
@@ -325,21 +323,20 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpathscheme):
     # automatically use fake VASP and write POTCAR.spec during the test
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # !!! Generate job
     job = PhononMaker(
         min_length=3.0,
         bulk_relax_maker=None,
         static_energy_maker=None,
         born_maker=None,
         use_symmetrized_structure="primitive",
-        kpath_scheme=kpathscheme,
+        kpath_scheme=kpath_scheme,
         generate_frequencies_eigenvectors_kwargs={"tstep": 100},
     ).make(structure)
 
     # run the flow or job and ensure that it finished running successfully
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
-    # !!! validation on the outputs
+    # validate the outputs
     # print(type(responses))
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
@@ -391,7 +388,7 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpathscheme):
     assert responses[job.jobs[-1].uuid][1].output.phonopy_settings.npoints_band == 101
     assert (
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpath_scheme
-        == kpathscheme
+        == kpath_scheme
     )
     assert (
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
@@ -493,7 +490,7 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
     # run the flow or job and ensure that it finished running successfully
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
-    # !!! validation on the outputs
+    # validate the outputs
     # print(type(responses))
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
@@ -577,7 +574,6 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
     # automatically use fake VASP and write POTCAR.spec during the test
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # !!! Generate job
     job = PhononMaker(
         min_length=3,
         bulk_relax_maker=None,
@@ -593,7 +589,7 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
     # run the flow or job and ensure that it finished running successfully
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
-    # !!! validation on the outputs
+    # validate the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
     assert_allclose(
@@ -700,7 +696,7 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
     # run the flow or job and ensure that it finished running successfully
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
-    # !!! validation on the outputs
+    # validate the outputs
     assert isinstance(responses[job.jobs[-1].uuid][1].output, PhononBSDOSDoc)
 
     assert_allclose(
@@ -778,10 +774,10 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
 # combined with non-standard-primitive structures
 # this will test all kpath schemes in combination with primitive cell
 @pytest.mark.parametrize(
-    "kpathscheme", ["hinuma", "setyawan_curtarolo", "latimer_munro"]
+    "kpath_scheme", ["hinuma", "setyawan_curtarolo", "latimer_munro"]
 )
 def test_phonon_wf_only_displacements_kpath_raises_no_cell_change(
-    mock_vasp, clean_dir, kpathscheme
+    mock_vasp, clean_dir, kpath_scheme
 ):
     structure = Structure(
         lattice=[[0, 2.73, 2.73], [2.73, 0, 2.73], [2.73, 2.73, 0]],
@@ -805,15 +801,15 @@ def test_phonon_wf_only_displacements_kpath_raises_no_cell_change(
             static_energy_maker=None,
             born_maker=None,
             use_symmetrized_structure=None,
-            kpath_scheme=kpathscheme,
+            kpath_scheme=kpath_scheme,
             generate_frequencies_eigenvectors_kwargs={"tstep": 100},
         ).make(structure)
 
 
 @pytest.mark.parametrize(
-    "kpathscheme", ["hinuma", "setyawan_curtarolo", "latimer_munro"]
+    "kpath_scheme", ["hinuma", "setyawan_curtarolo", "latimer_munro"]
 )
-def test_phonon_wf_only_displacements_kpath_raises(mock_vasp, clean_dir, kpathscheme):
+def test_phonon_wf_only_displacements_kpath_raises(mock_vasp, clean_dir, kpath_scheme):
     structure = Structure(
         lattice=[[0, 2.73, 2.73], [2.73, 0, 2.73], [2.73, 2.73, 0]],
         species=["Si", "Si"],
@@ -829,14 +825,13 @@ def test_phonon_wf_only_displacements_kpath_raises(mock_vasp, clean_dir, kpathsc
     # automatically use fake VASP and write POTCAR.spec during the test
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
     with pytest.raises(ValueError):
-        # !!! Generate job
         PhononMaker(
             min_length=3.0,
             bulk_relax_maker=None,
             static_energy_maker=None,
             born_maker=None,
             use_symmetrized_structure="conventional",
-            kpath_scheme=kpathscheme,
+            kpath_scheme=kpath_scheme,
             generate_frequencies_eigenvectors_kwargs={"tstep": 100},
         ).make(structure)
 
@@ -889,7 +884,7 @@ def test_phonon_wf_all_steps_na_cl(mock_vasp, clean_dir):
     # run the job
     responses = run_locally(phonon_flow, create_folders=True, ensure_success=True)
 
-    # !!! validation on the outputs
+    # validate the outputs
     assert isinstance(responses[phonon_flow.jobs[-1].uuid][1].output, PhononBSDOSDoc)
     assert_allclose(
         responses[phonon_flow.jobs[-1].uuid][1].output.born,
@@ -965,7 +960,7 @@ def test_phonon_wf_all_steps_na_cl(mock_vasp, clean_dir):
         # run the job
         responses = run_locally(phonon_flow, create_folders=True, ensure_success=True)
 
-        # !!! validation on the outputs
+        # validate the outputs
         assert isinstance(
             responses[phonon_flow.jobs[-1].uuid][1].output, PhononBSDOSDoc
         )

--- a/tests/vasp/flows/test_phonons.py
+++ b/tests/vasp/flows/test_phonons.py
@@ -345,13 +345,8 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpathscheme):
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
-        [
-            5776.1499503440455,
-            5617.747377776762,
-            4725.502693639196,
-            3043.818276263367,
-            694.4907835517783,
-        ],
+        [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.490783551],
+        atol=1e-8,
     )
 
     assert isinstance(
@@ -504,13 +499,8 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
-        [
-            5776.1499503440455,
-            5617.747377776762,
-            4725.502693639196,
-            3043.818276263367,
-            694.4907835517783,
-        ],
+        [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.490783551],
+        atol=1e-8,
     )
 
     assert isinstance(
@@ -608,44 +598,24 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
-        [
-            5776.1499503440455,
-            5617.747377776762,
-            4725.502693639196,
-            3043.818276263367,
-            694.4907835517783,
-        ],
+        [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.490783551],
+        atol=1e-8,
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
-        [
-            0,
-            4.790668183967239,
-            13.034706214127153,
-            20.374002842560785,
-            26.414254898744545,
-        ],
+        [0, 4.79066818396, 13.0347062141, 20.3740028425, 26.4142548987],
+        atol=1e-8,
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
-        [
-            0.0,
-            8.053736263830405,
-            15.980056690395037,
-            19.980312349314378,
-            21.885134767453195,
-        ],
+        [0.0, 8.05373626383, 15.9800566903, 19.9803123493, 21.8851347674],
+        atol=1e-8,
     )
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.internal_energies,
-        [
-            5776.1499503440455,
-            6096.814195199836,
-            7332.443935293648,
-            9156.019127569401,
-            11260.192741251365,
-        ],
+        [5776.14995034, 6096.81419519, 7332.44393529, 9156.01912756, 11260.1927412],
+        atol=1e-8,
     )
 
     assert isinstance(

--- a/tests/vasp/jobs/test_core.py
+++ b/tests/vasp/jobs/test_core.py
@@ -1,3 +1,4 @@
+from numpy.testing import assert_allclose
 from pytest import approx
 
 
@@ -70,7 +71,6 @@ def test_relax_maker(mock_vasp, clean_dir, si_structure):
 
 
 def test_dielectric(mock_vasp, clean_dir, si_structure):
-    import numpy as np
     from jobflow import run_locally
 
     from atomate2.vasp.jobs.core import DielectricMaker
@@ -93,12 +93,12 @@ def test_dielectric(mock_vasp, clean_dir, si_structure):
 
     # Additional validation on the outputs of the job
     output1 = responses[job.uuid][1].output
-    assert np.allclose(
+    assert_allclose(
         output1.calcs_reversed[0].output.epsilon_static,
         [[11.41539467, 0, 0], [0, 11.41539963, 0], [0, 0, 11.41539866]],
         atol=0.01,
     )
-    assert np.allclose(
+    assert_allclose(
         output1.calcs_reversed[0].output.epsilon_ionic,
         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
         atol=0.01,

--- a/tests/vasp/lobster/schemas/test_lobster.py
+++ b/tests/vasp/lobster/schemas/test_lobster.py
@@ -3,8 +3,7 @@ def test_lobster_task_document(lobster_test_dir):
     Test the CCDDocument schema, this test needs to be placed here
     since we are using the VASP TaskDocuments for testing.
     """
-
-    import numpy as np
+    from numpy.testing import assert_allclose
     from pymatgen.core.structure import Structure
     from pymatgen.electronic_structure.cohp import Cohp, CompleteCohp
     from pymatgen.electronic_structure.dos import LobsterCompleteDos
@@ -21,53 +20,53 @@ def test_lobster_task_document(lobster_test_dir):
     )
     assert isinstance(doc.structure, Structure)
     assert isinstance(doc.lobsterout, LobsteroutModel)
-    assert np.isclose(doc.lobsterout.charge_spilling[0], 0.009899999999999999)
+    assert_allclose(doc.lobsterout.charge_spilling[0], 0.009899999999999999)
 
     assert isinstance(doc.lobsterin, LobsterinModel)
-    assert np.isclose(doc.lobsterin.cohpstartenergy, -5)
+    assert_allclose(doc.lobsterin.cohpstartenergy, -5)
     assert isinstance(doc.strongest_bonds_icohp, StrongestBonds)
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icohp.strongest_bonds["As-Ga"]["ICOHP"], -4.32971
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icobi.strongest_bonds["As-Ga"]["ICOBI"], 0.82707
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icoop.strongest_bonds["As-Ga"]["ICOOP"], 0.31405
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icohp.strongest_bonds["As-Ga"]["length"], 2.4899
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icobi.strongest_bonds["As-Ga"]["length"], 2.4899
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icoop.strongest_bonds["As-Ga"]["length"], 2.4899
     )
     assert doc.strongest_bonds_icoop.which_bonds == "all"
     assert doc.strongest_bonds_icohp.which_bonds == "all"
     assert doc.strongest_bonds_icobi.which_bonds == "all"
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icohp_cation_anion.strongest_bonds["As-Ga"]["ICOHP"],
         -4.32971,
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icobi_cation_anion.strongest_bonds["As-Ga"]["ICOBI"],
         0.82707,
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icoop_cation_anion.strongest_bonds["As-Ga"]["ICOOP"],
         0.31405,
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icohp_cation_anion.strongest_bonds["As-Ga"]["length"],
         2.4899,
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icobi_cation_anion.strongest_bonds["As-Ga"]["length"],
         2.4899,
     )
-    assert np.isclose(
+    assert_allclose(
         doc.strongest_bonds_icoop_cation_anion.strongest_bonds["As-Ga"]["length"],
         2.4899,
     )
@@ -88,13 +87,13 @@ def test_lobster_task_document(lobster_test_dir):
     assert isinstance(doc.cobi_data, CompleteCohp)
     assert isinstance(doc.coop_data, CompleteCohp)
     assert isinstance(doc.dos, LobsterCompleteDos)
-    assert np.isclose(doc.madelung_energies["Mulliken"], -0.68)
-    assert np.allclose(
+    assert_allclose(doc.madelung_energies["Mulliken"], -0.68)
+    assert_allclose(
         doc.site_potentials["Mulliken"],
         [-1.26, -1.27, -1.26, -1.27, 1.27, 1.27, 1.26, 1.26],
         rtol=1e-2,
     )
-    assert np.isclose(doc.site_potentials["Ewald_splitting"], 3.14)
+    assert_allclose(doc.site_potentials["Ewald_splitting"], 3.14)
     assert len(doc.gross_populations) == 8
     assert doc.gross_populations[5]["element"] == "As"
     expected_gross_pop = {
@@ -106,7 +105,7 @@ def test_lobster_task_document(lobster_test_dir):
     }
     gross_pop_here = doc.gross_populations[5]["Loewdin GP"]
     assert expected_gross_pop == gross_pop_here
-    assert np.allclose(
+    assert_allclose(
         doc.charges["Mulliken"],
         [0.13, 0.13, 0.13, 0.13, -0.13, -0.13, -0.13, -0.13],
         rtol=1e-2,
@@ -118,35 +117,19 @@ def test_lobster_task_document(lobster_test_dir):
     doc2 = LobsterTaskDocument.from_directory(
         dir_name=lobster_test_dir / "lobsteroutputs/mp-754354", save_cohp_plots=False
     )
-    assert np.isclose(
+    assert_allclose(
         doc2.strongest_bonds_icohp.strongest_bonds["Ba-O"]["ICOHP"], -0.55689
     )
-    assert np.isclose(
+    assert_allclose(
         doc2.strongest_bonds_icohp.strongest_bonds["Ba-F"]["ICOHP"], -0.44806
     )
     assert len(doc2.band_overlaps["1"]) + len(doc2.band_overlaps["-1"]) == 2
-    assert np.allclose(
+    assert_allclose(
         doc2.site_potentials["Loewdin"],
-        [
-            *[-15.09] * 8,
-            14.78,
-            14.78,
-            8.14,
-            8.14,
-            8.48,
-            8.48,
-            8.14,
-            8.14,
-            8.14,
-            8.14,
-            8.48,
-            8.48,
-            8.14,
-            8.14,
-        ],
+        [*[-15.09] * 8, 14.78, 14.78, *[8.14, 8.14, 8.48, 8.48, 8.14, 8.14] * 2],
         rtol=1e-2,
     )
-    assert np.isclose(doc2.site_potentials["Ewald_splitting"], 3.14)
+    assert_allclose(doc2.site_potentials["Ewald_splitting"], 3.14)
     assert len(doc2.gross_populations) == 22
     assert doc2.gross_populations[10]["element"] == "F"
     expected_gross_pop = {


### PR DESCRIPTION
For much better error messages

```py
AssertionError:
Not equal to tolerance rtol=1e-07, atol=0.05

Mismatched elements: 5 / 5 (100%)
Max absolute difference: 20.93780092
Max relative difference: 0.00351895
 x: array([ 5076.241999,  5402.944837,  6781.803129,  8742.033493,
       10939.957742])
 y: array([ 5058.441588,  5385.880586,  6765.198542,  8723.785881,
       10919.019941])
```

vs previously

```py
AssertionError: assert False
```

Related PR https://github.com/materialsproject/pymatgen/pull/3253.