### PR TITLE
Test MP + MatPES set generators

### DIFF
--- a/src/atomate2/vasp/sets/mp.py
+++ b/src/atomate2/vasp/sets/mp.py
@@ -88,6 +88,7 @@ class MPMetaGGAStaticSetGenerator(StaticSetGenerator):
 
     config_dict: dict = field(default_factory=lambda: _BASE_MP_R2SCAN_RELAX_SET)
     auto_kspacing: bool = True
+    bandgap_tol: float = 1e-4
 
     def get_incar_updates(
         self,

--- a/tests/common/schemas/test_cclib.py
+++ b/tests/common/schemas/test_cclib.py
@@ -36,15 +36,15 @@ def test_cclib_taskdoc(test_dir):
     assert doc["molecule"][0].coords == pytest.approx([0.397382, 0.0, 0.0])
     assert doc["last_updated"] is not None
     assert doc["attributes"]["homo_energies"] == pytest.approx(
-        [-7.054007346511501, -11.618445074798501]
+        [-7.05400734, -11.61844507]
     )
     assert doc["attributes"]["lumo_energies"] == pytest.approx(
-        [4.2384453353880005, -3.9423854660440005]
+        [4.23844533, -3.94238546]
     )
     assert doc["attributes"]["homo_lumo_gaps"] == pytest.approx(
-        [11.292452681899501, 7.6760596087545006]
+        [11.29245268, 7.67605960]
     )
-    assert doc["attributes"]["min_homo_lumo_gap"] == pytest.approx(7.6760596087545006)
+    assert doc["attributes"]["min_homo_lumo_gap"] == pytest.approx(7.67605960)
 
     # Now we will try two possible extensions, but we will make sure that
     # it fails because the newest log file (.txt) is not valid

--- a/tests/cp2k/jobs/test_core.py
+++ b/tests/cp2k/jobs/test_core.py
@@ -32,7 +32,7 @@ def test_static_maker(tmp_path, mock_cp2k, si_structure, basis_and_potential):
     # validate job outputs
     output1 = responses[job.uuid][1].output
     assert isinstance(output1, TaskDocument)
-    assert output1.output.energy == approx(-214.23651374775685)
+    assert output1.output.energy == approx(-214.23651374)
 
 
 def test_relax_maker(tmp_path, mock_cp2k, basis_and_potential, si_structure):
@@ -66,7 +66,7 @@ def test_relax_maker(tmp_path, mock_cp2k, basis_and_potential, si_structure):
     # validate job outputs
     output1 = responses[job.uuid][1].output
     assert isinstance(output1, TaskDocument)
-    assert output1.output.energy == approx(-193.39161102270234)
+    assert output1.output.energy == approx(-193.39161102)
     assert len(output1.calcs_reversed[0].output.ionic_steps) == 1
     assert output1.calcs_reversed[0].output.structure.lattice.abc == approx(
         si_structure.lattice.abc
@@ -106,7 +106,7 @@ def test_transmuter(tmp_path, mock_cp2k, basis_and_potential, si_structure):
     # validate outputs
     output1 = responses[job.uuid][1].output
     assert isinstance(output1, TaskDocument)
-    assert output1.output.energy == approx(-404.0823179177859)
+    assert output1.output.energy == approx(-404.08231791)
     assert output1.transformations["history"][0]["scaling_matrix"] == [
         [1, 0, 0],
         [0, 1, 0],

--- a/tests/forcefields/flows/test_elastic.py
+++ b/tests/forcefields/flows/test_elastic.py
@@ -24,7 +24,5 @@ def test_elastic_wf(clean_dir, si_structure):
     elastic_output = responses[job.jobs[-1].uuid][1].output
     assert isinstance(elastic_output, ElasticDocument)
     assert_allclose(elastic_output.derived_properties.k_voigt, 118.26914, atol=1e-1)
-    assert_allclose(
-        elastic_output.derived_properties.g_voigt, 17.327374125417816, atol=1e-1
-    )
+    assert_allclose(elastic_output.derived_properties.g_voigt, 17.32737412, atol=1e-1)
     assert elastic_output.chemsys == "Si"

--- a/tests/forcefields/flows/test_phonon.py
+++ b/tests/forcefields/flows/test_phonon.py
@@ -55,7 +55,7 @@ def test_phonon_wf(clean_dir):
     assert isinstance(responses[job.jobs[-1].uuid][1].output.jobdirs, PhononJobDirs)
     assert isinstance(responses[job.jobs[-1].uuid][1].output.uuids, PhononUUIDs)
     assert_allclose(
-        responses[job.jobs[-1].uuid][1].output.total_dft_energy, -5.372457981109619, 4
+        responses[job.jobs[-1].uuid][1].output.total_dft_energy, -5.37245798, 4
     )
     assert responses[job.jobs[-1].uuid][1].output.born is None
     assert responses[job.jobs[-1].uuid][1].output.epsilon_static is None
@@ -84,12 +84,12 @@ def test_phonon_wf(clean_dir):
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
-        [0.0, 4.7839398173, 13.993186953, 21.886413347, 28.191106671],
+        [0.0, 4.78393981, 13.99318695, 21.88641334, 28.19110667],
         atol=2,
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
-        [0.0, 8.8606058656, 17.557589434, 21.089039169, 22.625872713],
+        [0.0, 8.86060586, 17.55758943, 21.08903916, 22.62587271],
         atol=2,
     )
     assert_allclose(

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -44,7 +44,7 @@ def test_chgnet_relax_maker(si_structure):
     output1 = responses[job.uuid][1].output
     assert isinstance(output1, ForceFieldTaskDocument)
     assert output1.output.energy == approx(-10.6274, rel=1e-4)
-    assert output1.output.ionic_steps[-1].magmoms[0] == approx(0.003035724, rel=1e-4)
+    assert output1.output.ionic_steps[-1].magmoms[0] == approx(0.00303572, rel=1e-4)
     assert output1.output.n_steps >= 12
 
 

--- a/tests/vasp/flows/test_phonons.py
+++ b/tests/vasp/flows/test_phonons.py
@@ -58,7 +58,7 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
-        [5774.60355377, 5616.33406091, 4724.76619808, 3044.20807258, 696.337319349],
+        [5774.60355377, 5616.33406091, 4724.76619808, 3044.20807258, 696.33731934],
     )
 
     assert isinstance(
@@ -107,31 +107,31 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
         responses[job.jobs[-1].uuid][1].output.entropies,
         [
             0.0,
-            4.786689009990746,
-            13.02544271435008,
-            20.360935069065423,
-            26.39830736008501,
+            4.78668900,
+            13.02544271,
+            20.36093506,
+            26.39830736,
         ],
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
         [
             0.0,
-            8.047577577838897,
-            15.97117761314484,
-            19.97051059716143,
-            21.87494655884403,
+            8.04757757,
+            15.97117761,
+            19.97051059,
+            21.87494655,
         ],
     )
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.internal_energies,
         [
-            5774.603553771463,
-            6095.002960937394,
-            7329.854739783488,
-            9152.488591840654,
-            11255.660261586278,
+            5774.60355377,
+            6095.00296093,
+            7329.85473978,
+            9152.48859184,
+            11255.66026158,
         ],
     )
     assert responses[job.jobs[-1].uuid][1].output.chemsys == "Si"
@@ -184,42 +184,42 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [
-            5774.566996471001,
-            5616.29786373465,
-            4724.736849262271,
-            3044.193412800876,
-            696.3435315493462,
+            5774.56699647,
+            5616.29786373,
+            4724.73684926,
+            3044.19341280,
+            696.34353154,
         ],
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
         [
             0.0,
-            4.78666294741712,
-            13.025332342984333,
-            20.36075467024152,
-            26.398072464162844,
+            4.78666294,
+            13.02533234,
+            20.36075467,
+            26.39807246,
         ],
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
         [
             0.0,
-            8.047497695382027,
-            15.971019069215203,
-            19.970326488158854,
-            21.874752681396565,
+            8.04749769,
+            15.97101906,
+            19.97032648,
+            21.87475268,
         ],
     )
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.internal_energies,
         [
-            5774.566996471001,
-            6094.964157503006,
-            7329.8033166885825,
-            9152.419812411707,
-            11255.57251541699,
+            5774.56699647,
+            6094.96415750,
+            7329.80331668,
+            9152.41981241,
+            11255.57251541,
         ],
     )
 
