### PR TITLE
Breaking: Unify previous directory `Maker` API

### DIFF
--- a/src/atomate2/amset/jobs.py
+++ b/src/atomate2/amset/jobs.py
@@ -42,7 +42,7 @@ class AmsetMaker(Maker):
     def make(
         self,
         settings: dict,
-        prev_amset_dir: str | Path = None,
+        prev_dir: str | Path = None,
         wavefunction_dir: str | Path = None,
         deformation_dir: str | Path = None,
         bandstructure_dir: str | Path = None,
@@ -54,7 +54,7 @@ class AmsetMaker(Maker):
         ----------
         settings : dict
             Amset settings.
-        prev_amset_dir : str or Path
+        prev_dir : str or Path
             A previous AMSET calculation directory to copy output files from. The
             previous directory is also used to check for transport convergence.
         wavefunction_dir : str or Path
@@ -66,14 +66,12 @@ class AmsetMaker(Maker):
             band_structure_data.json).
         """
         # copy previous inputs
-        from_prev = prev_amset_dir is not None
-        if prev_amset_dir is not None:
-            copy_amset_files(prev_amset_dir)
+        from_prev = prev_dir is not None
+        if prev_dir is not None:
+            copy_amset_files(prev_dir)
         else:
             if bandstructure_dir is None:
-                raise ValueError(
-                    "Either prev_amset_dir or bandstructure_dir must be set"
-                )
+                raise ValueError("Either prev_dir or bandstructure_dir must be set")
 
             copy_amset_files(bandstructure_dir)
 
@@ -116,7 +114,7 @@ class AmsetMaker(Maker):
         if self.resubmit and not converged:
             replace = self.make(
                 {"interpolation_factor": settings.get("interpolation_factor", 10) + 5},
-                prev_amset_dir=task_doc.dir_name,
+                prev_dir=task_doc.dir_name,
             )
 
         return Response(output=task_doc, replace=replace)

--- a/src/atomate2/common/flows/defect.py
+++ b/src/atomate2/common/flows/defect.py
@@ -110,7 +110,7 @@ class ConfigurationCoordinateMaker(Maker):
             struct2,
             distortions=self.distortions,
             static_maker=self.static_maker,
-            prev_vasp_dir=dir1,
+            prev_dir=dir1,
             add_name="q1",
             add_info={"relaxed_uuid": relax1.uuid, "distorted_uuid": relax2.uuid},
         )
@@ -120,7 +120,7 @@ class ConfigurationCoordinateMaker(Maker):
             struct1,
             distortions=self.distortions,
             static_maker=self.static_maker,
-            prev_vasp_dir=dir2,
+            prev_dir=dir2,
             add_name="q2",
             add_info={"relaxed_uuid": relax2.uuid, "distorted_uuid": relax1.uuid},
         )

--- a/src/atomate2/common/flows/elastic.py
+++ b/src/atomate2/common/flows/elastic.py
@@ -94,7 +94,7 @@ class BaseElasticMaker(Maker, ABC):
         ----------
         structure : .Structure
             A pymatgen structure.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous vasp calculation directory to use for copying outputs.
         equilibrium_stress : tuple of tuple of float
             The equilibrium stress of the (relaxed) structure, if known.

--- a/src/atomate2/common/jobs/defect.py
+++ b/src/atomate2/common/jobs/defect.py
@@ -70,7 +70,7 @@ def spawn_energy_curve_calcs(
     distorted_structure: Structure,
     distortions: Iterable[float],
     static_maker: StaticMaker,
-    prev_vasp_dir: str | Path | None = None,
+    prev_dir: str | Path | None = None,
     add_name: str = "",
     add_info: dict | None = None,
 ) -> Response:
@@ -108,7 +108,7 @@ def spawn_energy_curve_calcs(
     )
     # add all the distorted structures
     for i, d_struct in enumerate(distorted_structures):
-        static_job = static_maker.make(d_struct, prev_vasp_dir=prev_vasp_dir)
+        static_job = static_maker.make(d_struct, prev_dir=prev_dir)
         suffix = f" {i}" if add_name == "" else f" {add_name} {i}"
 
         # write some provenances data in info.json file

--- a/src/atomate2/common/jobs/phonons.py
+++ b/src/atomate2/common/jobs/phonons.py
@@ -252,7 +252,7 @@ def run_phonon_displacements(
     structure: Structure,
     supercell_matrix,
     phonon_maker: BaseVaspMaker | ForceFieldStaticMaker = None,
-    prev_vasp_dir: str | Path = None,
+    prev_dir: str | Path = None,
 ) -> Flow:
     """
     Run phonon displacements.
