### PR TITLE
[WIP] Support general ASE Calculator for general MLIP MD simulations

### DIFF
--- a/src/atomate2/forcefields/jobs.py
+++ b/src/atomate2/forcefields/jobs.py
@@ -94,7 +94,7 @@ class ForceFieldRelaxMaker(Maker):
 @dataclass
 class ForceFieldStaticMaker(ForceFieldRelaxMaker):
     """
-    Maker to calculate forces and stresses using the CHGNet force field.
+    Maker to calculate forces and stresses using ML force field.
 
     Parameters
     ----------

--- a/src/atomate2/forcefields/run.py
+++ b/src/atomate2/forcefields/run.py
@@ -1,0 +1,127 @@
+"""ASE wrapper.
+
+This module provides a wrapper around ASE to run ASE jobs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from ase import units
+from ase.md.npt import NPT
+from ase.md.velocitydistribution import MaxwellBoltzmannDistribution, Stationary
+from jobflow.utils import ValueEnum
+from scipy.interpolate import interp1d
+
+from atomate2 import SETTINGS
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from ase import Atoms
+    from ase.calculators.calculator import Calculator
+    from ase.md.md import MolecularDynamics
+    from custodian.custodian import Validator
+# TODO: add custodian support
+
+class JobType(ValueEnum):
+    """
+    Type of ASE job.
+
+    - ``DIRECT``: Run ASE without custodian.
+    - ``NORMAL``: Normal custodian :obj:`.ASEJob`.
+    """
+
+    DIRECT = "direct"
+    NORMAL = "normal"
+
+def run_ase(
+    job_type: JobType | str = JobType.NORMAL,
+    ase_cmd: str = SETTINGS.ASE_CMD,
+    max_errors: int = None, # TODO: add default custodian max_errors
+    scratch_dir: str = SETTINGS.CUSTODIAN_SCRATCH_DIR,
+    validators: Sequence[Validator] = None, # TODO: add validators
+    ase_job_kwargs: dict[str, Any] = None,
+    custodian_kwargs: dict[str, Any] = None,
+) -> None:
+    pass
+
+
+def run_ase_md(
+    atoms: Atoms,
+    calculator: Calculator,
+    input_set: str | dict[str, Any],
+) -> None:
+    """Run ASE molecular dynamics."""
+    atoms.calc = calculator
+
+    ensemble = input_set.pop("ensemble", "nvt").lower()
+    dynamics = input_set.pop("dynamics", NPT)
+    nsteps = input_set.pop("nsteps", 1000)
+    timestep = input_set.pop("timestep", 2) * units.fs
+    temperature = input_set.pop("temperature", 300)
+    pressure = input_set.pop("pressure", 0) * 0.1 * units.GPa
+
+    trajectory = input_set.pop("trajectory", "trajectory.traj")
+
+    if isinstance(temperature, list):
+        tschedule = np.interp(
+            np.arange(nsteps),
+            np.arange(len(temperature)),
+            temperature
+        )
+    else:
+        tschedule = np.full(nsteps, temperature)
+
+    if isinstance(pressure, list):
+        pschedule = np.interp(np.arange(nsteps), np.arange(len(pressure)), pressure)
+    elif isinstance(pressure, np.ndarray):
+        pschedule = interp1d(np.arange(nsteps), pressure, kind="linear")
+    else:
+        pschedule = np.full(nsteps, pressure)
+
+
+    MaxwellBoltzmannDistribution(atoms, temperature_K=tschedule[0])
+    Stationary(atoms)
+
+    if ensemble == "nve":
+        dyn = dynamics(atoms, timestep=timestep, trajectory=trajectory, **input_set)
+    elif ensemble == "nvt":
+        dyn = dynamics(
+            atoms,
+            timestep=timestep,
+            temperature_K=tschedule[0],
+            trajectory=trajectory,
+            **input_set
+        )
+    elif ensemble == "npt":
+        dyn = dynamics(
+            atoms,
+            timestep=timestep,
+            temperature_K=tschedule[0],
+            pressure=pschedule[0],
+            trajectory=trajectory,
+            **input_set,
+        )
+    else:
+        raise ValueError(f"Unknown ensemble: {ensemble}")
+
+    def callback(dyn: MolecularDynamics = dyn) -> None:
+        if ensemble == "nve":
+            return
+        dyn.set_temperature(tschedule[dyn.nsteps])
+        if ensemble == "npt":
+            return
+        dyn.set_stress(pschedule[dyn.nsteps])
+
+    dyn.attach(callback, interval=1)
+    dyn.run(nsteps)
+
+
+
+
+
+
+
+

