### PR TITLE
Warn on non-default `ATOMATE2_CONFIG_FILE` that's not found

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.3.0
+  rev: v0.3.4
   hooks:
   - id: ruff
     args: [--fix]
@@ -29,7 +29,7 @@ repos:
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.8.0
+  rev: v1.9.0
   hooks:
   - id: mypy
     files: ^src/

--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -10,6 +10,7 @@ from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _DEFAULT_CONFIG_FILE_PATH = "~/.atomate2.yaml"
+_ENV_PREFIX = "atomate2_"
 
 
 class Atomate2Settings(BaseSettings):
@@ -190,7 +191,7 @@ class Atomate2Settings(BaseSettings):
         None, description="Additional settings applied to AMSET settings file."
     )
 
-    model_config = SettingsConfigDict(env_prefix="atomate2_")
+    model_config = SettingsConfigDict(env_prefix=_ENV_PREFIX)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -206,14 +206,15 @@ class Atomate2Settings(BaseSettings):
         """
         from monty.serialization import loadfn
 
-        config_file_path = values.get("CONFIG_FILE", _DEFAULT_CONFIG_FILE_PATH)
+        config_file_path = values.get(key := "CONFIG_FILE", _DEFAULT_CONFIG_FILE_PATH)
+        env_var_name = f"{_ENV_PREFIX.upper()}{key}"
         config_file_path = Path(config_file_path).expanduser()
 
         new_values = {}
         if config_file_path.exists():
             if config_file_path.stat().st_size == 0:
                 warnings.warn(
-                    f"Using atomate2 config file at {config_file_path} but it's empty",
+                    f"Using {env_var_name} at {config_file_path} but it's empty",
                     stacklevel=2,
                 )
             else:
@@ -221,7 +222,7 @@ class Atomate2Settings(BaseSettings):
                     new_values.update(loadfn(config_file_path))
                 except ValueError:
                     raise SyntaxError(
-                        f"atomate2 config file at {config_file_path} is unparsable"
+                        f"{env_var_name} at {config_file_path} is unparsable"
                     ) from None
 
         return {**new_values, **values}

--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -224,5 +224,10 @@ class Atomate2Settings(BaseSettings):
                     raise SyntaxError(
                         f"{env_var_name} at {config_file_path} is unparsable"
                     ) from None
+        # warn if config path is not the default but file doesn't exist
+        elif config_file_path != Path(_DEFAULT_CONFIG_FILE_PATH).expanduser():
+            warnings.warn(
+                f"{env_var_name} at {config_file_path} does not exist", stacklevel=2
+            )
 
         return {**new_values, **values}

--- a/tests/common/test_settings.py
+++ b/tests/common/test_settings.py
@@ -60,3 +60,8 @@ def test_empty_and_invalid_config_file(
         "Input should be a valid number",
     ):
         Atomate2Settings()
+
+    # test warning if config path is non-default and file does not exist
+    config_file_path.unlink()
+    with pytest.warns(UserWarning, match=f"{env_var_name} at .+ does not exist"):
+        Atomate2Settings()

--- a/tests/common/test_settings.py
+++ b/tests/common/test_settings.py
@@ -3,13 +3,23 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from atomate2.settings import _ENV_PREFIX, Atomate2Settings
+from atomate2.settings import _DEFAULT_CONFIG_FILE_PATH, _ENV_PREFIX, Atomate2Settings
 
 
-def test_empty_and_invalid_config_file(clean_dir, monkeypatch: pytest.MonkeyPatch):
+def test_empty_and_invalid_config_file(
+    clean_dir, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    # test no warning if config path is default and file does not exist
+    env_var_name = f"{_ENV_PREFIX.upper()}CONFIG_FILE"
+    monkeypatch.delenv(env_var_name, raising=False)
+    settings = Atomate2Settings()
+    assert settings.CONFIG_FILE == _DEFAULT_CONFIG_FILE_PATH
+    stdout, stderr = capsys.readouterr()
+    assert stdout == ""
+    assert stderr == ""
+
     # set path to load settings from with ATOMATE2_CONFIG_FILE env variable
     config_file_path = Path.cwd() / "test-atomate2-config.yaml"
-    env_var_name = f"{_ENV_PREFIX.upper()}CONFIG_FILE"
     monkeypatch.setenv(env_var_name, str(config_file_path))
 
     settings = Atomate2Settings()


### PR DESCRIPTION
just a small QoL improvement to warn users when they set a custom `ATOMATE2_CONFIG_FILE` but the file doesn't exist

@utf i added tests to assert
- no warning if config path is default and file does not exist
- warning if config path is non-default and file does not exist

also  used `monkeypatch.setenv("ATOMATE2_CONFIG_FILE", ...)` which is auto-reverted on test-exit to avoid polluting other tests