@@ -268,7 +268,7 @@ def run_phonon_displacements(
         supercell matrix for meta data
     phonon_maker : .BaseVaspMaker
         A VaspMaker to use to generate the elastic relaxation jobs.
-    prev_vasp_dir : str or Path or None
+    prev_dir : str or Path or None
         A previous vasp calculation directory to use for copying outputs.
     """
     if phonon_maker is None:
@@ -282,8 +282,8 @@ def run_phonon_displacements(
     }
 
     for i, displacement in enumerate(displacements):
-        if prev_vasp_dir is not None:
-            phonon_job = phonon_maker.make(displacement, prev_vasp_dir=prev_vasp_dir)
+        if prev_dir is not None:
+            phonon_job = phonon_maker.make(displacement, prev_dir=prev_dir)
         else:
             phonon_job = phonon_maker.make(displacement)
         phonon_job.append_name(f" {i + 1}/{len(displacements)}")

--- a/src/atomate2/common/utils.py
+++ b/src/atomate2/common/utils.py
@@ -116,7 +116,7 @@ def parse_additional_json(dir_name: Path) -> dict[str, Any]:
     additional_json = {}
     for filename in dir_name.glob("*.json*"):
         key = filename.name.split(".")[0]
-        # ignore FW.json(.gz) so jobflow doesn't try to parse prev_vasp_dir
+        # ignore FW.json(.gz) so jobflow doesn't try to parse prev_dir
         # OutputReferences was causing atomate2 MP workflows to fail with ValueError:
         # Could not resolve reference 7f5a7f14-464c-4a5b-85f9-8d11b595be3b not in store
         # or cache contact @janosh in case of questions

--- a/src/atomate2/cp2k/flows/core.py
+++ b/src/atomate2/cp2k/flows/core.py
@@ -46,9 +46,7 @@ class DoubleRelaxMaker(Maker):
     relax_maker1: Maker = field(default_factory=RelaxMaker)
     relax_maker2: Maker = field(default_factory=RelaxMaker)
 
-    def make(
-        self, structure: Structure, prev_cp2k_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Create a flow with two chained relaxations.
 
@@ -56,7 +54,7 @@ class DoubleRelaxMaker(Maker):
         ----------
         structure : .Structure
             A pymatgen structure object.
-        prev_cp2k_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous Cp2k calculation directory to copy output files from.
 
         Returns
@@ -64,11 +62,11 @@ class DoubleRelaxMaker(Maker):
         Flow
             A flow containing two relaxations.
         """
-        relax1 = self.relax_maker1.make(structure, prev_cp2k_dir=prev_cp2k_dir)
+        relax1 = self.relax_maker1.make(structure, prev_dir=prev_dir)
         relax1.name += " 1"
 
         relax2 = self.relax_maker2.make(
-            relax1.output.structure, prev_cp2k_dir=relax1.output.dir_name
+            relax1.output.structure, prev_dir=relax1.output.dir_name
         )
         relax2.name += " 2"
 
@@ -114,9 +112,7 @@ class BandStructureMaker(Maker):
     static_maker: Maker = field(default_factory=StaticMaker)
     bs_maker: Maker = field(default_factory=NonSCFMaker)
 
-    def make(
-        self, structure: Structure, prev_cp2k_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Create a band structure flow.
 
@@ -124,7 +120,7 @@ class BandStructureMaker(Maker):
         ----------
         structure : Structure
             A pymatgen structure object.
-        prev_cp2k_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -132,7 +128,7 @@ class BandStructureMaker(Maker):
         Flow
             A band structure flow.
         """
-        static_job = self.static_maker.make(structure, prev_cp2k_dir=prev_cp2k_dir)
+        static_job = self.static_maker.make(structure, prev_dir=prev_dir)
         jobs = [static_job]
 
         outputs = {}
@@ -140,7 +136,7 @@ class BandStructureMaker(Maker):
         if bandstructure_type in ("both", "uniform"):
             uniform_job = self.bs_maker.make(
                 static_job.output.structure,
-                prev_cp2k_dir=static_job.output.dir_name,
+                prev_dir=static_job.output.dir_name,
                 mode="uniform",
             )
             uniform_job.name += " uniform"
@@ -154,7 +150,7 @@ class BandStructureMaker(Maker):
         if bandstructure_type in ("both", "line"):
             line_job = self.bs_maker.make(
                 static_job.output.structure,
-                prev_cp2k_dir=static_job.output.dir_name,
+                prev_dir=static_job.output.dir_name,
                 mode="line",
             )
             line_job.name += " line"
@@ -192,9 +188,7 @@ class RelaxBandStructureMaker(Maker):
     relax_maker: Maker = field(default_factory=DoubleRelaxMaker)
     band_structure_maker: Maker = field(default_factory=BandStructureMaker)
 
-    def make(
-        self, structure: Structure, prev_cp2k_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Run a relaxation and then calculate the uniform and line mode band structures.
 
@@ -202,7 +196,7 @@ class RelaxBandStructureMaker(Maker):
         ----------
         structure: .Structure
             A pymatgen structure object.
-        prev_cp2k_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous CP2K calculation directory to copy output files from.
 
         Returns
@@ -210,9 +204,9 @@ class RelaxBandStructureMaker(Maker):
         Flow
             A relax and band structure flow.
         """
-        relax_job = self.relax_maker.make(structure, prev_cp2k_dir=prev_cp2k_dir)
+        relax_job = self.relax_maker.make(structure, prev_dir=prev_dir)
         bs_flow = self.band_structure_maker.make(
-            relax_job.output.structure, prev_cp2k_dir=relax_job.output.dir_name
+            relax_job.output.structure, prev_dir=relax_job.output.dir_name
         )
 
         return Flow([relax_job, bs_flow], bs_flow.output, name=self.name)
@@ -265,9 +259,7 @@ class HybridFlowMaker(Maker):
             updates, self.hybrid_maker.input_set_generator.user_input_settings
         )
 
-    def make(
-        self, structure: Structure, prev_cp2k_dir: str | Path | None = None
-    ) -> Job:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Job:
         """
         Make a hybrid flow.
 
@@ -275,7 +267,7 @@ class HybridFlowMaker(Maker):
         ----------
         structure: .Structure
             A pymatgen structure object.
-        prev_cp2k_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous CP2K calculation directory to copy output files from.
 
         Returns
@@ -285,13 +277,13 @@ class HybridFlowMaker(Maker):
         """
         jobs = []
         if self.initialize_with_pbe:
-            initialization = self.pbe_maker.make(structure, prev_cp2k_dir)
+            initialization = self.pbe_maker.make(structure, prev_dir)
             jobs.append(initialization)
         hyb = self.hybrid_maker.make(
             initialization.output.structure if self.initialize_with_pbe else structure,
-            prev_cp2k_dir=initialization.output.dir_name
+            prev_dir=initialization.output.dir_name
             if self.initialize_with_pbe
-            else prev_cp2k_dir,
+            else prev_dir,
         )
         jobs.append(hyb)
         return Flow(jobs, output=hyb.output, name=self.name)

--- a/src/atomate2/cp2k/jobs/base.py
+++ b/src/atomate2/cp2k/jobs/base.py
@@ -129,7 +129,7 @@ class BaseCp2kMaker(Maker):
 
     @cp2k_job
     def make(
-        self, structure: Structure, prev_cp2k_dir: str | Path | None = None
+        self, structure: Structure, prev_dir: str | Path | None = None
     ) -> Response:
         """
         Run a CP2K calculation.
@@ -155,9 +155,9 @@ class BaseCp2kMaker(Maker):
             self.write_additional_data.setdefault("transformations:json", t_json)
 
         # copy previous inputs
-        from_prev = prev_cp2k_dir is not None
-        if prev_cp2k_dir is not None:
-            copy_cp2k_outputs(prev_cp2k_dir, **self.copy_cp2k_kwargs)
+        from_prev = prev_dir is not None
+        if prev_dir is not None:
+            copy_cp2k_outputs(prev_dir, **self.copy_cp2k_kwargs)
 
         # write cp2k input files
         self.write_input_set_kwargs["from_prev"] = from_prev

--- a/src/atomate2/cp2k/jobs/base.py
+++ b/src/atomate2/cp2k/jobs/base.py
@@ -138,7 +138,7 @@ class BaseCp2kMaker(Maker):
         ----------
         structure : Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous CP2K calculation directory to copy output files from.
         """
         # Apply transformations if they are present

--- a/src/atomate2/cp2k/jobs/core.py
+++ b/src/atomate2/cp2k/jobs/core.py
@@ -300,7 +300,7 @@ class NonSCFMaker(BaseCp2kMaker):
     def make(
         self,
         structure: Structure,
-        prev_cp2k_dir: str | Path | None,
+        prev_dir: str | Path | None,
         mode: str = "uniform",
     ) -> None:
         """
@@ -325,7 +325,7 @@ class NonSCFMaker(BaseCp2kMaker):
         # copy previous inputs
         self.copy_cp2k_kwargs.setdefault("additional_cp2k_files", ("wfn",))
 
-        return super().make.original(self, structure, prev_cp2k_dir)
+        return super().make.original(self, structure, prev_dir)
 
 
 @dataclass
@@ -376,7 +376,7 @@ class TransmuterMaker(BaseCp2kMaker):
     def make(
         self,
         structure: Structure,
-        prev_cp2k_dir: str | Path | None = None,
+        prev_dir: str | Path | None = None,
     ) -> None:
         """
         Run a transmuter Cp2k job.
@@ -399,7 +399,7 @@ class TransmuterMaker(BaseCp2kMaker):
         tjson = transmuter.transformed_structures[-1]
         self.write_additional_data.setdefault("transformations:json", tjson)
 
-        return super().make.original(self, structure, prev_cp2k_dir)
+        return super().make.original(self, structure, prev_dir)
 
 
 @dataclass

--- a/src/atomate2/cp2k/jobs/core.py
+++ b/src/atomate2/cp2k/jobs/core.py
@@ -310,7 +310,7 @@ class NonSCFMaker(BaseCp2kMaker):
         ----------
         structure : .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous CP2K calculation directory to copy output files from.
         mode : str
             Type of band structure calculation. Options are:
@@ -385,7 +385,7 @@ class TransmuterMaker(BaseCp2kMaker):
         ----------
         structure : Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous Cp2k calculation directory to copy output files from.
         """
         transformations = get_transformations(

--- a/src/atomate2/forcefields/jobs.py
+++ b/src/atomate2/forcefields/jobs.py
@@ -51,14 +51,19 @@ class ForceFieldRelaxMaker(Maker):
     task_document_kwargs: dict = field(default_factory=dict)
 
     @job(output_schema=ForceFieldTaskDocument)
-    def make(self, structure: Structure) -> ForceFieldTaskDocument:
+    def make(
+        self, structure: Structure, prev_dir: str | Path | None = None
+    ) -> ForceFieldTaskDocument:
         """
         Perform a relaxation of a structure using a force field.
 
         Parameters
         ----------
         structure: .Structure
-             pymatgen structure.
+            pymatgen structure.
+        prev_dir : str or Path or None
+            A previous calculation directory to copy output files from. Unused, just
+                added to match the method signature of other makers.
         """
         if self.steps < 0:
             logger.warning(
@@ -102,7 +107,9 @@ class ForceFieldStaticMaker(ForceFieldRelaxMaker):
     task_document_kwargs: dict = field(default_factory=dict)
 
     @job(output_schema=ForceFieldTaskDocument)
-    def make(self, structure: Structure) -> ForceFieldTaskDocument:
+    def make(
+        self, structure: Structure, prev_dir: str | Path | None = None
+    ) -> ForceFieldTaskDocument:
         """
         Perform a static evaluation using a force field.
 
@@ -110,6 +117,9 @@ class ForceFieldStaticMaker(ForceFieldRelaxMaker):
         ----------
         structure: .Structure
             pymatgen structure.
+        prev_dir : str or Path or None
+            A previous calculation directory to copy output files from. Unused, just
+                added to match the method signature of other makers.
         """
         if self.steps < 0:
             logger.warning(
@@ -240,11 +250,7 @@ class M3GNetRelaxMaker(ForceFieldRelaxMaker):
             **self.optimizer_kwargs,
         )
 
-        return relaxer.relax(
-            structure,
-            steps=self.steps,
-            **self.relax_kwargs,
-        )
+        return relaxer.relax(structure, steps=self.steps, **self.relax_kwargs)
 
 
 @dataclass
@@ -279,10 +285,7 @@ class M3GNetStaticMaker(ForceFieldStaticMaker):
             relax_cell=False,
         )
 
-        return relaxer.relax(
-            structure,
-            steps=1,
-        )
+        return relaxer.relax(structure, steps=1)
 
 
 @dataclass

--- a/src/atomate2/vasp/flows/amset.py
+++ b/src/atomate2/vasp/flows/amset.py
@@ -86,7 +86,7 @@ class DeformationPotentialMaker(Maker):
     def make(
         self,
         structure: Structure,
-        prev_vasp_dir: str | Path | None = None,
+        prev_dir: str | Path | None = None,
         ibands: tuple[list[int], list[int]] = None,
     ) -> Flow:
         """
@@ -96,16 +96,14 @@ class DeformationPotentialMaker(Maker):
         ----------
         structure : .Structure
             A pymatgen structure.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous vasp calculation directory to use for copying outputs.
         ibands : tuple of list of int
             Which bands to include in the deformation.h5 file. Given as a tuple of one
             or two lists (one for each spin channel). The bands indices are zero
             indexed.
         """
-        bulk = self.static_deformation_maker.make(
-            structure, prev_vasp_dir=prev_vasp_dir
-        )
+        bulk = self.static_deformation_maker.make(structure, prev_dir=prev_dir)
         bulk.append_name("bulk ", prepend=True)
 
         # all deformation calculations need to be on the same k-point mesh, to achieve
@@ -118,7 +116,7 @@ class DeformationPotentialMaker(Maker):
         vasp_deformation_calcs = run_amset_deformations(
             bulk.output.structure,
             symprec=self.symprec,
-            prev_vasp_dir=bulk.output.dir_name,
+            prev_dir=bulk.output.dir_name,
             static_deformation_maker=self.static_deformation_maker,
         )
 
@@ -205,7 +203,7 @@ class VaspAmsetMaker(Maker):
     def make(
         self,
         structure: Structure,
-        prev_vasp_dir: str | Path | None = None,
+        prev_dir: str | Path | None = None,
     ) -> Flow:
         """
         Make flow to calculate electronic transport properties using AMSET and VASP.
@@ -214,23 +212,23 @@ class VaspAmsetMaker(Maker):
         ----------
         structure : .Structure
             A pymatgen structure.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous vasp calculation directory to use for copying outputs.
         """
         jobs = []
 
         if self.relax_maker is not None:
             # optionally relax the structure
-            bulk = self.relax_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+            bulk = self.relax_maker.make(structure, prev_dir=prev_dir)
             jobs.append(bulk)
             structure = bulk.output.structure
-            prev_vasp_dir = bulk.output.dir_name
+            prev_dir = bulk.output.dir_name
 
-        static = self.static_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+        static = self.static_maker.make(structure, prev_dir=prev_dir)
 
         # dense band structure for eigenvalues and wave functions
         dense_bs = self.dense_uniform_maker.make(
-            static.output.structure, prev_vasp_dir=static.output.dir_name
+            static.output.structure, prev_dir=static.output.dir_name
         )
 
         # elastic constant
@@ -242,7 +240,7 @@ class VaspAmsetMaker(Maker):
 
         # dielectric constant
         dielectric = self.dielectric_maker.make(
-            static.output.structure, prev_vasp_dir=static.output.dir_name
+            static.output.structure, prev_dir=static.output.dir_name
         )
 
         # polar phonon frequency
@@ -259,7 +257,7 @@ class VaspAmsetMaker(Maker):
         # deformation potentials
         deformation = self.deformation_potential_maker.make(
             static.output.structure,
-            prev_vasp_dir=static.output.dir_name,
+            prev_dir=static.output.dir_name,
             ibands=wavefunction.output["ibands"],
         )
 
@@ -303,7 +301,7 @@ class VaspAmsetMaker(Maker):
         if self.use_hse_gap and "bandgap" not in self.amset_settings:
             gap = self.hse_gap_maker.make(
                 dense_bs.output.structure,
-                prev_vasp_dir=dense_bs.output.dir_name,
+                prev_dir=dense_bs.output.dir_name,
                 mode="gap",
             )
             settings["bandgap"] = gap.output.output.bandgap
@@ -387,7 +385,7 @@ class HSEVaspAmsetMaker(Maker):
     def make(
         self,
         structure: Structure,
-        prev_vasp_dir: str | Path | None = None,
+        prev_dir: str | Path | None = None,
     ) -> Flow:
         """
         Make flow to calculate electronic transport properties using AMSET and VASP.
@@ -396,23 +394,23 @@ class HSEVaspAmsetMaker(Maker):
         ----------
         structure : Structure
             A pymatgen structure.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous vasp calculation directory to use for copying outputs.
         """
         jobs = []
 
         if self.relax_maker is not None:
             # optionally relax the structure
-            bulk = self.relax_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+            bulk = self.relax_maker.make(structure, prev_dir=prev_dir)
             jobs.append(bulk)
             structure = bulk.output.structure
-            prev_vasp_dir = bulk.output.dir_name
+            prev_dir = bulk.output.dir_name
 
-        static = self.static_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+        static = self.static_maker.make(structure, prev_dir=prev_dir)
 
         # dense band structure for eigenvalues and wave functions
         dense_bs = self.dense_uniform_maker.make(
-            static.output.structure, prev_vasp_dir=static.output.dir_name
+            static.output.structure, prev_dir=static.output.dir_name
         )
 
         # elastic constant
@@ -424,7 +422,7 @@ class HSEVaspAmsetMaker(Maker):
 
         # dielectric constant
         dielectric = self.dielectric_maker.make(
-            static.output.structure, prev_vasp_dir=static.output.dir_name
+            static.output.structure, prev_dir=static.output.dir_name
         )
 
         # polar phonon frequency
@@ -441,7 +439,7 @@ class HSEVaspAmsetMaker(Maker):
         # deformation potentials
         deformation = self.deformation_potential_maker.make(
             static.output.structure,
-            prev_vasp_dir=static.output.dir_name,
+            prev_dir=static.output.dir_name,
             ibands=wavefunction.output["ibands"],
         )
 

--- a/src/atomate2/vasp/flows/core.py
+++ b/src/atomate2/vasp/flows/core.py
@@ -46,9 +46,7 @@ class DoubleRelaxMaker(Maker):
     relax_maker1: BaseVaspMaker | None = field(default_factory=RelaxMaker)
     relax_maker2: BaseVaspMaker = field(default_factory=RelaxMaker)
 
-    def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Create a flow with two chained relaxations.
 
@@ -56,7 +54,7 @@ class DoubleRelaxMaker(Maker):
         ----------
         structure : .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -67,13 +65,13 @@ class DoubleRelaxMaker(Maker):
         jobs: list[Job] = []
         if self.relax_maker1:
             # Run a pre-relaxation
-            relax1 = self.relax_maker1.make(structure, prev_vasp_dir=prev_vasp_dir)
+            relax1 = self.relax_maker1.make(structure, prev_dir=prev_dir)
             relax1.name += " 1"
             jobs += [relax1]
             structure = relax1.output.structure
-            prev_vasp_dir = relax1.output.dir_name
+            prev_dir = relax1.output.dir_name
 
-        relax2 = self.relax_maker2.make(structure, prev_vasp_dir=prev_vasp_dir)
+        relax2 = self.relax_maker2.make(structure, prev_dir=prev_dir)
         relax2.name += " 2"
         jobs += [relax2]
 
@@ -119,9 +117,7 @@ class BandStructureMaker(Maker):
     static_maker: BaseVaspMaker = field(default_factory=StaticMaker)
     bs_maker: BaseVaspMaker = field(default_factory=NonSCFMaker)
 
-    def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Create a band structure flow.
 
@@ -129,7 +125,7 @@ class BandStructureMaker(Maker):
         ----------
         structure : Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -137,7 +133,7 @@ class BandStructureMaker(Maker):
         Flow
             A band structure flow.
         """
-        static_job = self.static_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+        static_job = self.static_maker.make(structure, prev_dir=prev_dir)
         jobs = [static_job]
 
         outputs = {}
@@ -145,7 +141,7 @@ class BandStructureMaker(Maker):
         if bandstructure_type in ("both", "uniform"):
             uniform_job = self.bs_maker.make(
                 static_job.output.structure,
-                prev_vasp_dir=static_job.output.dir_name,
+                prev_dir=static_job.output.dir_name,
                 mode="uniform",
             )
             uniform_job.name += " uniform"
@@ -159,7 +155,7 @@ class BandStructureMaker(Maker):
         if bandstructure_type in ("both", "line"):
             line_job = self.bs_maker.make(
                 static_job.output.structure,
-                prev_vasp_dir=static_job.output.dir_name,
+                prev_dir=static_job.output.dir_name,
                 mode="line",
             )
             line_job.name += " line"
@@ -198,9 +194,7 @@ class UniformBandStructureMaker(Maker):
     static_maker: BaseVaspMaker = field(default_factory=StaticMaker)
     bs_maker: BaseVaspMaker = field(default_factory=NonSCFMaker)
 
-    def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Create a uniform band structure flow.
 
@@ -208,7 +202,7 @@ class UniformBandStructureMaker(Maker):
         ----------
         structure : Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -216,10 +210,10 @@ class UniformBandStructureMaker(Maker):
         Flow
             A uniform band structure flow.
         """
-        static_job = self.static_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+        static_job = self.static_maker.make(structure, prev_dir=prev_dir)
         uniform_job = self.bs_maker.make(
             static_job.output.structure,
-            prev_vasp_dir=static_job.output.dir_name,
+            prev_dir=static_job.output.dir_name,
             mode="uniform",
         )
         uniform_job.name += " uniform"
@@ -249,9 +243,7 @@ class LineModeBandStructureMaker(Maker):
     static_maker: BaseVaspMaker = field(default_factory=StaticMaker)
     bs_maker: BaseVaspMaker = field(default_factory=NonSCFMaker)
 
-    def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Create a line mode band structure flow.
 
@@ -259,7 +251,7 @@ class LineModeBandStructureMaker(Maker):
         ----------
         structure : Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -267,10 +259,10 @@ class LineModeBandStructureMaker(Maker):
         Flow
             A line mode band structure flow.
         """
-        static_job = self.static_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+        static_job = self.static_maker.make(structure, prev_dir=prev_dir)
         line_job = self.bs_maker.make(
             static_job.output.structure,
-            prev_vasp_dir=static_job.output.dir_name,
+            prev_dir=static_job.output.dir_name,
             mode="line",
         )
         line_job.name += " line"
@@ -369,9 +361,7 @@ class RelaxBandStructureMaker(Maker):
     relax_maker: BaseVaspMaker = field(default_factory=DoubleRelaxMaker)
     band_structure_maker: BaseVaspMaker = field(default_factory=BandStructureMaker)
 
-    def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Run a relaxation and then calculate the uniform and line mode band structures.
 
@@ -379,7 +369,7 @@ class RelaxBandStructureMaker(Maker):
         ----------
         structure: .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -387,9 +377,9 @@ class RelaxBandStructureMaker(Maker):
         Flow
             A relax and band structure flow.
         """
-        relax_job = self.relax_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+        relax_job = self.relax_maker.make(structure, prev_dir=prev_dir)
         bs_flow = self.band_structure_maker.make(
-            relax_job.output.structure, prev_vasp_dir=relax_job.output.dir_name
+            relax_job.output.structure, prev_dir=relax_job.output.dir_name
         )
 
         return Flow([relax_job, bs_flow], bs_flow.output, name=self.name)
@@ -429,9 +419,7 @@ class OpticsMaker(Maker):
         )
     )
 
-    def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Run a static and then a non-scf optics calculation.
 
@@ -439,7 +427,7 @@ class OpticsMaker(Maker):
         ----------
         structure: .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -447,9 +435,9 @@ class OpticsMaker(Maker):
         Flow
             A static and nscf with optics flow.
         """
-        static_job = self.static_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+        static_job = self.static_maker.make(structure, prev_dir=prev_dir)
         nscf_job = self.band_structure_maker.make(
-            static_job.output.structure, prev_vasp_dir=static_job.output.dir_name
+            static_job.output.structure, prev_dir=static_job.output.dir_name
         )
         return Flow([static_job, nscf_job], nscf_job.output, name=self.name)
 
@@ -488,9 +476,7 @@ class HSEOpticsMaker(Maker):
         )
     )
 