@@ -249,9 +249,9 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.primitive_matrix,
         (
-            (1.0000000000000002, 0.0, 0.0),
-            (0.0, 1.0000000000000002, 0.0),
-            (0.0, 0.0, 1.0000000000000002),
+            (1.00000000, 0.0, 0.0),
+            (0.0, 1.00000000, 0.0),
+            (0.0, 0.0, 1.00000000),
         ),
     )
     assert responses[job.jobs[-1].uuid][1].output.code == "vasp"
@@ -272,31 +272,31 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
         responses[job.jobs[-1].uuid][1].output.entropies,
         [
             0.0,
-            4.78666294741712,
-            13.025332342984333,
-            20.36075467024152,
-            26.398072464162844,
+            4.78666294,
+            13.02533234,
+            20.36075467,
+            26.39807246,
         ],
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
         [
             0.0,
-            8.047497695382027,
-            15.971019069215203,
-            19.970326488158854,
-            21.874752681396565,
+            8.04749769,
+            15.97101906,
+            19.97032648,
+            21.87475268,
         ],
     )
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.internal_energies,
         [
-            5774.566996471001,
-            6094.964157503006,
-            7329.8033166885825,
-            9152.419812411707,
-            11255.57251541699,
+            5774.56699647,
+            6094.96415750,
+            7329.80331668,
+            9152.41981241,
+            11255.57251541,
         ],
     )
 
