### PR TITLE
Default `create_thermal_displacements` to `False` in VASP and forcefield `PhononMaker`

### DIFF
--- a/src/atomate2/common/schemas/phonons.py
+++ b/src/atomate2/common/schemas/phonons.py
@@ -339,7 +339,7 @@ class PhononBSDOSDoc(StructureMetadata):
         # get phonon density of states
         filename_dos_yaml = "phonon_dos.yaml"
 
-        kpoint_density_dos = kwargs.get("kpoint_density_dos", 7000)
+        kpoint_density_dos = kwargs.get("kpoint_density_dos", 7_000)
         kpoint = Kpoints.automatic_density(
             structure=get_pmg_structure(phonon.primitive),
             kppa=kpoint_density_dos,

--- a/src/atomate2/forcefields/flows/phonons.py
+++ b/src/atomate2/forcefields/flows/phonons.py
@@ -140,7 +140,7 @@ class PhononMaker(Maker):
     phonon_displacement_maker: BaseVaspMaker | ForceFieldStaticMaker = field(
         default_factory=CHGNetStaticMaker
     )
-    create_thermal_displacements: bool = True
+    create_thermal_displacements: bool = False
     generate_frequencies_eigenvectors_kwargs: dict = field(default_factory=dict)
     kpath_scheme: str = "seekpath"
     code: str = "vasp"

--- a/src/atomate2/vasp/flows/phonons.py
+++ b/src/atomate2/vasp/flows/phonons.py
@@ -144,7 +144,7 @@ class PhononMaker(Maker):
     phonon_displacement_maker: BaseVaspMaker = field(
         default_factory=PhononDisplacementMaker
     )
-    create_thermal_displacements: bool = True
+    create_thermal_displacements: bool = False
     generate_frequencies_eigenvectors_kwargs: dict = field(default_factory=dict)
     kpath_scheme: str = "seekpath"
     code: str = "vasp"

--- a/src/atomate2/vasp/jobs/elastic.py
+++ b/src/atomate2/vasp/jobs/elastic.py
@@ -51,7 +51,7 @@ class ElasticRelaxMaker(BaseVaspMaker):
     name: str = "elastic relax"
     input_set_generator: VaspInputGenerator = field(
         default_factory=lambda: StaticSetGenerator(
-            user_kpoints_settings={"grid_density": 7000},
+            user_kpoints_settings={"grid_density": 7_000},
             user_incar_settings={
                 "IBRION": 2,
                 "ISIF": 2,

--- a/tests/forcefields/flows/test_phonon.py
+++ b/tests/forcefields/flows/test_phonon.py
@@ -83,7 +83,7 @@ def test_phonon_wf(clean_dir):
     )
     assert (
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
-        == 7000
+        == 7_000
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,

--- a/tests/vasp/flows/test_phonons.py
+++ b/tests/vasp/flows/test_phonons.py
@@ -100,7 +100,7 @@ def test_phonon_wf_only_displacements3(mock_vasp, clean_dir):
     )
     assert (
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
-        == 7000
+        == 7_000
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
@@ -263,7 +263,7 @@ def test_phonon_wf_only_displacements_no_structural_transformation(
     )
     assert (
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
-        == 7000
+        == 7_000
     )
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.entropies,
@@ -387,7 +387,7 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpath_scheme):
     )
     assert (
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
-        == 7000
+        == 7_000
     )
 
 
@@ -542,7 +542,7 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
     )
     assert (
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
-        == 7000
+        == 7_000
     )
 
 
@@ -641,7 +641,7 @@ def test_phonon_wf_only_displacements_optional_settings(mock_vasp, clean_dir):
     )
     assert (
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
-        == 7000
+        == 7_000
     )
 
 
@@ -748,7 +748,7 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
     )
     assert (
         responses[job.jobs[-1].uuid][1].output.phonopy_settings.kpoint_density_dos
-        == 7000
+        == 7_000
     )
 
 

