### PR TITLE
Make functions prefixed with `_` but cross-imported public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,17 @@
 ## v0.0.14
 
 ### New Features 🎉
+
 * Add lobster mp workflow by @JaGeo in https://github.com/materialsproject/atomate2/pull/634
 * Add FHI-aims DFT calculator by @tpurcell90 in https://github.com/materialsproject/atomate2/pull/562
 * Electrode Workflow by @jmmshn in https://github.com/materialsproject/atomate2/pull/655
 * Equation of state (EOS) workflows by @esoteric-ephemera in https://github.com/materialsproject/atomate2/pull/623
+
 ### Bug Fixes 🐛
+
 * Skip final LDAU/J/L/MAGMOM updates and fix setting MAGMOM via `user_incar_settings` by @JonathanSchmidt1 in https://github.com/materialsproject/atomate2/pull/648
 * Prep for next `pymatgen` release by @janosh in https://github.com/materialsproject/atomate2/pull/690
-* [bug fix] SC Matrix Checking Logic by @jmmshn in https://github.com/materialsproject/atomate2/pull/704
+* fix SC Matrix Checking Logic by @jmmshn in https://github.com/materialsproject/atomate2/pull/704
 * Fix elastic conventional structure by @mjwen in https://github.com/materialsproject/atomate2/pull/706
 * Add `KspacingMetalHandler` to VASP `_DEFAULT_HANDLERS` by @janosh in https://github.com/materialsproject/atomate2/pull/600
 * Fix import error [ijson] by @naik-aakash in https://github.com/materialsproject/atomate2/pull/708
@@ -18,24 +21,31 @@
 * Update minimum `monty` version, allow newer `pydantic` by @mkhorton in https://github.com/materialsproject/atomate2/pull/720
 * Fix phonon + Lobster flow by removing magmoms before passing to `phonopy` by @naik-aakash in https://github.com/materialsproject/atomate2/pull/751
 * Fix MP query by @utf in https://github.com/materialsproject/atomate2/pull/755
+
 ### Enhancements 🛠
+
 * add directory of task doc generation to phonon schema by @JaGeo in https://github.com/materialsproject/atomate2/pull/674
 * Ensure MP VASP sets don't use auto_ismear, few other fixes by @esoteric-ephemera in https://github.com/materialsproject/atomate2/pull/673
 * Schema update > Update plot example LOBSTER workflow by @naik-aakash in https://github.com/materialsproject/atomate2/pull/682
 * Modify `BadInputSetWarning` logic for relaxations of a likely metal by @Andrew-S-Rosen in https://github.com/materialsproject/atomate2/pull/727
 * Define `MLFF` `Enum` to ensure consistent force field names by @janosh in https://github.com/materialsproject/atomate2/pull/729
+
 ### Documentation 📖
+
 * Update doc: adding metadata to flow by @naik-aakash in https://github.com/materialsproject/atomate2/pull/638
 * Fix hyperlink in Docs by @naik-aakash in https://github.com/materialsproject/atomate2/pull/686
 * Correct typo in doc by @JiQi535 in https://github.com/materialsproject/atomate2/pull/716
 * Fix docstring on `MatPesMetaGGAStaticSetGenerator` by @Andrew-S-Rosen in https://github.com/materialsproject/atomate2/pull/725
 * Add `citation.cff` file, Zenodo record and readme "How to cite" section by @janosh in https://github.com/materialsproject/atomate2/pull/731
+
 ### House-Keeping 🧹
+
 * Address TODO re missing asserts in `test_elastic_wf_with_mace()` by @janosh in https://github.com/materialsproject/atomate2/pull/679
 * Update lobsterpy version by @naik-aakash in https://github.com/materialsproject/atomate2/pull/683
 * Fix all ruff PT011 (not checking error message when testing exceptions) by @janosh in https://github.com/materialsproject/atomate2/pull/698
 
 ## New Contributors
+
 * @JonathanSchmidt1 made their first contribution in https://github.com/materialsproject/atomate2/pull/648
 * @rdguha1995 made their first contribution in https://github.com/materialsproject/atomate2/pull/161
 * @JiQi535 made their first contribution in https://github.com/materialsproject/atomate2/pull/716