-    def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Run a static and then a non-scf optics calculation.
 
@@ -498,7 +484,7 @@ class HSEOpticsMaker(Maker):
         ----------
         structure: .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -506,8 +492,8 @@ class HSEOpticsMaker(Maker):
         Flow
             A static and nscf with optics flow.
         """
-        static_job = self.static_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+        static_job = self.static_maker.make(structure, prev_dir=prev_dir)
         bs_job = self.band_structure_maker.make(
-            static_job.output.structure, prev_vasp_dir=static_job.output.dir_name
+            static_job.output.structure, prev_dir=static_job.output.dir_name
         )
         return Flow([static_job, bs_job], bs_job.output, name=self.name)

--- a/src/atomate2/vasp/flows/elastic.py
+++ b/src/atomate2/vasp/flows/elastic.py
@@ -79,4 +79,4 @@ class ElasticMaker(BaseElasticMaker):
         Note: this is only applicable if a relax_maker is specified; i.e., two
         calculations are performed for each ordering (relax -> static)
         """
-        return "prev_vasp_dir"
+        return "prev_dir"

--- a/src/atomate2/vasp/flows/lobster.py
+++ b/src/atomate2/vasp/flows/lobster.py
@@ -104,7 +104,7 @@ class VaspLobsterMaker(Maker):
     def make(
         self,
         structure: Structure,
-        prev_vasp_dir: str | Path | None = None,
+        prev_dir: str | Path | None = None,
     ) -> Flow:
         """
         Make flow to calculate bonding properties.
@@ -115,7 +115,7 @@ class VaspLobsterMaker(Maker):
             A pymatgen structure. Please start with a structure
             that is nearly fully optimized as the internal optimizers
             have very strict settings!
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous vasp calculation directory to use for copying outputs.
         """
         jobs = []