@@ -342,7 +342,7 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpath_scheme):
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
-        [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.490783551],
+        [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.49078355],
         atol=1e-3,
     )
 
@@ -496,7 +496,7 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
-        [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.490783551],
+        [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.49078355],
         atol=1e-3,
     )
 
@@ -594,17 +594,17 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
-        [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.490783551],
+        [5776.14995034, 5617.74737777, 4725.50269363, 3043.81827626, 694.49078355],
         atol=1e-3,
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
-        [0, 4.79066818396, 13.0347062141, 20.3740028425, 26.4142548987],
+        [0, 4.79066818, 13.03470621, 20.37400284, 26.41425489],
         atol=1e-8,
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.heat_capacities,
-        [0.0, 8.05373626383, 15.9800566903, 19.9803123493, 21.8851347674],
+        [0.0, 8.05373626, 15.98005669, 19.98031234, 21.88513476],
         atol=1e-8,
     )
 
@@ -702,11 +702,11 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
         [
-            5853.741503991992,
-            5692.290895556432,
-            4798.677849195808,
-            3122.482960037922,
-            782.1734533334413,
+            5853.74150399,
+            5692.29089555,
+            4798.67784919,
+            3122.48296003,
+            782.17345333,
         ],
     )
 
@@ -728,13 +728,13 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
         responses[job.jobs[-1].uuid][1].output.force_constants.force_constants[0][0][0][
             0
         ],
-        13.411855999999997,
+        13.41185599,
     )
     assert isinstance(responses[job.jobs[-1].uuid][1].output.jobdirs, PhononJobDirs)
     assert isinstance(responses[job.jobs[-1].uuid][1].output.uuids, PhononUUIDs)
     assert_allclose(responses[job.jobs[-1].uuid][1].output.born, np.zeros((2, 3, 3)))
     assert_allclose(
-        responses[job.jobs[-1].uuid][1].output.total_dft_energy, -5.746290585
+        responses[job.jobs[-1].uuid][1].output.total_dft_energy, -5.74629058
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.epsilon_static,
@@ -902,17 +902,17 @@ def test_phonon_wf_all_steps_na_cl(mock_vasp, clean_dir):
 
         structure = Structure(
             lattice=[
-                [2.3003714889113018, -3.9843602950772405, 0.0000000000000000],
-                [2.3003714889113018, 3.9843602950772405, 0.0000000000000000],
-                [0.0000000000000000, 0.0000000000000000, 7.2813299999999996],
+                [2.30037148, -3.98436029, 0.00000000],
+                [2.30037148, 3.98436029, 0.00000000],
+                [0.00000000, 0.00000000, 7.28132999],
             ],
             species=["Mg", "Mg", "Mg", "Sb", "Sb"],
             coords=[
                 [0.0, 0.0, 0.0],
-                [0.3333333333333333, 0.6666666666666666, 0.3683250000000000],
-                [0.6666666666666667, 0.3333333333333334, 0.6316750000000000],
-                [0.3333333333333333, 0.6666666666666666, 0.7747490000000000],
-                [0.6666666666666667, 0.3333333333333334, 0.2252510000000000],
+                [0.33333333, 0.66666666, 0.36832500],
+                [0.66666666, 0.33333333, 0.63167500],
+                [0.33333333, 0.66666666, 0.77474900],
+                [0.66666666, 0.33333333, 0.22525100],
             ],
         )
 

--- a/tests/vasp/jobs/test_matpes.py
+++ b/tests/vasp/jobs/test_matpes.py
@@ -92,7 +92,6 @@ def test_matpes_gga_static_maker(mock_vasp, clean_dir, vasp_test_dir):
 
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # generate flow
     job = MatPesGGAStaticMaker().make(si_struct)
 
     # ensure flow runs successfully
@@ -118,7 +117,6 @@ def test_matpes_meta_gga_static_maker(mock_vasp, clean_dir, vasp_test_dir):
 
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # generate flow
     job = MatPesMetaGGAStaticMaker().make(si_struct)
 
     # ensure flow runs successfully

--- a/tests/vasp/jobs/test_mp.py
+++ b/tests/vasp/jobs/test_mp.py
@@ -58,7 +58,6 @@ def test_mp_meta_gga_static_maker(mock_vasp, clean_dir, vasp_test_dir):
 
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # generate flow
     job = MPMetaGGAStaticMaker(
         input_set_generator=MPMetaGGARelaxSetGenerator(auto_kspacing=0.8249)
     ).make(si_struct)
@@ -91,7 +90,6 @@ def test_mp_meta_gga_relax_maker(mock_vasp, clean_dir, vasp_test_dir):
 
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # generate flow
     job = MPMetaGGARelaxMaker(
         input_set_generator=MPMetaGGARelaxSetGenerator(auto_kspacing=0.4786)
     ).make(si_struct)
@@ -124,7 +122,6 @@ def test_mp_gga_relax_maker(mock_vasp, clean_dir, vasp_test_dir):
 
     mock_vasp(ref_paths, fake_run_vasp_kwargs)
 
-    # generate flow
     job = MPGGARelaxMaker().make(si_struct)
 
     # ensure flow runs successfully

--- a/tests/vasp/lobster/schemas/test_lobster.py
+++ b/tests/vasp/lobster/schemas/test_lobster.py
@@ -20,7 +20,7 @@ def test_lobster_task_document(lobster_test_dir):
     )
     assert isinstance(doc.structure, Structure)
     assert isinstance(doc.lobsterout, LobsteroutModel)
