### PR TITLE
Change `MatPesGGAPlusMetaGGAStaticMaker.output` to dict containing both statics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ ignore_missing_imports = true
 no_strict_optional = true
 
 [tool.pytest.ini_options]
+addopts = "-p no:warnings --import-mode=importlib"
 filterwarnings = [
     "ignore:.*POTCAR.*:UserWarning",
     "ignore:.*input structure.*:UserWarning",

--- a/src/atomate2/common/schemas/elastic.py
+++ b/src/atomate2/common/schemas/elastic.py
@@ -207,7 +207,7 @@ class ElasticDocument(StructureMetadata):
                 strains, pk_stresses, eq_stress=eq_stress
             )
         else:
-            raise ValueError(f"Unsupported elastic fitting method {fitting_method}")
+            raise ValueError(f"Unsupported elastic {fitting_method=}")
 
         ieee = result.convert_to_ieee(structure)
         property_tensor = ieee if order == 2 else ElasticTensor(ieee[0])

--- a/src/atomate2/cp2k/flows/core.py
+++ b/src/atomate2/cp2k/flows/core.py
@@ -136,7 +136,8 @@ class BandStructureMaker(Maker):
         jobs = [static_job]
 
         outputs = {}
-        if self.bandstructure_type in ("both", "uniform"):
+        bandstructure_type = self.bandstructure_type
+        if bandstructure_type in ("both", "uniform"):
             uniform_job = self.bs_maker.make(
                 static_job.output.structure,
                 prev_cp2k_dir=static_job.output.dir_name,
@@ -150,7 +151,7 @@ class BandStructureMaker(Maker):
             }
             outputs.update(output)
 
-        if self.bandstructure_type in ("both", "line"):
+        if bandstructure_type in ("both", "line"):
             line_job = self.bs_maker.make(
                 static_job.output.structure,
                 prev_cp2k_dir=static_job.output.dir_name,
@@ -164,10 +165,8 @@ class BandStructureMaker(Maker):
             }
             outputs.update(output)
 
-        if self.bandstructure_type not in ("both", "line", "uniform"):
-            raise ValueError(
-                f"Unrecognised bandstructure type {self.bandstructure_type}"
-            )
+        if bandstructure_type not in ("both", "line", "uniform"):
+            raise ValueError(f"Unrecognised {bandstructure_type=}")
 
         return Flow(jobs, outputs, name=self.name)
 