--- a/tests/vasp/flows/test_phonons.py
+++ b/tests/vasp/flows/test_phonons.py
@@ -326,6 +326,7 @@ def test_phonon_wf_only_displacements_kpath(mock_vasp, clean_dir, kpath_scheme):
         use_symmetrized_structure="primitive",
         kpath_scheme=kpath_scheme,
         generate_frequencies_eigenvectors_kwargs={"tstep": 100},
+        create_thermal_displacements=True,
     ).make(structure)
 
     # run the flow or job and ensure that it finished running successfully
@@ -427,6 +428,7 @@ def test_phonon_wf_only_displacements_add_inputs_raises(mock_vasp, clean_dir):
         born_maker=None,
         use_symmetrized_structure="primitive",
         generate_frequencies_eigenvectors_kwargs={"tstep": 100},
+        create_thermal_displacements=True,
     ).make(
         structure=structure,
         total_dft_energy_per_formula_unit=total_dft_energy_per_formula_unit,
@@ -471,6 +473,7 @@ def test_phonon_wf_only_displacements_add_inputs(mock_vasp, clean_dir):
         born_maker=None,
         use_symmetrized_structure="primitive",
         generate_frequencies_eigenvectors_kwargs={"tstep": 100},
+        create_thermal_displacements=True,
     ).make(
         structure=structure,
         total_dft_energy_per_formula_unit=total_dft_energy_per_formula_unit,
@@ -678,6 +681,7 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
         min_length=3.0,
         use_symmetrized_structure=None,
         generate_frequencies_eigenvectors_kwargs={"tstep": 100},
+        create_thermal_displacements=True,
     ).make(structure)
 
     # run the flow or job and ensure that it finished running successfully
@@ -688,13 +692,7 @@ def test_phonon_wf_all_steps(mock_vasp, clean_dir):
 
     assert_allclose(
         responses[job.jobs[-1].uuid][1].output.free_energies,
-        [
-            5853.74150399,
-            5692.29089555,
-            4798.67784919,
-            3122.48296003,
-            782.17345333,
-        ],
+        [5853.74150399, 5692.29089555, 4798.67784919, 3122.48296003, 782.17345333],
     )
 
     assert isinstance(


### PR DESCRIPTION
Motivation: Most people likely won't use the `thermal_displacement_matrix` resulting from `create_thermal_displacements=True` but having it on can cause the calculation to fail [due to this line in `phonopy`'s](https://github.com/phonopy/phonopy/blob/4b0b2e5ea7c88d9a184bf72411be210d996ab602/phonopy/phonon/thermal_displacement.py#L405) `_get_disp_matrices`

```
assert (abs(disps.imag) < 1e-1).all()
```

This change was discussed with @JaGeo but pinging her for final approval.


Full stack trace

```py
INFO:jobflow.managers.local:generate_frequencies_eigenvectors failed with exception:
Traceback (most recent call last):
  File "/Users/janosh/dev/jobflow/src/jobflow/managers/local.py", line 106, in _run_job
    response = job.run(store=store)
               ^^^^^^^^^^^^^^^^^^^^
  File "/Users/janosh/dev/jobflow/src/jobflow/core/job.py", line 584, in run
    response = function(*self.function_args, **self.function_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/janosh/dev/atomate2/src/atomate2/common/jobs/phonons.py", line 232, in generate_frequencies_eigenvectors
    return PhononBSDOSDoc.from_forces_born(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/janosh/dev/atomate2/src/atomate2/common/schemas/phonons.py", line 397, in from_forces_born
    phonon.run_thermal_displacement_matrices(
  File "/Users/janosh/.venv/py311/lib/python3.11/site-packages/phonopy/api_phonopy.py", line 2927, in run_thermal_displacement_matrices
    tdm.run()
  File "/Users/janosh/.venv/py311/lib/python3.11/site-packages/phonopy/phonon/thermal_displacement.py", line 359, in run
    self._get_disp_matrices()
  File "/Users/janosh/.venv/py311/lib/python3.11/site-packages/phonopy/phonon/thermal_displacement.py", line 404, in _get_disp_matrices
    assert (abs(disps.imag) < 1e-10).all()
```