-    assert_allclose(doc.lobsterout.charge_spilling[0], 0.009899999999999999)
+    assert_allclose(doc.lobsterout.charge_spilling[0], 0.00989999)
 
     assert isinstance(doc.lobsterin, LobsterinModel)
     assert_allclose(doc.lobsterin.cohpstartenergy, -5)

--- a/tests/vasp/lobster/schemas/test_lobster.py
+++ b/tests/vasp/lobster/schemas/test_lobster.py
@@ -20,7 +20,7 @@ def test_lobster_task_document(lobster_test_dir):
     )
     assert isinstance(doc.structure, Structure)
     assert isinstance(doc.lobsterout, LobsteroutModel)
-    assert_allclose(doc.lobsterout.charge_spilling[0], 0.00989999)
+    assert_allclose(doc.lobsterout.charge_spilling[0], 0.00989999, atol=1e-7)
 
     assert isinstance(doc.lobsterin, LobsterinModel)
     assert_allclose(doc.lobsterin.cohpstartenergy, -5)

--- a/tests/vasp/sets/test_matpes.py
+++ b/tests/vasp/sets/test_matpes.py
@@ -1,3 +1,5 @@
+"""Confirm with @janosh before changing any of the expected values below."""
+
 import pytest
 
 from atomate2.vasp.sets.base import VaspInputGenerator

--- a/tests/vasp/sets/test_matpes.py
+++ b/tests/vasp/sets/test_matpes.py
@@ -1,0 +1,49 @@
+import pytest
+
+from atomate2.vasp.sets.base import VaspInputGenerator
+from atomate2.vasp.sets.matpes import (
+    MatPesGGAStaticSetGenerator,
+    MatPesMetaGGAStaticSetGenerator,
+)
+
+
+@pytest.mark.parametrize(
+    "set_generator",
+    [MatPesGGAStaticSetGenerator, MatPesMetaGGAStaticSetGenerator],
+)
+def test_matpes_sets(set_generator: VaspInputGenerator) -> None:
+    matpes_set: VaspInputGenerator = set_generator()
+    assert {*matpes_set.as_dict()} >= {
+        "@class",
+        "@module",
+        "@version",
+        "auto_ismear",
+        "auto_ispin",
+        "auto_kspacing",
+        "auto_lreal",
+        "auto_metal_kpoints",
+        "config_dict",
+        "constrain_total_magmom",
+        "force_gamma",
+        "inherit_incar",
+        "sort_structure",
+        "symprec",
+        "use_structure_charge",
+        "user_incar_settings",
+        "user_kpoints_settings",
+        "user_potcar_functional",
+        "user_potcar_settings",
+        "validate_magmom",
+        "vdw",
+    }
+    assert matpes_set.potcar_functional == "PBE_54"
+    assert matpes_set.inherit_incar is False
+    assert matpes_set.auto_ismear is False
+    assert matpes_set.auto_kspacing is False
+    assert matpes_set.force_gamma is True
+    assert matpes_set.auto_lreal is False
+    assert matpes_set.auto_metal_kpoints is True
+    assert matpes_set.sort_structure is True
+    assert matpes_set.symprec == 0.1
+    assert matpes_set.use_structure_charge is False
+    assert matpes_set.vdw is None

