### PR TITLE
Drop `flake8`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,19 +21,6 @@ repos:
   - id: blacken-docs
     additional_dependencies: [black]
     exclude: README.md
-- repo: https://github.com/pycqa/flake8
-  rev: 6.1.0
-  hooks:
-  - id: flake8
-    entry: pflake8
-    files: ^src/
-    additional_dependencies:
-    - pyproject-flake8==6.0.0a1
-    - flake8-bugbear==22.12.6
-    - flake8-typing-imports==1.14.0
-    - flake8-docstrings==1.6.0
-    - flake8-rst-docstrings==0.3.0
-    - flake8-rst==0.8.0
 - repo: https://github.com/pre-commit/pygrep-hooks
   rev: v1.10.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,15 +111,6 @@ atomate2 = ["py.typed"]
 method = "git"
 default-tag = "0.0.1"
 
-[tool.flake8]
-max-line-length = 88
-max-doc-length = 88
-select = "C, E, F, W, B"
-extend-ignore = "E203, W503, E501, F401, RST21"
-min-python-version = "3.8.0"
-docstring-convention = "numpy"
-rst-roles = "class, func, ref, obj"
-
 [tool.mypy]
 ignore_missing_imports = true
 no_strict_optional = true


### PR DESCRIPTION
@utf IIUC, `flake8` last remaining use was to lint python code in rST files? I see only 5 rST files and none of them contain Python code. Combined with the fact that [`ruff` now lints Python in doc strings](https://astral.sh/blog/ruff-v0.1.8), I think we can get rid of `flake8` entirely. Let me know if I missed something.