@@ -124,12 +124,12 @@ class VaspLobsterMaker(Maker):
         optimization_dir = None
         optimization_uuid = None
         if self.relax_maker is not None:
-            optimization = self.relax_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+            optimization = self.relax_maker.make(structure, prev_dir=prev_dir)
             jobs.append(optimization)
             structure = optimization.output.structure
             optimization_dir = optimization.output.dir_name
             optimization_uuid = optimization.output.uuid
-            prev_vasp_dir = optimization_dir
+            prev_dir = optimization_dir
 
         # Information about the basis is collected
         basis_infos = get_basis_infos(
@@ -146,7 +146,7 @@ class VaspLobsterMaker(Maker):
             self.lobster_static_maker,
             basis_infos.output["nbands"],
             structure,
-            prev_vasp_dir,
+            prev_dir,
         )
         jobs.append(lobster_static)
         lobster_static_dir = lobster_static.output.dir_name

--- a/src/atomate2/vasp/flows/matpes.py
+++ b/src/atomate2/vasp/flows/matpes.py
@@ -46,7 +46,7 @@ class MatPesGGAPlusMetaGGAStaticMaker(Maker):
         )
     )
 
-    def make(self, structure: Structure, prev_vasp_dir: str | Path | None = None):
+    def make(self, structure: Structure, prev_dir: str | Path | None = None):
         """
         Create a flow with two chained statics.
 
@@ -54,7 +54,7 @@ class MatPesGGAPlusMetaGGAStaticMaker(Maker):
         ----------
         structure : .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -62,7 +62,7 @@ class MatPesGGAPlusMetaGGAStaticMaker(Maker):
         Flow
             A flow containing two statics.
         """
