### PR TITLE
Resolve bandstructure datastore bug

### DIFF
--- a/src/atomate2/vasp/jobs/base.py
+++ b/src/atomate2/vasp/jobs/base.py
@@ -41,7 +41,7 @@ _DATA_OBJECTS = [
     Trajectory,
     "force_constants",
     "normalmode_eigenvecs",
-    "bandstructure",
+    "bandstructure",  # FIX: BandStructure is not currently MSONable
 ]
 
 # Input files. Partially from https://www.vasp.at/wiki/index.php/Category:Input_files

--- a/src/atomate2/vasp/jobs/base.py
+++ b/src/atomate2/vasp/jobs/base.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
 _BADER_EXE_EXISTS = bool(which("bader") or which("bader.exe"))
 _DATA_OBJECTS = [
+    BandStructure,
+    BandStructureSymmLine,
     DOS,
     Dos,
     CompleteDos,
@@ -39,7 +41,7 @@ _DATA_OBJECTS = [
     Trajectory,
     "force_constants",
     "normalmode_eigenvecs",
-    "bandstructure"
+    "bandstructure",
 ]
 
 # Input files. Partially from https://www.vasp.at/wiki/index.php/Category:Input_files

--- a/src/atomate2/vasp/jobs/base.py
+++ b/src/atomate2/vasp/jobs/base.py
@@ -30,8 +30,6 @@ if TYPE_CHECKING:
 
 _BADER_EXE_EXISTS = bool(which("bader") or which("bader.exe"))
 _DATA_OBJECTS = [
-    BandStructure,
-    BandStructureSymmLine,
     DOS,
     Dos,
     CompleteDos,
@@ -41,6 +39,7 @@ _DATA_OBJECTS = [
     Trajectory,
     "force_constants",
     "normalmode_eigenvecs",
+    "bandstructure"
 ]
 
 # Input files. Partially from https://www.vasp.at/wiki/index.php/Category:Input_files


### PR DESCRIPTION
Closes https://github.com/materialsproject/atomate2/issues/584. 

I added "bandstructure" to the list of object names that should be saved in the datastore. I think it is related to how emmet saves the bandstructures:
https://github.com/materialsproject/emmet/blob/08f143833ac6ba5732abadb7beee9e424d0220cf/emmet-core/emmet/core/vasp/calculation.py#L49

For DOS, I assume it works by accident. 