--- a/src/atomate2/cp2k/run.py
+++ b/src/atomate2/cp2k/run.py
@@ -110,7 +110,7 @@ def run_cp2k(
     if job_type == JobType.NORMAL:
         jobs = [Cp2kJob(split_cp2k_cmd, **cp2k_job_kwargs)]
     else:
-        raise ValueError(f"Unsupported job type: {job_type}")
+        raise ValueError(f"Unsupported {job_type=}")
 
     c = Custodian(
         handlers,
@@ -161,4 +161,4 @@ def should_stop_children(
             "limit of electronic/ionic iterations)!"
         )
 
-    raise RuntimeError(f"Unknown option for defuse_unsuccessful: {handle_unsuccessful}")
+    raise RuntimeError(f"Unknown option for {handle_unsuccessful=}")

--- a/src/atomate2/lobster/run.py
+++ b/src/atomate2/lobster/run.py
@@ -85,7 +85,7 @@ def run_lobster(
     if job_type == JobType.NORMAL:
         jobs = [LobsterJob(split_lobster_cmd, **lobster_job_kwargs)]
     else:
-        raise ValueError(f"Unsupported job type: {job_type}")
+        raise ValueError(f"Unsupported {job_type=}")
 
     handlers: list = []
 

--- a/src/atomate2/vasp/flows/core.py
+++ b/src/atomate2/vasp/flows/core.py
@@ -141,7 +141,8 @@ class BandStructureMaker(Maker):
         jobs = [static_job]
 
         outputs = {}
-        if self.bandstructure_type in ("both", "uniform"):
+        bandstructure_type = self.bandstructure_type
+        if bandstructure_type in ("both", "uniform"):
             uniform_job = self.bs_maker.make(
                 static_job.output.structure,
                 prev_vasp_dir=static_job.output.dir_name,
@@ -155,7 +156,7 @@ class BandStructureMaker(Maker):
             }
             outputs.update(output)
 
-        if self.bandstructure_type in ("both", "line"):
+        if bandstructure_type in ("both", "line"):
             line_job = self.bs_maker.make(
                 static_job.output.structure,
                 prev_vasp_dir=static_job.output.dir_name,
@@ -169,10 +170,8 @@ class BandStructureMaker(Maker):
             }
             outputs.update(output)
 
-        if self.bandstructure_type not in ("both", "line", "uniform"):
-            raise ValueError(
-                f"Unrecognised bandstructure type {self.bandstructure_type}"
-            )
+        if bandstructure_type not in ("both", "line", "uniform"):
+            raise ValueError(f"Unrecognised {bandstructure_type=}")
 
         return Flow(jobs, outputs, name=self.name)
 

--- a/src/atomate2/vasp/flows/matpes.py
+++ b/src/atomate2/vasp/flows/matpes.py
@@ -64,4 +64,5 @@ class MatPesGGAPlusMetaGGAStaticMaker(Maker):
         """
         static1 = self.static1.make(structure, prev_vasp_dir=prev_vasp_dir)
         static2 = self.static2.make(structure, prev_vasp_dir=static1.output.dir_name)
-        return Flow([static1, static2], output=static2.output, name=self.name)
+        output = {"static1": static1.output, "static2": static2.output}
+        return Flow([static1, static2], output=output, name=self.name)

--- a/src/atomate2/vasp/run.py
+++ b/src/atomate2/vasp/run.py
@@ -147,7 +147,7 @@ def run_vasp(
     elif job_type == JobType.FULL_OPT:
         jobs = VaspJob.full_opt_run(split_vasp_cmd, **vasp_job_kwargs)
     else:
-        raise ValueError(f"Unsupported job type: {job_type}")
+        raise ValueError(f"Unsupported {job_type=}")
 
     if wall_time is not None:
         handlers = [*handlers, WalltimeHandler(wall_time=wall_time)]
@@ -201,4 +201,4 @@ def should_stop_children(
             "limit of electronic/ionic iterations)!"
         )
 
-    raise RuntimeError(f"Unknown option for defuse_unsuccessful: {handle_unsuccessful}")
+    raise RuntimeError(f"Unknown option for {handle_unsuccessful=}")

--- a/tests/vasp/flows/test_matpes.py
+++ b/tests/vasp/flows/test_matpes.py
@@ -30,7 +30,15 @@ def test_matpes_gga_plus_meta_gga_static_maker(mock_vasp, clean_dir, vasp_test_d
     responses = run_locally(flow, create_folders=True, ensure_success=True)
 
     # validate output
-    output = responses[flow.jobs[-1].uuid][1].output
-    assert isinstance(output, TaskDoc)
-    assert output.output.energy == pytest.approx(-17.53895666)
-    assert output.output.bandgap == pytest.approx(0.8087999)
+    pbe_doc = responses[flow.jobs[0].uuid][1].output
+    r2scan_doc = responses[flow.jobs[-1].uuid][1].output
+    assert isinstance(r2scan_doc, TaskDoc)
+    assert r2scan_doc.output.energy == pytest.approx(-17.53895666)
+    assert r2scan_doc.output.bandgap == pytest.approx(0.8087999)
+
+    assert isinstance(pbe_doc, TaskDoc)
+    assert pbe_doc.output.energy == pytest.approx(-10.84940729)
+    assert pbe_doc.output.bandgap == pytest.approx(0.6172, abs=1e-3)
+
+    assert isinstance(flow.output, dict)
+    assert {*flow.output} == {"static1", "static2"}

--- a/tests/vasp/flows/test_mp.py
+++ b/tests/vasp/flows/test_mp.py
@@ -77,9 +77,9 @@ def test_mp_meta_gga_double_relax_static(mock_vasp, clean_dir, vasp_test_dir):
     responses = run_locally(flow, create_folders=True, ensure_success=True)
 
     # validate output
-    output = responses[flow.jobs[-1].uuid][1].output
-    assert isinstance(output, TaskDoc)
-    assert output.output.energy == pytest.approx(-46.8613738)
+    task_doc = responses[flow.jobs[-1].uuid][1].output
+    assert isinstance(task_doc, TaskDoc)
+    assert task_doc.output.energy == pytest.approx(-46.8613738)
 
 
 def test_mp_gga_double_relax_static(mock_vasp, clean_dir, vasp_test_dir):
@@ -106,9 +106,9 @@ def test_mp_gga_double_relax_static(mock_vasp, clean_dir, vasp_test_dir):
     responses = run_locally(flow, create_folders=True, ensure_success=True)
 
     # validate output
-    output = responses[flow.jobs[-1].uuid][1].output
-    assert isinstance(output, TaskDoc)
-    assert output.output.energy == pytest.approx(-10.84060922)
+    task_doc = responses[flow.jobs[-1].uuid][1].output
+    assert isinstance(task_doc, TaskDoc)
+    assert task_doc.output.energy == pytest.approx(-10.84060922)
 
 
 def test_mp_gga_double_relax(mock_vasp, clean_dir, vasp_test_dir):
@@ -134,6 +134,6 @@ def test_mp_gga_double_relax(mock_vasp, clean_dir, vasp_test_dir):
     responses = run_locally(flow, create_folders=True, ensure_success=True)
 
     # validate output
-    output = responses[flow.jobs[-1].uuid][1].output
-    assert isinstance(output, TaskDoc)
-    assert output.output.energy == pytest.approx(-10.84145656)
+    task_doc = responses[flow.jobs[-1].uuid][1].output
+    assert isinstance(task_doc, TaskDoc)
+    assert task_doc.output.energy == pytest.approx(-10.84145656)

--- a/tests/vasp/flows/test_phonons.py
+++ b/tests/vasp/flows/test_phonons.py
@@ -343,7 +343,7 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpath_scheme):
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.490783551],
-        atol=1e-8,
+        atol=1e-3,
     )
 
     assert isinstance(
@@ -497,7 +497,7 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.490783551],
-        atol=1e-8,
+        atol=1e-3,
     )
 
     assert isinstance(
@@ -595,7 +595,7 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.490783551],
-        atol=1e-8,
+        atol=1e-3,
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,

--- a/tests/vasp/jobs/test_matpes.py
+++ b/tests/vasp/jobs/test_matpes.py
@@ -99,9 +99,9 @@ def test_matpes_gga_static_maker(mock_vasp, clean_dir, vasp_test_dir):
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
     # validate output
-    output = responses[job.uuid][1].output
-    assert isinstance(output, TaskDoc)
-    assert output.output.energy == pytest.approx(-10.84940729)
+    task_doc = responses[job.uuid][1].output
+    assert isinstance(task_doc, TaskDoc)
+    assert task_doc.output.energy == pytest.approx(-10.84940729)
 
 
 def test_matpes_meta_gga_static_maker(mock_vasp, clean_dir, vasp_test_dir):
@@ -125,6 +125,6 @@ def test_matpes_meta_gga_static_maker(mock_vasp, clean_dir, vasp_test_dir):
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
     # validate output
-    output = responses[job.uuid][1].output
-    assert isinstance(output, TaskDoc)
-    assert output.output.energy == pytest.approx(-17.53895667)
+    task_doc = responses[job.uuid][1].output
+    assert isinstance(task_doc, TaskDoc)
+    assert task_doc.output.energy == pytest.approx(-17.53895667)

--- a/tests/vasp/jobs/test_mp.py
+++ b/tests/vasp/jobs/test_mp.py
@@ -67,9 +67,9 @@ def test_mp_meta_gga_static_maker(mock_vasp, clean_dir, vasp_test_dir):
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
     # validate output
-    output = responses[job.uuid][1].output
-    assert isinstance(output, TaskDoc)
-    assert output.output.energy == pytest.approx(-46.8613738)
+    task_doc = responses[job.uuid][1].output
+    assert isinstance(task_doc, TaskDoc)
+    assert task_doc.output.energy == pytest.approx(-46.8613738)
 
 
 def test_mp_meta_gga_relax_maker(mock_vasp, clean_dir, vasp_test_dir):
@@ -100,9 +100,9 @@ def test_mp_meta_gga_relax_maker(mock_vasp, clean_dir, vasp_test_dir):
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
     # validate output
-    output = responses[job.uuid][1].output
-    assert isinstance(output, TaskDoc)
-    assert output.output.energy == pytest.approx(-46.86703814)
+    task_doc = responses[job.uuid][1].output
+    assert isinstance(task_doc, TaskDoc)
+    assert task_doc.output.energy == pytest.approx(-46.86703814)
 
 
 def test_mp_gga_relax_maker(mock_vasp, clean_dir, vasp_test_dir):
@@ -131,6 +131,6 @@ def test_mp_gga_relax_maker(mock_vasp, clean_dir, vasp_test_dir):
     responses = run_locally(job, create_folders=True, ensure_success=True)
 
     # validate output
-    output = responses[job.uuid][1].output
-    assert isinstance(output, TaskDoc)
-    assert output.output.energy == pytest.approx(-10.84140641)
+    task_doc = responses[job.uuid][1].output
+    assert isinstance(task_doc, TaskDoc)
+    assert task_doc.output.energy == pytest.approx(-10.84140641)


### PR DESCRIPTION
Change `MatPesGGAPlusMetaGGAStaticMaker.output` from `static2.output` to `{"static1": static1.output, "static2": static2.output}`. Brings it more in line with e.g. `BandStructureMaker`:

https://github.com/materialsproject/atomate2/blob/5aced196baf8bbbf41875cbd19836c09069611bf/src/atomate2/vasp/flows/core.py#L143-L156

ac67d333 pytest addopts = "-p no:warnings --import-mode=importlib"
4a7a9428 fix should_stop_children RuntimeError err msg calling handle_unsuccessful defuse_unsuccessful
7f6219a8 MatPesGGAPlusMetaGGAStaticMaker change output from static2.output to {"static1": static1.output, "static2": static2.output}
e47db541 test_matpes_gga_plus_meta_gga_static_maker assert isinstance(flow.output, dict)
5aced196 rename output to task_doc in matpes and mp tests