--- a/src/atomate2/aims/files.py
+++ b/src/atomate2/aims/files.py
@@ -19,8 +19,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["copy_aims_outputs", "write_aims_input_set", "cleanup_aims_outputs"]
-
 
 @auto_fileclient
 def copy_aims_outputs(

--- a/src/atomate2/aims/flows/phonons.py
+++ b/src/atomate2/aims/flows/phonons.py
@@ -125,7 +125,7 @@ class PhononMaker(BasePhononMaker):
     socket: bool = False
     code: str = "aims"
     bulk_relax_maker: BaseAimsMaker | None = field(
-        default_factory=lambda: RelaxMaker.full_relaxation()
+        default_factory=RelaxMaker.full_relaxation
     )
     static_energy_maker: BaseAimsMaker | None = field(default_factory=StaticMaker)
     born_maker: BaseAimsMaker | None = None

--- a/src/atomate2/common/schemas/elastic.py
+++ b/src/atomate2/common/schemas/elastic.py
@@ -191,7 +191,7 @@ class ElasticDocument(StructureMetadata):
         strains = [d.green_lagrange_strain for d in deformations]
 
         if symprec is not None:
-            strains, stresses, uuids, job_dirs = _expand_strains(
+            strains, stresses, uuids, job_dirs = expand_strains(
                 structure, strains, stresses, uuids, job_dirs, symprec
             )
 
@@ -257,7 +257,7 @@ class ElasticDocument(StructureMetadata):
         )
 
 
-def _expand_strains(
+def expand_strains(
     structure: Structure,
     strains: list[Strain],
     stresses: list[Stress],

--- a/src/atomate2/vasp/run.py
+++ b/src/atomate2/vasp/run.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from emmet.core.tasks import TaskDoc
 
 
-_DEFAULT_HANDLERS = (
+DEFAULT_HANDLERS = (
     VaspErrorHandler(),
     MeshSymmetryErrorHandler(),
     UnconvergedErrorHandler(),
@@ -87,7 +87,7 @@ def run_vasp(
     vasp_gamma_cmd: str = SETTINGS.VASP_GAMMA_CMD,
     max_errors: int = SETTINGS.VASP_CUSTODIAN_MAX_ERRORS,
     scratch_dir: str = SETTINGS.CUSTODIAN_SCRATCH_DIR,
-    handlers: Sequence[ErrorHandler] = _DEFAULT_HANDLERS,
+    handlers: Sequence[ErrorHandler] = DEFAULT_HANDLERS,
     validators: Sequence[Validator] = _DEFAULT_VALIDATORS,
     wall_time: int | None = None,
     vasp_job_kwargs: dict[str, Any] = None,

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -655,19 +655,21 @@ class VaspInputGenerator(InputGenerator):
 
         # generate incar
         incar = Incar()
-        for k, v in incar_settings.items():
-            if k == "MAGMOM":
-                incar[k] = _get_magmoms(
+        for key, val in incar_settings.items():
+            if key == "MAGMOM":
+                incar[key] = get_magmoms(
                     structure,
                     magmoms=self.user_incar_settings.get("MAGMOM", {}),
                     config_magmoms=config_magmoms,
                 )
-            elif k in ("LDAUU", "LDAUJ", "LDAUL") and incar_settings.get("LDAU", False):
-                incar[k] = _get_u_param(k, v, structure)
-            elif k.startswith("EDIFF") and k != "EDIFFG":
-                incar["EDIFF"] = _get_ediff(k, v, structure, incar_settings)
+            elif key in ("LDAUU", "LDAUJ", "LDAUL") and incar_settings.get(
+                "LDAU", False
+            ):
+                incar[key] = _get_u_param(key, val, structure)
+            elif key.startswith("EDIFF") and key != "EDIFFG":
+                incar["EDIFF"] = _get_ediff(key, val, structure, incar_settings)
             else:
-                incar[k] = v
+                incar[key] = val
         _set_u_params(incar, incar_settings, structure)
 
         # apply previous incar settings, be careful not to override user_incar_settings
@@ -903,7 +905,7 @@ class VaspInputGenerator(InputGenerator):
         )
 
 
-def _get_magmoms(
+def get_magmoms(
     structure: Structure,
     magmoms: dict[str, float] = None,
     config_magmoms: dict[str, float] = None,

--- a/tests/common/jobs/test_elastic.py
+++ b/tests/common/jobs/test_elastic.py
@@ -6,7 +6,7 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from atomate2 import SETTINGS
 from atomate2.common.jobs.elastic import generate_elastic_deformations
-from atomate2.common.schemas.elastic import _expand_strains
+from atomate2.common.schemas.elastic import expand_strains
 
 
 @pytest.mark.parametrize("conventional", [False, True])
@@ -25,7 +25,7 @@ def test_reduce_expand_strains(clean_dir, symmetry_structure, conventional):
     dummy_stresses = [Stress(np.zeros((3, 3)))] * len(reduced_strains)
     dummy = ["dummy"] * len(reduced_strains)
 
-    recovered_strains, _, _, _ = _expand_strains(
+    recovered_strains, _, _, _ = expand_strains(
         structure,
         reduced_strains,
         stresses=dummy_stresses,

--- a/tests/vasp/flows/test_eos.py
+++ b/tests/vasp/flows/test_eos.py
@@ -86,7 +86,9 @@ def test_mp_eos_maker(
     }
 
     for idx in range(2):
-        ref_paths[f"EOS MP GGA relax {1+idx}"] = f"mp-149-PBE-EOS_MP_GGA_relax_{1+idx}"
+        ref_paths[f"EOS MP GGA relax {idx + 1}"] = (
+            f"mp-149-PBE-EOS_MP_GGA_relax_{idx + 1}"
+        )
 
     for idx in range(nframes):
         ref_paths[f"EOS MP GGA relax deformation {idx}"] = (

--- a/tests/vasp/test_base.py
+++ b/tests/vasp/test_base.py
@@ -4,8 +4,8 @@ import pytest
 from custodian.vasp.handlers import ErrorHandler
 from pymatgen.core import Lattice, Structure
 
-from atomate2.vasp.run import _DEFAULT_HANDLERS
-from atomate2.vasp.sets.base import _get_magmoms
+from atomate2.vasp.run import DEFAULT_HANDLERS
+from atomate2.vasp.sets.base import get_magmoms
 
 
 @pytest.mark.parametrize("magmoms", [None, {"Co": 0.8, "Fe": 2.2}])
@@ -27,7 +27,7 @@ def test_get_magmoms(
     msg = "Co without an oxidation state is initialized as low spin by default"
     # check there are no warnings
     with pytest.warns(None if magmoms else UserWarning) as warns:
-        out = _get_magmoms(struct, magmoms=magmoms, config_magmoms=config_magmoms)
+        out = get_magmoms(struct, magmoms=magmoms, config_magmoms=config_magmoms)
 
         expected_magmoms = list(
             (magmoms or config_magmoms or {"Co": 0.6, "Fe": 0.6}).values()
@@ -51,10 +51,10 @@ def test_get_magmoms_with_specie() -> None:
     site = struct.sites[0]
     assert not hasattr(site, "magmom")
     assert struct[0].specie.spin is None
-    out = _get_magmoms(struct)
+    out = get_magmoms(struct)
     assert out == [0.6, 0.6]
 
 
 def test_default_handlers():
-    assert len(_DEFAULT_HANDLERS) >= 8
-    assert all(isinstance(handler, ErrorHandler) for handler in _DEFAULT_HANDLERS)
+    assert len(DEFAULT_HANDLERS) >= 8
+    assert all(isinstance(handler, ErrorHandler) for handler in DEFAULT_HANDLERS)


### PR DESCRIPTION
prefix "_" indicates private but cross-imported means de facto public.

strictly speaking breaking if downstream code was importing these private symbols but given they were marked private there was no expectation of stability.