### PR TITLE
Fix Lobster workflow

### DIFF
--- a/src/atomate2/lobster/jobs.py
+++ b/src/atomate2/lobster/jobs.py
@@ -13,14 +13,18 @@ from pymatgen.io.lobster import Lobsterin
 
 from atomate2 import SETTINGS
 from atomate2.common.files import gzip_output_folder
-from atomate2.lobster.files import LOBSTEROUTPUT_FILES, copy_lobster_files
+from atomate2.lobster.files import (
+    LOBSTEROUTPUT_FILES,
+    VASP_OUTPUT_FILES,
+    copy_lobster_files,
+)
 from atomate2.lobster.run import run_lobster
 from atomate2.lobster.schemas import LobsterTaskDocument
 
 logger = logging.getLogger(__name__)
 
 
-_FILES_TO_ZIP = [*LOBSTEROUTPUT_FILES, "lobsterin"]
+_FILES_TO_ZIP = [*LOBSTEROUTPUT_FILES, "lobsterin", *VASP_OUTPUT_FILES]
 
 
 @dataclass

--- a/src/atomate2/vasp/flows/lobster.py
+++ b/src/atomate2/vasp/flows/lobster.py
@@ -48,7 +48,8 @@ LOBSTER_UNIFORM_MAKER = UniformBandStructureMaker(
                 "LWAVE": True,
                 "ISYM": 0,
             },
-        )
+        ),
+        task_document_kwargs={"parse_dos": False, "parse_bandstructure": False},
     ),
 )
 
@@ -61,9 +62,8 @@ class VaspLobsterMaker(Maker):
     The calculations performed are:
 
     1. Optional optimization.
-    2. Optional static computation with symmetry to preconverge the wavefunction.
-    3. Static calculation with ISYM=0.
-    4. Several Lobster computations testing several basis sets are performed.
+    2. Static calculation with ISYM=0.
+    3. Several Lobster computations testing several basis sets are performed.
 
     .. Note::
 
@@ -76,9 +76,6 @@ class VaspLobsterMaker(Maker):
     relax_maker : .BaseVaspMaker or None
         A maker to perform a relaxation on the bulk. Set to ``None`` to skip the
         bulk relaxation.
-    preconverge_static_maker : .BaseVaspMaker or None
-        A maker to perform a preconvergence run before the wavefunction computation
-        without symmetry
     lobster_static_maker : .BaseVaspMaker
         A maker to perform the computation of the wavefunction before the static run.
         Cannot be skipped. It can be LOBSTERUNIFORM or LobsterStaticMaker()


### PR DESCRIPTION
## Summary

Closes #572 

It's not solving potential related issues with jobflow but a solution for the Lobster workflow. We don't need to save the band structure of DOS from VASP in this case. (Actually, only the BandStructure does not end up in the data store which is something I cannot really understand).

The gzip error was initially resolved by @naik-aakash as a part of his larger PR. However, I would very much appreciate it if this fix could be merged rather quickly.

I also fixed a tiny issue in the documentation that I had forgotten the last time.