### PR TITLE
Add setting `VASP_RUN_DDEC6: bool = False`

### DIFF
--- a/src/atomate2/cp2k/schemas/calculation.py
+++ b/src/atomate2/cp2k/schemas/calculation.py
@@ -336,9 +336,9 @@ class Calculation(BaseModel):
               vbm, cbm, band_gap, is_metal and efermi rather than the full
               band structure object.
 
-        average_v_hartree
+        average_v_hartree : bool = True
             Whether to store the average of the V_HARTREE along the crystal axes.
-        run_bader
+        run_bader : bool = False
             Whether to run bader on the charge density.
         strip_dos_projections : bool
             Whether to strip the element and site projections from the density of
@@ -347,13 +347,13 @@ class Calculation(BaseModel):
         strip_bandstructure_projections : bool
             Whether to strip the element and site projections from the band structure.
             This can help reduce the size of DOS objects in systems with many atoms.
-        store_trajectory:
+        store_trajectory : bool = False
             Whether to store the ionic steps as a pmg trajectory object, which can be
             pushed, to a bson data store, instead of as a list od dicts. Useful for
             large trajectories.
-        store_scf:
+        store_scf : bool = False
             Whether to store the SCF convergence data.
-        store_volumetric_data
+        store_volumetric_data : tuple[str] | None = SETTINGS.CP2K_STORE_VOLUMETRIC_DATA
             Which volumetric files to store.
 
         Returns

