### PR TITLE
Bug in supercell matrix determination in phonon workflow

### DIFF
--- a/src/atomate2/common/jobs/phonons.py
+++ b/src/atomate2/common/jobs/phonons.py
@@ -101,7 +101,8 @@ def get_supercell_size(
             )
             transformation.apply_transformation(structure=structure)
 
-    return transformation.transformation_matrix.tolist()
+    # matrix from pymatgen has to be transposed
+    return transformation.transformation_matrix.transpose().tolist()
 
 
 @job(data=[Structure])


### PR DESCRIPTION
## Summary

Currently, the supercells that are generated with the phonon workflow are sometimes not as cubic as possible (e.g., for diamond-type Si). This is due to a bug in the supercell matrix handling. The supercell matrix as determined by pymatgen needs to be transposed before it is inserted into phonopy. 

- [ ] add tests