### PR TITLE
Fix docstring on `MatPesMetaGGAStaticSetGenerator`

### DIFF
--- a/src/atomate2/vasp/sets/matpes.py
+++ b/src/atomate2/vasp/sets/matpes.py
@@ -70,7 +70,7 @@ class MatPesGGAStaticSetGenerator(VaspInputGenerator):
 
 @dataclass
 class MatPesMetaGGAStaticSetGenerator(MatPesGGAStaticSetGenerator):
-    """Class to generate MP-compatible VASP GGA static input sets."""
+    """Class to generate MP-compatible VASP meta-GGA static input sets."""
 
     def get_incar_updates(
         self,


### PR DESCRIPTION
It said GGA when it should have said meta-GGA. Trivial. CC @janosh.