--- a/src/atomate2/forcefields/schemas.py
+++ b/src/atomate2/forcefields/schemas.py
@@ -135,7 +135,7 @@ class ForceFieldTaskDocument(StructureMetadata):
         """
         trajectory = result["trajectory"].__dict__
 
-        # NOTE: units for stresses were converted from ev/Angstrom³ to kbar
+        # NOTE: units for stresses were converted from eV/Angstrom³ to kbar
         # (* -1 from standard output)
         # and to 3x3 matrix to comply with MP convention
         for i in range(len(trajectory["stresses"])):

--- a/src/atomate2/forcefields/schemas.py
+++ b/src/atomate2/forcefields/schemas.py
@@ -1,4 +1,4 @@
-"""Job to prerelax a structure using an MD Potential."""
+"""Schema definitions for force field tasks."""
 
 from typing import Optional
 
@@ -6,12 +6,12 @@ from ase.stress import voigt_6_to_full_3x3_stress
 from ase.units import GPa
 from emmet.core.math import Matrix3D, Vector3D
 from emmet.core.structure import StructureMetadata
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Field
 from pymatgen.core.structure import Structure
 from pymatgen.io.ase import AseAtomsAdaptor
 
 
-class IonicStep(BaseModel, extra=Extra.allow):  # type: ignore[call-arg]
+class IonicStep(BaseModel, extra="allow"):  # type: ignore[call-arg]
     """Document defining the information at each ionic step."""
 
     energy: float = Field(None, description="The free energy.")
@@ -178,55 +178,55 @@ class ForceFieldTaskDocument(StructureMetadata):
         n_steps = len(trajectory["energies"])
 
         ionic_steps = []
-        for i in range(n_steps):
-            cur_energy = (
-                trajectory["energies"][i] if "energy" in ionic_step_data else None
+        for idx in range(n_steps):
+            energy = (
+                trajectory["energies"][idx] if "energy" in ionic_step_data else None
             )
-            cur_forces = (
-                trajectory["forces"][i].tolist()
+            forces = (
+                trajectory["forces"][idx].tolist()
                 if "forces" in ionic_step_data
                 else None
             )
-            cur_stress = (
-                trajectory["stresses"][i].tolist()
+            stress = (
+                trajectory["stresses"][idx].tolist()
                 if "stress" in ionic_step_data
                 else None
             )
 
             if "structure" in ionic_step_data:
                 cur_structure = Structure(
-                    lattice=trajectory["cells"][i],
-                    coords=trajectory["atom_positions"][i],
+                    lattice=trajectory["cells"][idx],
+                    coords=trajectory["atom_positions"][idx],
                     species=species,
                     coords_are_cartesian=True,
                 )
             else:
                 cur_structure = None
 
-            # include "magmoms" in :obj:`cur_ionic_step` if the trajectory has "magmoms"
+            # include "magmoms" in :obj:`ionic_step` if the trajectory has "magmoms"
             if "magmoms" in trajectory:
-                cur_ionic_step = IonicStep(
-                    energy=cur_energy,
-                    forces=cur_forces,
+                ionic_step = IonicStep(
+                    energy=energy,
+                    forces=forces,
                     magmoms=(
-                        trajectory["magmoms"][i].tolist()
+                        trajectory["magmoms"][idx].tolist()
                         if "magmoms" in ionic_step_data
                         else None
                     ),
-                    stress=cur_stress,
+                    stress=stress,
                     structure=cur_structure,
                 )
 
-            # otherwise do not include "magmoms" in :obj:`cur_ionic_step`
+            # otherwise do not include "magmoms" in :obj:`ionic_step`
             elif "magmoms" not in trajectory:
-                cur_ionic_step = IonicStep(
-                    energy=cur_energy,
-                    forces=cur_forces,
-                    stress=cur_stress,
+                ionic_step = IonicStep(
+                    energy=energy,
+                    forces=forces,
+                    stress=stress,
                     structure=cur_structure,
                 )
 
-            ionic_steps.append(cur_ionic_step)
+            ionic_steps.append(ionic_step)
 
         output_doc = OutputDoc(
             structure=output_structure,

--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -84,6 +84,11 @@ class Atomate2Settings(BaseSettings):
         description="Whether to run the Bader program when parsing VASP calculations."
         "Requires the bader executable to be on the path.",
     )
+    VASP_RUN_DDEC6: bool = Field(
+        default=False,
+        description="Whether to run the DDEC6 program when parsing VASP calculations."
+        "Requires the chargemol executable to be on the path.",
+    )
 
     VASP_ZIP_FILES: Union[bool, Literal["atomate"]] = Field(
         "atomate",

--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -93,7 +93,7 @@ class Atomate2Settings(BaseSettings):
         default=None,
         description="Directory where the atomic densities are stored. If not set, "
         "pymatgen tries to auto-download the densities and extract them into "
-        "~/.cache/pymatgen",
+        "~/.cache/pymatgen/ddec",
     )
 
     VASP_ZIP_FILES: Union[bool, Literal["atomate"]] = Field(

--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -89,6 +89,12 @@ class Atomate2Settings(BaseSettings):
         description="Whether to run the DDEC6 program when parsing VASP calculations."
         "Requires the chargemol executable to be on the path.",
     )
+    DDEC6_ATOMIC_DENSITIES_DIR: Optional[str] = Field(
+        default=None,
+        description="Directory where the atomic densities are stored. If not set, "
+        "pymatgen tries to auto-download the densities and extract them into "
+        "~/.cache/pymatgen",
+    )
 
     VASP_ZIP_FILES: Union[bool, Literal["atomate"]] = Field(
         "atomate",

--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -91,9 +91,10 @@ class Atomate2Settings(BaseSettings):
     )
     DDEC6_ATOMIC_DENSITIES_DIR: Optional[str] = Field(
         default=None,
-        description="Directory where the atomic densities are stored. If not set, "
-        "pymatgen tries to auto-download the densities and extract them into "
-        "~/.cache/pymatgen/ddec",
+        description="Directory where the atomic densities are stored.",
+        # TODO uncomment below once that functionality is actually implemented
+        # If not set, pymatgen tries to auto-download the densities and extract them
+        # into ~/.cache/pymatgen/ddec
     )
 
     VASP_ZIP_FILES: Union[bool, Literal["atomate"]] = Field(

--- a/src/atomate2/vasp/jobs/base.py
+++ b/src/atomate2/vasp/jobs/base.py
@@ -254,18 +254,21 @@ def get_vasp_task_document(path: Path | str, **kwargs) -> TaskDoc:
         "volume_change_warning_tol", SETTINGS.VASP_VOLUME_CHANGE_WARNING_TOL
     )
 
-    kwargs.setdefault("run_bader", SETTINGS.VASP_RUN_BADER and _BADER_EXE_EXISTS)
-    if SETTINGS.VASP_RUN_BADER and not _BADER_EXE_EXISTS:
-        warnings.warn(
-            f"{SETTINGS.VASP_RUN_BADER=} but bader executable not found on path",
-            stacklevel=1,
-        )
-    kwargs.setdefault("run_ddec6", SETTINGS.VASP_RUN_DDEC6 and _CHARGEMOL_EXE_EXISTS)
-    if SETTINGS.VASP_RUN_DDEC6 and not _CHARGEMOL_EXE_EXISTS:
-        warnings.warn(
-            f"{SETTINGS.VASP_RUN_DDEC6=} but chargemol executable not found on path",
-            stacklevel=1,
-        )
+    if SETTINGS.VASP_RUN_BADER:
+        kwargs.setdefault("run_bader", _BADER_EXE_EXISTS)
+        if not _BADER_EXE_EXISTS:
+            warnings.warn(
+                f"{SETTINGS.VASP_RUN_BADER=} but bader executable not found on path",
+                stacklevel=1,
+            )
+    if SETTINGS.VASP_RUN_DDEC6:
+        kwargs.setdefault("run_ddec6", _CHARGEMOL_EXE_EXISTS)
+        if not _CHARGEMOL_EXE_EXISTS:
+            warnings.warn(
+                f"{SETTINGS.VASP_RUN_DDEC6=} but chargemol executable not found on "
+                "path",
+                stacklevel=1,
+            )
 
     kwargs.setdefault("store_volumetric_data", SETTINGS.VASP_STORE_VOLUMETRIC_DATA)
 

--- a/src/atomate2/vasp/jobs/base.py
+++ b/src/atomate2/vasp/jobs/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from shutil import which
@@ -29,6 +30,12 @@ if TYPE_CHECKING:
 
 
 _BADER_EXE_EXISTS = bool(which("bader") or which("bader.exe"))
+_CHARGEMOL_EXE_EXISTS = bool(
+    which("Chargemol_09_26_2017_linux_parallel")
+    or which("Chargemol_09_26_2017_linux_serial")
+    or which("chargemol")
+)
+
 _DATA_OBJECTS = [
     BandStructure,
     BandStructureSymmLine,
@@ -239,10 +246,7 @@ class BaseVaspMaker(Maker):
         )
 
 
-def get_vasp_task_document(
-    path: Path | str,
-    **kwargs,
-) -> TaskDoc:
+def get_vasp_task_document(path: Path | str, **kwargs) -> TaskDoc:
     """Get VASP Task Document using atomate2 settings."""
     kwargs.setdefault("store_additional_json", SETTINGS.VASP_STORE_ADDITIONAL_JSON)
 
@@ -251,6 +255,17 @@ def get_vasp_task_document(
     )
 
     kwargs.setdefault("run_bader", SETTINGS.VASP_RUN_BADER and _BADER_EXE_EXISTS)
+    if SETTINGS.VASP_RUN_BADER and not _BADER_EXE_EXISTS:
+        warnings.warn(
+            f"{SETTINGS.VASP_RUN_BADER=} but bader executable not found on path",
+            stacklevel=1,
+        )
+    kwargs.setdefault("run_ddec6", SETTINGS.VASP_RUN_DDEC6 and _CHARGEMOL_EXE_EXISTS)
+    if SETTINGS.VASP_RUN_DDEC6 and not _CHARGEMOL_EXE_EXISTS:
+        warnings.warn(
+            f"{SETTINGS.VASP_RUN_DDEC6=} but chargemol executable not found on path",
+            stacklevel=1,
+        )
 
     kwargs.setdefault("store_volumetric_data", SETTINGS.VASP_STORE_VOLUMETRIC_DATA)
 

--- a/src/atomate2/vasp/jobs/base.py
+++ b/src/atomate2/vasp/jobs/base.py
@@ -266,17 +266,17 @@ def get_vasp_task_document(path: Path | str, **kwargs) -> TaskDoc:
         # skip running DDEC6
         run_ddec6: bool | str = _CHARGEMOL_EXE_EXISTS
         if run_ddec6 and isinstance(SETTINGS.DDEC6_ATOMIC_DENSITIES_DIR, str):
-            # if DDEC6_ATOMIC_DENSITIES_DIR is a string, use that as the path to the
-            # atomic densities.
-            if not Path(SETTINGS.DDEC6_ATOMIC_DENSITIES_DIR).is_dir():
-                # warn the user if the directory doesn't exist and skip running DDEC6
+            # if DDEC6_ATOMIC_DENSITIES_DIR is a string and directory at that path
+            # exists, use as path to the atomic densities
+            if Path(SETTINGS.DDEC6_ATOMIC_DENSITIES_DIR).is_dir():
+                run_ddec6 = SETTINGS.DDEC6_ATOMIC_DENSITIES_DIR
+            else:
+                # if the directory doesn't exist, warn the user and skip running DDEC6
                 warnings.warn(
                     f"{SETTINGS.DDEC6_ATOMIC_DENSITIES_DIR=} does not exist, skipping "
                     "DDEC6",
                     stacklevel=1,
                 )
-            else:
-                run_ddec6 = SETTINGS.DDEC6_ATOMIC_DENSITIES_DIR
         kwargs.setdefault("run_ddec6", run_ddec6)
 
         if not _CHARGEMOL_EXE_EXISTS:

--- a/tests/common/test_settings.py
+++ b/tests/common/test_settings.py
@@ -18,6 +18,7 @@ def test_empty_and_invalid_config_file(clean_dir):
     assert settings.BANDGAP_TOL == 1e-4
     assert settings.VASP_RUN_BADER is False
     assert settings.VASP_RUN_DDEC6 is False
+    assert settings.DDEC6_ATOMIC_DENSITIES_DIR is None
 
     # test warning if config file is empty
     config_file_path.touch()

--- a/tests/common/test_settings.py
+++ b/tests/common/test_settings.py
@@ -12,6 +12,13 @@ def test_empty_and_invalid_config_file(clean_dir):
     config_file_path = Path.cwd() / "test-atomate2-config.yaml"
     os.environ["ATOMATE2_CONFIG_FILE"] = str(config_file_path)
 
+    settings = Atomate2Settings()
+    assert str(config_file_path) == settings.CONFIG_FILE
+    assert settings.SYMPREC == 0.1
+    assert settings.BANDGAP_TOL == 1e-4
+    assert settings.VASP_RUN_BADER is False
+    assert settings.VASP_RUN_DDEC6 is False
+
     # test warning if config file is empty
     config_file_path.touch()
     with pytest.warns(

--- a/tests/vasp/flows/test_phonons.py
+++ b/tests/vasp/flows/test_phonons.py
@@ -416,13 +416,13 @@ def test_phonon_wf_only_displacements_add_inputs_raises(mock_vasp, clean_dir):
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
     born = [
-        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.1]],
+        [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
+        [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
+        [[0, 0, 0], [0, 0, 0], [0, 0, 0.1]],
     ]
     epsilon_static = [
         [5.25, 0, 0],
-        [0, 5.25, -0],
+        [0, 5.25, 0],
         [0, 0, 5.25],
     ]
     total_dft_energy_per_formula_unit = -5
@@ -469,7 +469,7 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
     ]
     epsilon_static = [
         [5.25, 0, 0],
-        [0, 5.25, -0],
+        [0, 5.25, 0],
         [0, 0, 5.25],
     ]
     total_dft_energy_per_formula_unit = -5


### PR DESCRIPTION
Similar to existing setting `VASP_RUN_BADER`, allows saving DDEC6 charge analysis automatically in any VASP `TaskDoc`.

https://github.com/materialsproject/atomate2/blob/a3215dbe6dcd094eb4dfdff51d77dbdf71530f33/src/atomate2/settings.py#L82

Related PR https://github.com/materialsproject/emmet/pull/869