--- a/tests/vasp/sets/test_mp.py
+++ b/tests/vasp/sets/test_mp.py
@@ -1,0 +1,62 @@
+import pytest
+
+from atomate2.vasp.sets.base import VaspInputGenerator
+from atomate2.vasp.sets.mp import (
+    MPGGARelaxSetGenerator,
+    MPGGAStaticSetGenerator,
+    MPMetaGGARelaxSetGenerator,
+    MPMetaGGAStaticSetGenerator,
+)
+
+
+@pytest.mark.parametrize(
+    "set_generator",
+    [
+        MPGGAStaticSetGenerator,
+        MPMetaGGAStaticSetGenerator,
+        MPGGARelaxSetGenerator,
+        MPMetaGGARelaxSetGenerator,
+    ],
+)
+def test_mp_sets(set_generator: VaspInputGenerator) -> None:
+    mp_set: VaspInputGenerator = set_generator()
+    assert {*mp_set.as_dict()} >= {
+        "@class",
+        "@module",
+        "@version",
+        "auto_ismear",
+        "auto_ispin",
+        "auto_kspacing",
+        "auto_lreal",
+        "auto_metal_kpoints",
+        "config_dict",
+        "constrain_total_magmom",
+        "force_gamma",
+        "inherit_incar",
+        "sort_structure",
+        "symprec",
+        "use_structure_charge",
+        "user_incar_settings",
+        "user_kpoints_settings",
+        "user_potcar_functional",
+        "user_potcar_settings",
+        "validate_magmom",
+        "vdw",
+    }
+    assert (
+        mp_set.potcar_functional == "PBE_54"
+        if "Meta" in set_generator.__name__
+        else "PBE"
+    )
+    assert mp_set.inherit_incar is False
+    assert mp_set.auto_ismear is True
+    assert mp_set.auto_kspacing is True
+    assert mp_set.force_gamma is True
+    assert mp_set.auto_lreal is False
+    assert mp_set.auto_metal_kpoints is True
+    assert mp_set.sort_structure is True
+    assert mp_set.symprec == 0.1
+    assert mp_set.use_structure_charge is False
+    assert mp_set.vdw is None
+    bandgap_tol = getattr(mp_set, "bandgap_tol", None)
+    assert bandgap_tol == (1e-4 if "Meta" in set_generator.__name__ else None)

--- a/tests/vasp/sets/test_mp.py
+++ b/tests/vasp/sets/test_mp.py
@@ -1,3 +1,5 @@
+"""Confirm with @janosh before changing any of the expected values below."""
+
 import pytest
 
 from atomate2.vasp.sets.base import VaspInputGenerator

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -166,9 +166,9 @@ def test_set_u_params(structure, request) -> None:
     "bandgap, expected_params",
     [
         (0, {"KSPACING": 0.22, "ISMEAR": 2, "SIGMA": 0.2}),
-        (0.1, {"KSPACING": 0.269695615, "ISMEAR": -5, "SIGMA": 0.05}),
-        (1, {"KSPACING": 0.302352354, "ISMEAR": -5, "SIGMA": 0.05}),
-        (2, {"KSPACING": 0.349355136, "ISMEAR": -5, "SIGMA": 0.05}),
+        (0.1, {"KSPACING": 0.26969561, "ISMEAR": -5, "SIGMA": 0.05}),
+        (1, {"KSPACING": 0.30235235, "ISMEAR": -5, "SIGMA": 0.05}),
+        (2, {"KSPACING": 0.34935513, "ISMEAR": -5, "SIGMA": 0.05}),
         (5, {"KSPACING": 0.44, "ISMEAR": -5, "SIGMA": 0.05}),
         (10, {"KSPACING": 0.44, "ISMEAR": -5, "SIGMA": 0.05}),
     ],


### PR DESCRIPTION
We already had tests for MP and MatPES jobs and flows but none for the set generators. Felt more necessary after the `inherit_incar` default change in #594 in case other defaults change in the future that might affect the MP/MatPES input sets.


cbc11e4a add `tests/vasp/sets/test_mp.py`
3364f6aa fix: add missing `bandgap_tol: float = 1e-4` default to `MPMetaGGAStaticSetGenerator`
9e1b269e add `tests/vasp/sets/test_matpes.py`
50b0313b remove excess float precision of more than 8 decimal points in tests