### PR TITLE
[BUGFIX] Minor test and install bugs

### DIFF
--- a/tests/forcefields/test_utils.py
+++ b/tests/forcefields/test_utils.py
@@ -111,9 +111,11 @@ def test_relaxer(si_structure, test_dir, tmp_dir, optimizer, traj_file):
 
     assert relax_output["trajectory"].energies[-1] == pytest.approx(expected_energy)
 
-    assert_allclose(relax_output["trajectory"].forces[-1], expected_forces)
+    assert_allclose(relax_output["trajectory"].forces[-1], expected_forces, atol=1e-8)
 
-    assert_allclose(relax_output["trajectory"].stresses[-1], expected_stresses)
+    assert_allclose(
+        relax_output["trajectory"].stresses[-1], expected_stresses, atol=1e-8
+    )
 
     if traj_file:
         assert os.path.isfile(traj_file)


### PR DESCRIPTION
## Minor test and install bugs

Currently installing on a new system.

Noticed a couple of bugs during testing:
- The `assert_allclose` is missing `atol` which errors out on some systems.
- Ase must be installed with `ase-core` first then `ase`, otherwise a large number of tests fail. (Not sure how to fix this)

The following asa packages, installed in order, allowed the tests to pass without linking to the gitlab repo for ase.

```
ase-core                  3.23.0b1.post3
ase                       3.22.1
```