-        static1 = self.static1.make(structure, prev_vasp_dir=prev_vasp_dir)
-        static2 = self.static2.make(structure, prev_vasp_dir=static1.output.dir_name)
+        static1 = self.static1.make(structure, prev_dir=prev_dir)
+        static2 = self.static2.make(structure, prev_dir=static1.output.dir_name)
         output = {"static1": static1.output, "static2": static2.output}
         return Flow([static1, static2], output=output, name=self.name)

--- a/src/atomate2/vasp/flows/mp.py
+++ b/src/atomate2/vasp/flows/mp.py
@@ -100,9 +100,7 @@ class MPGGADoubleRelaxStaticMaker(Maker):
         )
     )
 
-    def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         1, 2 or 3-step flow with optional pre-relax and final static jobs.
 
@@ -110,7 +108,7 @@ class MPGGADoubleRelaxStaticMaker(Maker):
         ----------
         structure : .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -120,16 +118,14 @@ class MPGGADoubleRelaxStaticMaker(Maker):
         """
         jobs: list[Job] = []
 
-        relax_flow = self.relax_maker.make(
-            structure=structure, prev_vasp_dir=prev_vasp_dir
-        )
+        relax_flow = self.relax_maker.make(structure=structure, prev_dir=prev_dir)
         output = relax_flow.output
         jobs += [relax_flow]
 
         if self.static_maker:
             # Run a static calculation
             static_job = self.static_maker.make(
-                structure=output.structure, prev_vasp_dir=output.dir_name
+                structure=output.structure, prev_dir=output.dir_name
             )
             output = static_job.output
             jobs += [static_job]
@@ -162,9 +158,7 @@ class MPMetaGGADoubleRelaxStaticMaker(MPGGADoubleRelaxMaker):
         )
     )
 
-    def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
-    ) -> Flow:
+    def make(self, structure: Structure, prev_dir: str | Path | None = None) -> Flow:
         """
         Create a 2-step flow with a cheap pre-relaxation followed by a high-quality one.
 