--- a/src/atomate2/forcefields/sets/core.py
+++ b/src/atomate2/forcefields/sets/core.py
@@ -62,10 +62,12 @@ class MDSetGenerator(InputGenerator):
     @staticmethod
     def _get_ensemble_defaults(ensemble: str) -> dict[str, Any]:
         """Get default params for the ensemble."""
+        from ase.md.npt import NPT
+        from ase.md.verlet import VelocityVerlet
         defaults = {
-            "nve": {"algorithm": "verlet"},
-            "nvt": {"algorithm": "nose-hoover"},
-            "npt": {"algorithm": "nose-hoover"},
+            "nve": {"dynamics": VelocityVerlet},
+            "nvt": {"dynamics": NPT},
+            "npt": {"dynamics": NPT},
         }
 
         try:

--- a/src/atomate2/forcefields/sets/core.py
+++ b/src/atomate2/forcefields/sets/core.py
@@ -1,0 +1,57 @@
+"""Module defining core ASE MD input set generators."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from pymatgen.io.core import InputGenerator
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class MDSetGenerator(InputGenerator):
+    """
+    Class to generate ASE molecular dynamics input sets.
+
+    Parameters
+    ----------
+    ensemble
+        Molecular dynamics ensemble to run. Options include `nvt`, `nve`, and `npt`.
+    nsteps
+        Number of ionic steps for simulations.
+    timestep
+        The time step (in femtosecond) for the simulation.
+    temp_schedule
+        Temperature schedule for the simulation in Kelvin. Default is None. If None,
+        the temperature is constant at the value of 300 K.
+    press_schedule
+        Pressure schedule for the simulation in kilobar. Default is None. If None,
+        the pressure is constant at the value of 0. Positive values are for compression.
+    **kwargs
+        Other parameters passed to the InputGenerator.
+    """
+
+    ensemble: str = "nvt"
+    nsteps: int = 1000
+    timestep: float = 2
+    temp_schedule: list[float] | None = None
+    press_schedule: list[float] | None = None
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+    # TODO: revise for ASE
+    @staticmethod
+    def _get_ensemble_defaults(ensemble: str) -> dict[str, Any]:
+        """Get default params for the ensemble."""
+        defaults = {
+            "nve": {"algorithm": "verlet"},
+            "nvt": {"algorithm": "nose-hoover"},
+            "npt": {"algorithm": "nose-hoover"},
+        }
+
+        try:
+            return defaults[ensemble.lower()]  # type: ignore[return-value]
+        except KeyError as err:
+            supported = tuple(defaults)
+            raise ValueError(f"Expect {ensemble=} to be one of {supported}") from err


### PR DESCRIPTION
## Summary

Given that some of the popular MLIPs lean on ASE Calculator, this PR aims to add ASE Calculator support for MD simulations in a similar manner to #134 and #489. The design is similar to existing [forcefield](https://github.com/materialsproject/atomate2/tree/main/src/atomate2/forcefields) but allows user to pass any subclass of ASE Calculator and run various of dynamics supported by [ASE MD module](https://wiki.fysik.dtu.dk/ase/ase/md.html). 

The design should be kept general and abstract so that we can avoid code duplication and won't need to add more ASE-based MLIPs in the future. This actually makes more sense than the [existing relaxation implementation](https://github.com/materialsproject/atomate2/blob/main/src/atomate2/forcefields/jobs.py) where most of them run ASE calculator as [Relaxer](https://github.com/materialsproject/atomate2/blob/e2181ea87f8e51f6362369d61b9c46b29e4d392a/src/atomate2/forcefields/utils.py#L129) at the bottom level. By doing so we can also ensure that all the MLIPs fairly run on the same settings of dynamics .

## TODO
- [x] Add support for temperature and pressure schedules (T/P ramp, non-linear temperature schedule, shear external pressure, etc.)
- [ ] For NPT ensemble, add `mask` and `dyn.set_fraction_traceless(0)`
- [ ] Custodian and `ASEJob`
- [ ] MultiMDMaker
- [ ] test

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

* [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [ ] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [ ] Tests have been added for any new functionality or bug fixes.
* [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
