### PR TITLE
[bug fix] SC Matrix Checking Logic

### DIFF
--- a/src/atomate2/common/jobs/defect.py
+++ b/src/atomate2/common/jobs/defect.py
@@ -219,8 +219,8 @@ def get_supercell_from_prv_calc(
     )
 
     if sc_mat_ref is not None:
-        latt_ref = Lattice(sc_mat_ref)
-        latt_prv = Lattice(sc_mat_prv)
+        latt_ref = (uc_structure * sc_mat_ref).lattice
+        latt_prv = (uc_structure * sc_mat_prv).lattice
         if not (
             np.allclose(sorted(latt_ref.abc), sorted(latt_prv.abc))
             and np.allclose(sorted(latt_ref.angles), sorted(latt_prv.angles))


### PR DESCRIPTION
## Summary

Make the check for the shape of the reference suprecell matrix more explicit.

Under the old code, it is possible to have two sc of the exact same shape.


The exact example is given below
```
ipdb> print(uc_structure.lattice)
5.090004 -0.000001 -0.000007
2.545003 -4.408073 -0.000007
2.545009 -1.469362 -4.595759

# sc_mats are different (old code will compare these and raise an error)
ipdb> print(sc_mat_ref)
[[2, 0, 0], [2, -3, 0], [1, 1, -3]]
ipdb> print(sc_mat_prv)
[[-2  2  0]
 [-2 -1  0]
 [-1 -1  3]]

# actual structures are the same (new code will continue excution)
ipdb> print(sc_ref.lattice.abc, sc_ref.lattice.angles)
(10.180005983446268, 13.466886920683072, 13.787261249420052) (90.0001838526074, 89.99999983000444, 79.10660876819587)
ipdb> print(sc_prv.lattice.abc, sc_prv.lattice.angles)
(10.180005983446268, 13.466886920683072, 13.787261249420052) (90.0001838526074, 89.99999983000444, 79.10660876819587)
```