@@ -174,7 +168,7 @@ class MPMetaGGADoubleRelaxStaticMaker(MPGGADoubleRelaxMaker):
         ----------
         structure : .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -184,15 +178,13 @@ class MPMetaGGADoubleRelaxStaticMaker(MPGGADoubleRelaxMaker):
         """
         jobs: list[Job] = []
 
-        relax_flow = self.relax_maker.make(
-            structure=structure, prev_vasp_dir=prev_vasp_dir
-        )
+        relax_flow = self.relax_maker.make(structure=structure, prev_dir=prev_dir)
         output = relax_flow.output
         jobs += [relax_flow]
         if self.static_maker:
             # Run a static calculation (typically r2SCAN)
             static_job = self.static_maker.make(
-                structure=output.structure, prev_vasp_dir=output.dir_name
+                structure=output.structure, prev_dir=output.dir_name
             )
             output = static_job.output
             jobs += [static_job]

--- a/src/atomate2/vasp/flows/phonons.py
+++ b/src/atomate2/vasp/flows/phonons.py
@@ -153,7 +153,7 @@ class PhononMaker(Maker):
     def make(
         self,
         structure: Structure,
-        prev_vasp_dir: str | Path | None = None,
+        prev_dir: str | Path | None = None,
         born: list[Matrix3D] | None = None,
         epsilon_static: Matrix3D | None = None,
         total_dft_energy_per_formula_unit: float | None = None,
@@ -167,7 +167,7 @@ class PhononMaker(Maker):
         structure : .Structure
             A pymatgen structure. Please start with a structure that is nearly fully
             optimized as the internal optimizers have very strict settings!
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous vasp calculation directory to use for copying outputs.
         born: Matrix3D
             Instead of recomputing born charges and epsilon, these values can also be
@@ -233,10 +233,10 @@ class PhononMaker(Maker):
         optimization_run_uuid = None
         if self.bulk_relax_maker is not None:
             # optionally relax the structure
-            bulk = self.bulk_relax_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+            bulk = self.bulk_relax_maker.make(structure, prev_dir=prev_dir)
             jobs.append(bulk)
             structure = bulk.output.structure
-            prev_vasp_dir = bulk.output.dir_name
+            prev_dir = bulk.output.dir_name
             optimization_run_job_dir = bulk.output.dir_name
             optimization_run_uuid = bulk.output.uuid
 
@@ -260,13 +260,13 @@ class PhononMaker(Maker):
             total_dft_energy_per_formula_unit is None
         ):
             static_job = self.static_energy_maker.make(
-                structure=structure, prev_vasp_dir=prev_vasp_dir
+                structure=structure, prev_dir=prev_dir
             )
             jobs.append(static_job)
             total_dft_energy = static_job.output.output.energy
             static_run_job_dir = static_job.output.dir_name
             static_run_uuid = static_job.output.uuid
-            prev_vasp_dir = static_job.output.dir_name
+            prev_dir = static_job.output.dir_name
         elif total_dft_energy_per_formula_unit is not None:
             # to make sure that one can reuse results from Doc
             compute_total_energy_job = get_total_energy_per_cell(
@@ -294,7 +294,7 @@ class PhononMaker(Maker):
             structure=structure,
             supercell_matrix=supercell_matrix,
             phonon_maker=self.phonon_displacement_maker,
-            prev_vasp_dir=prev_vasp_dir,
+            prev_dir=prev_dir,
         )
         jobs.append(vasp_displacement_calcs)
 
@@ -302,7 +302,7 @@ class PhononMaker(Maker):
         born_run_job_dir = None
         born_run_uuid = None
         if self.born_maker is not None and (born is None or epsilon_static is None):
-            born_job = self.born_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+            born_job = self.born_maker.make(structure, prev_dir=prev_dir)
             jobs.append(born_job)
 
             # I am not happy how we currently access "born" charges

--- a/src/atomate2/vasp/jobs/amset.py
+++ b/src/atomate2/vasp/jobs/amset.py
@@ -200,7 +200,7 @@ class HSEDenseUniformMaker(HSEBSMaker):
 def run_amset_deformations(
     structure: Structure,
     symprec: float = SETTINGS.SYMPREC,
-    prev_vasp_dir: str | Path | None = None,
+    prev_dir: str | Path | None = None,
     static_deformation_maker: BaseVaspMaker | None = None,
 ) -> Response:
     """
