### PR TITLE
Modify `BadInputSetWarning` logic for relaxations of a likely metal

### DIFF
--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -173,7 +173,7 @@ class VaspInputSet(InputSet):
             and (incar.get("ISMEAR", 1) < 0 or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05))
         ):
             warnings.warn(
-                "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected.
+                "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected. "
                 "Please see VASP recommendations on ISMEAR for metals.",
                 BadInputSetWarning,
                 stacklevel=1,

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -171,8 +171,8 @@ class VaspInputSet(InputSet):
             all(k.is_metal for k in self.poscar.structure.composition)
             and self.incar.get("NSW", 0) > 0
             and (
-                incar.get("ISMEAR", 1) < 0
-                or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05)
+                self.incar.get("ISMEAR", 1) < 0
+                or (self.incar.get("ISMEAR", 1) == 0 and self.incar.get("SIGMA", 0.2) > 0.05)
             )
         ):
             warnings.warn(

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -167,17 +167,21 @@ class VaspInputSet(InputSet):
                 stacklevel=1,
             )
 
+        ismear = self.incar.get("ISMEAR", 1)
+        sigma = self.incar.get("SIGMA", 0.2)
         if (
             all(k.is_metal for k in self.poscar.structure.composition)
             and self.incar.get("NSW", 0) > 0
-            and (
-                self.incar.get("ISMEAR", 1) < 0
-                or (self.incar.get("ISMEAR", 1) == 0 and self.incar.get("SIGMA", 0.2) > 0.05)
-            )
+            and (ismear < 0 or (ismear == 0 and sigma > 0.05))
         ):
+            ismear_docs = "https://www.vasp.at/wiki/index.php/ISMEAR"
+            msg = ""
+            if ismear < 0:
+                msg = f"Relaxation of likely metal with ISMEAR < 0 ({ismear})."
+            elif ismear == 0 and sigma > 0.05:
+                msg = f"ISMEAR = 0 with a small SIGMA ({sigma}) detected."
             warnings.warn(
-                "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected. "
-                "Please see VASP recommendations on ISMEAR for metals.",
+                f"{msg} See VASP recommendations on ISMEAR for metals ({ismear_docs}).",
                 BadInputSetWarning,
                 stacklevel=1,
             )

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -170,11 +170,11 @@ class VaspInputSet(InputSet):
         if (
             all(k.is_metal for k in self.poscar.structure.composition)
             and self.incar.get("NSW", 0) > 0
-            and self.incar.get("ISMEAR", 1) < 1
+            and (incar.get("ISMEAR", 1) < 0 or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05))
         ):
             warnings.warn(
-                "Relaxation of likely metal with ISMEAR < 1 detected. Please see VASP "
-                "recommendations on ISMEAR for metals.",
+                "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected.
+                "Please see VASP recommendations on ISMEAR for metals.",
                 BadInputSetWarning,
                 stacklevel=1,
             )

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -170,7 +170,10 @@ class VaspInputSet(InputSet):
         if (
             all(k.is_metal for k in self.poscar.structure.composition)
             and self.incar.get("NSW", 0) > 0
-            and (incar.get("ISMEAR", 1) < 0 or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05))
+            and (
+                 incar.get("ISMEAR", 1) < 0
+                 or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05)
+             )
         ):
             warnings.warn(
                 "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected. "

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -171,9 +171,9 @@ class VaspInputSet(InputSet):
             all(k.is_metal for k in self.poscar.structure.composition)
             and self.incar.get("NSW", 0) > 0
             and (
-                 incar.get("ISMEAR", 1) < 0
-                 or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05)
-             )
+                incar.get("ISMEAR", 1) < 0
+                or (incar.get("ISMEAR", 1) == 0 and incar.get("SIGMA", 0.2) > 0.05)
+            )
         ):
             warnings.warn(
                 "Relaxation of likely metal with ISMEAR < 0 or ISMEAR = 1 with a small SIGMA detected. "


### PR DESCRIPTION
Closes #726. 

Relaxing a metal with ISMEAR = 0 is fine, as noted in the VASP manual, provided SIGMA is sufficiently small (< 0.05 is the recommendation in the VASP manual).

> If you have no a priori knowledge of your system, for instance, if you do not know whether your system is an insulator, semiconductor or metal then always use Gaussian smearing ISMEAR=0 in combination with a small [SIGMA](https://www.vasp.at/wiki/index.php/SIGMA)=0.03-0.05.