### PR TITLE
add directory of task doc generation to phonon schema

### DIFF
--- a/src/atomate2/common/schemas/phonons.py
+++ b/src/atomate2/common/schemas/phonons.py
@@ -464,7 +464,7 @@ class PhononBSDOSDoc(StructureMetadata, extra="allow"):  # type: ignore[call-arg
                 "static_run_job_dir": kwargs["static_run_job_dir"],
                 "born_run_job_dir": kwargs["born_run_job_dir"],
                 "optimization_run_job_dir": kwargs["optimization_run_job_dir"],
-                "taskdoc_run_job_dir": Path.cwd(),
+                "taskdoc_run_job_dir": str(Path.cwd()),
             },
             uuids={
                 "displacements_uuids": displacement_data["uuids"],

--- a/src/atomate2/common/schemas/phonons.py
+++ b/src/atomate2/common/schemas/phonons.py
@@ -2,6 +2,7 @@
 
 import copy
 import logging
+from pathlib import Path
 from typing import Optional, Union
 
 import numpy as np
@@ -97,6 +98,9 @@ class PhononJobDirs(BaseModel):
     )
     optimization_run_job_dir: Optional[str] = Field(
         None, description="Directory where optimization run was performed."
+    )
+    taskdoc_run_job_dir: Optional[str] = Field(
+        None, description="Directory where taskdoc was generated."
     )
 
 
@@ -460,6 +464,7 @@ class PhononBSDOSDoc(StructureMetadata, extra="allow"):  # type: ignore[call-arg
                 "static_run_job_dir": kwargs["static_run_job_dir"],
                 "born_run_job_dir": kwargs["born_run_job_dir"],
                 "optimization_run_job_dir": kwargs["optimization_run_job_dir"],
+                "taskdoc_run_job_dir": Path.cwd(),
             },
             uuids={
                 "displacements_uuids": displacement_data["uuids"],


### PR DESCRIPTION
## Summary

Currently, the path to the folder where the task doc and phonopy output files have been generated is not added to the list of directories of the output of the phonon run. This makes collecting all data unnecessarily hard. I have now added this directory path as well. 

