### PR TITLE
new_plotter flexible file extension in phonons.py

### DIFF
--- a/src/atomate2/common/schemas/phonons.py
+++ b/src/atomate2/common/schemas/phonons.py
@@ -324,7 +324,7 @@ class PhononBSDOSDoc(StructureMetadata):
         new_plotter = PhononBSPlotter(bs=bs_symm_line)
 
         new_plotter.save_plot(
-            "phonon_band_structure.eps",
+            "phonon_band_structure."+kwargs.get("img_format", "eps"),
             img_format=kwargs.get("img_format", "eps"),
             units=kwargs.get("units", "THz"),
         )


### PR DESCRIPTION
Before the new_plotter object has always produced `phonon_band_structure.eps` regardless the image format. I and @QuantumChemist made it more flexible using kwargs.

