### PR TITLE
Fix JobStoreDocument attribute access 

### DIFF
--- a/src/atomate2/cli/dev.py
+++ b/src/atomate2/cli/dev.py
@@ -47,7 +47,9 @@ def vasp_test_data(test_dir: Path) -> None:
 
     outputs = loadfn("outputs.json")
 
-    task_labels = [o["output"].task_label for o in outputs if isinstance(o, TaskDoc)]
+    task_labels = [
+        o.output.task_label for o in outputs if isinstance(o.output, TaskDoc)
+    ]
 
     if len(task_labels) != len(set(task_labels)):
         raise ValueError("Not all jobs have unique names")
@@ -59,9 +61,9 @@ def vasp_test_data(test_dir: Path) -> None:
             # this is not a VASP job
             continue
 
-        job_name = output["output"].task_label
-        orig_job_dir = strip_hostname(output["output"].dir_name)
-        folder_name = output["output"].task_label.replace("/", "_").replace(" ", "_")
+        job_name = output.output.task_label
+        orig_job_dir = strip_hostname(output.output.dir_name)
+        folder_name = output.output.task_label.replace("/", "_").replace(" ", "_")
 
         if len(task_labels) == 1:
             # only testing a single job

--- a/src/atomate2/cli/dev.py
+++ b/src/atomate2/cli/dev.py
@@ -55,7 +55,7 @@ def vasp_test_data(test_dir: Path) -> None:
     original_mapping = {}
     mapping = {}
     for output in outputs:
-        if not isinstance(output["output"], TaskDoc):
+        if not isinstance(output.output, TaskDoc):
             # this is not a VASP job
             continue
 


### PR DESCRIPTION
## Summary

Fix the error:
```
  File "/home/atomate2/src/atomate2/cli/dev.py", line 58, in vasp_test_data
    if not isinstance(output["output"], TaskDoc):
                      ~~~~~~^^^^^^^^^^
TypeError: 'JobStoreDocument' object is not subscriptable
```