### PR TITLE
Prep for next `pymatgen` release

### DIFF
--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -94,11 +94,7 @@ class VaspInputSet(InputSet):
         if make_dir:
             os.makedirs(directory, exist_ok=True)
 
-        inputs = {
-            "INCAR": self.incar,
-            "KPOINTS": self.kpoints,
-            "POSCAR": self.poscar,
-        }
+        inputs = {"INCAR": self.incar, "KPOINTS": self.kpoints, "POSCAR": self.poscar}
         inputs.update(self.optional_files)
 
         if isinstance(self.potcar, Potcar):
@@ -106,16 +102,16 @@ class VaspInputSet(InputSet):
         else:
             inputs["POTCAR.spec"] = "\n".join(self.potcar)
 
-        for k, v in inputs.items():
-            if v is not None and (overwrite or not (directory / k).exists()):
-                with zopen(directory / k, "wt") as f:
-                    if isinstance(v, Poscar):
+        for key, val in inputs.items():
+            if val is not None and (overwrite or not (directory / key).exists()):
+                with zopen(directory / key, mode="wt") as file:
+                    if isinstance(val, Poscar):
                         # write POSCAR with more significant figures
-                        f.write(v.get_string(significant_figures=16))
+                        file.write(val.get_str(significant_figures=16))
                     else:
-                        f.write(v.__str__())
-            elif not overwrite and (directory / k).exists():
-                raise FileExistsError(f"{directory / k} already exists.")
+                        file.write(val.__str__())
+            elif not overwrite and (directory / key).exists():
+                raise FileExistsError(f"{directory / key} already exists.")
 
     @staticmethod
     def from_directory(

--- a/tests/cp2k/conftest.py
+++ b/tests/cp2k/conftest.py
@@ -135,7 +135,7 @@ def fake_run_cp2k(
     input_settings: Sequence[str] = (),
     check_inputs: Sequence[Literal["cp2k.inp"]] = _VFILES,
     clear_inputs: bool = True,
-):
+) -> None:
     """
     Emulate running CP2K and validate CP2K input files.
 
@@ -171,16 +171,16 @@ def fake_run_cp2k(
 
 @pytest.fixture()
 def check_input():
-    def _check_input(ref_path, user_input):
-        from pymatgen.io.cp2k.inputs import Cp2kInput
+    from pymatgen.io.cp2k.inputs import Cp2kInput
 
-        ref = Cp2kInput.from_file(ref_path / "inputs" / "cp2k.inp")
+    def _check_input(ref_path, user_input: Cp2kInput):
+        ref_input = Cp2kInput.from_file(ref_path / "inputs" / "cp2k.inp")
         user_input.verbosity(verbosity=False)
-        ref.verbosity(verbosity=False)
-        user_string = " ".join(user_input.get_string().lower().split())
+        ref_input.verbosity(verbosity=False)
+        user_string = " ".join(user_input.get_str().lower().split())
         user_hash = md5(user_string.encode("utf-8")).hexdigest()
 
-        ref_string = " ".join(ref.get_string().lower().split())
+        ref_string = " ".join(ref_input.get_str().lower().split())
         ref_hash = md5(ref_string.encode("utf-8")).hexdigest()
 
         if ref_hash != user_hash:
@@ -190,10 +190,7 @@ def check_input():
 
 
 def clear_cp2k_inputs():
-    for cp2k_file in (
-        "cp2k.inp",
-        "cp2k.out",
-    ):
+    for cp2k_file in ("cp2k.inp", "cp2k.out"):
         if Path(cp2k_file).exists():
             Path(cp2k_file).unlink()
     logger.info("Cleared cp2k inputs")

--- a/tests/vasp/lobster/schemas/test_lobster.py
+++ b/tests/vasp/lobster/schemas/test_lobster.py
@@ -271,7 +271,7 @@ def test_lobster_task_document_non_gzip(lobster_test_dir, tmp_path):
     assert doc.chemsys == "As-Ga"
 
 
-def test_lobstertaskdocument_saved_jsons(lobster_test_dir):
+def test_lobster_task_doc_saved_jsons(lobster_test_dir):
     """
     Test if jsons saved are valid
     """


### PR DESCRIPTION
Many `pymatgen` classes had inconsistently named `get/from_(str|string)` methods. `get/from_string` was deprecated in favor of `get/from_str` 6 months ago and removed last week in https://github.com/materialsproject/pymatgen/pull/3561 which will be released this or next week.

@utf this change will require a new `atomate2` version to be compatible with the upcoming `pymatgen`.

resulting `AttributeError` incurrent `atomate2` reported by @abhardwaj73 in https://github.com/materialsproject/pymatgen/issues/3571#issuecomment-1911066021. thanks!