@@ -216,7 +216,7 @@ def run_amset_deformations(
     symprec : float
         Symmetry precision used to reduce the number of deformations. Set to None for
         no symmetry reduction.
-    prev_vasp_dir : str or Path or None
+    prev_dir : str or Path or None
         A previous VASP directory to use for copying VASP outputs.
     static_deformation_maker : .BaseVaspMaker or None
         A VaspMaker to use to generate the static deformation jobs.
@@ -244,7 +244,7 @@ def run_amset_deformations(
 
         # create the job
         static_job = static_deformation_maker.make(
-            deformed_structure, prev_vasp_dir=prev_vasp_dir
+            deformed_structure, prev_dir=prev_dir
         )
         static_job.append_name(f" {i + 1}/{len(deformations)}")
         statics.append(static_job)

--- a/src/atomate2/vasp/jobs/base.py
+++ b/src/atomate2/vasp/jobs/base.py
@@ -182,7 +182,7 @@ class BaseVaspMaker(Maker):
 
     @vasp_job
     def make(
-        self, structure: Structure, prev_vasp_dir: str | Path | None = None
+        self, structure: Structure, prev_dir: str | Path | None = None
     ) -> Response:
         """
         Run a VASP calculation.
@@ -191,7 +191,7 @@ class BaseVaspMaker(Maker):
         ----------
         structure : Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
 
         Returns
@@ -200,9 +200,9 @@ class BaseVaspMaker(Maker):
                 commands of the VASP run.
         """
         # copy previous inputs
-        from_prev = prev_vasp_dir is not None
-        if prev_vasp_dir is not None:
-            copy_vasp_outputs(prev_vasp_dir, **self.copy_vasp_kwargs)
+        from_prev = prev_dir is not None
+        if prev_dir is not None:
+            copy_vasp_outputs(prev_dir, **self.copy_vasp_kwargs)
 
         self.write_input_set_kwargs.setdefault("from_prev", from_prev)
 

--- a/src/atomate2/vasp/jobs/core.py
+++ b/src/atomate2/vasp/jobs/core.py
@@ -181,7 +181,7 @@ class NonSCFMaker(BaseVaspMaker):
     def make(
         self,
         structure: Structure,
-        prev_vasp_dir: str | Path | None,
+        prev_dir: str | Path | None,
         mode: str = "uniform",
     ) -> Response:
         """
@@ -191,7 +191,7 @@ class NonSCFMaker(BaseVaspMaker):
         ----------
         structure : .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
         mode : str
             Type of band structure calculation. Options are:
@@ -206,7 +206,7 @@ class NonSCFMaker(BaseVaspMaker):
         # copy previous inputs
         self.copy_vasp_kwargs.setdefault("additional_vasp_files", ("CHGCAR",))
 
-        return super().make.original(self, structure, prev_vasp_dir)
+        return super().make.original(self, structure, prev_dir)
 
 
 @dataclass
@@ -355,7 +355,7 @@ class HSEBSMaker(BaseVaspMaker):
     def make(
         self,
         structure: Structure,
-        prev_vasp_dir: str | Path | None = None,
+        prev_dir: str | Path | None = None,
         mode="uniform",
     ) -> Response:
         """
@@ -365,7 +365,7 @@ class HSEBSMaker(BaseVaspMaker):
         ----------
         structure : .Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
         mode : str
             Type of band structure calculation. Options are:
@@ -375,7 +375,7 @@ class HSEBSMaker(BaseVaspMaker):
         """
         self.input_set_generator.mode = mode
 
-        if mode == "gap" and prev_vasp_dir is None:
+        if mode == "gap" and prev_dir is None:
             logger.warning(
                 "HSE band structure in 'gap' mode requires a previous VASP calculation "
                 "directory from which to extract the VBM and CBM k-points. This "
@@ -390,10 +390,10 @@ class HSEBSMaker(BaseVaspMaker):
         self.task_document_kwargs.setdefault("parse_bandstructure", parse_bandstructure)
 
         # copy previous inputs
-        if prev_vasp_dir is not None:
+        if prev_dir is not None:
             self.copy_vasp_kwargs.setdefault("additional_vasp_files", ("CHGCAR",))
 
-        return super().make.original(self, structure, prev_vasp_dir)
+        return super().make.original(self, structure, prev_dir)
 
 
 @dataclass
@@ -487,7 +487,7 @@ class TransmuterMaker(BaseVaspMaker):
     def make(
         self,
         structure: Structure,
-        prev_vasp_dir: str | Path | None = None,
+        prev_dir: str | Path | None = None,
     ) -> Response:
         """
         Run a transmuter VASP job.
@@ -496,7 +496,7 @@ class TransmuterMaker(BaseVaspMaker):
         ----------
         structure : Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
         """
         transformations = get_transformations(
@@ -510,7 +510,7 @@ class TransmuterMaker(BaseVaspMaker):
         tjson = transmuter.transformed_structures[-1]
         self.write_additional_data.setdefault("transformations:json", tjson)
 
-        return super().make.original(self, structure, prev_vasp_dir)
+        return super().make.original(self, structure, prev_dir)
 
 
 @dataclass

--- a/src/atomate2/vasp/jobs/elph.py
+++ b/src/atomate2/vasp/jobs/elph.py
@@ -89,7 +89,7 @@ class SupercellElectronPhononDisplacedStructureMaker(TransmuterMaker):
     def make(
         self,
         structure: Structure,
-        prev_vasp_dir: str | Path | None = None,
+        prev_dir: str | Path | None = None,
     ) -> Response:
         """
         Run a transmuter VASP job.
@@ -98,7 +98,7 @@ class SupercellElectronPhononDisplacedStructureMaker(TransmuterMaker):
         ----------
         structure : Structure
             A pymatgen structure object.
-        prev_vasp_dir : str or Path or None
+        prev_dir : str or Path or None
             A previous VASP calculation directory to copy output files from.
         """
         dim = self.min_supercell_length / np.array(structure.lattice.abc)
@@ -110,7 +110,7 @@ class SupercellElectronPhononDisplacedStructureMaker(TransmuterMaker):
         # update temperatures
         self.input_set_generator.temperatures = self.temperatures
 
-        return super().make.original(self, structure, prev_vasp_dir)
+        return super().make.original(self, structure, prev_dir)
 
 
 @job
@@ -118,7 +118,7 @@ def run_elph_displacements(
     temperatures: list[float],
     structures: list[Structure],
     vasp_maker: BaseVaspMaker,
-    prev_vasp_dir: str | Path | None = None,
+    prev_dir: str | Path | None = None,
     original_structure: Structure = None,
     supercell_structure: Structure = None,
 ) -> Response:
@@ -135,7 +135,7 @@ def run_elph_displacements(
         Electron phonon displaced structures for each temperature.
     vasp_maker : BaseVaspMaker
         A maker to generate VASP calculations on the displaced structures.
-    prev_vasp_dir : str or Path or None
+    prev_dir : str or Path or None
         A previous VASP directory to use for copying VASP outputs.
     original_structure : Structure
         The original structure before supercell is made and before electron phonon
@@ -157,7 +157,7 @@ def run_elph_displacements(
     }
     for temp, structure in zip(temperatures, structures):
         # create the job
-        elph_job = vasp_maker.make(structure, prev_vasp_dir=prev_vasp_dir)
+        elph_job = vasp_maker.make(structure, prev_dir=prev_dir)
         elph_job.append_name(f" T={temp}")
 
         # write details of the electron phonon temperature and structure elph_info.json

--- a/src/atomate2/vasp/jobs/lobster.py
+++ b/src/atomate2/vasp/jobs/lobster.py
@@ -135,7 +135,7 @@ def update_user_incar_settings_maker(
     vasp_maker: BaseVaspMaker,
     nbands: int,
     structure: Structure,
-    prev_vasp_dir: Path | str,
+    prev_dir: Path | str,
 ) -> Response:
     """
     Update the INCAR settings of a maker.
@@ -149,7 +149,7 @@ def update_user_incar_settings_maker(
         integer indicating the correct number of bands
     structure : .Structure
         Structure object.
-    prev_vasp_dir : Path or str
+    prev_dir : Path or str
         Path or string to vasp files.
 
     Returns
@@ -158,7 +158,7 @@ def update_user_incar_settings_maker(
         LobsterStaticMaker with correct number of bands.
     """
     vasp_maker = update_user_incar_settings(vasp_maker, {"NBANDS": nbands})
-    vasp_job = vasp_maker.make(structure=structure, prev_vasp_dir=prev_vasp_dir)
+    vasp_job = vasp_maker.make(structure=structure, prev_dir=prev_dir)
     return Response(replace=vasp_job)
 
 


### PR DESCRIPTION
As discussed in today's `atomate2` maintainer meeting, it would be great to unify the API between `Makers` for different codes and forcefields to more easily swap, say, a PBEsol pre-relax maker for a forcefield pre-relax maker and not have to worry about the flow that stitches the makers together passing in an unrecognized keyword like `prev_vasp_dir` into the forcefield maker.