### PR TITLE
fix CP2K TaskDocument

### DIFF
--- a/src/atomate2/cp2k/schemas/calc_types/utils.py
+++ b/src/atomate2/cp2k/schemas/calc_types/utils.py
@@ -71,7 +71,7 @@ def task_type(inputs: dict) -> TaskType:
     """
     calc_type = []
     cp2k_run_type = inputs.get("cp2k_global", {}).get("Run_type", "")
-    ci = Cp2kInput.from_dict(inputs["cp2k_input"])
+    ci = inputs['cp2k_input']
 
     if cp2k_run_type.upper() in (
         "ENERGY",

--- a/src/atomate2/cp2k/schemas/calc_types/utils.py
+++ b/src/atomate2/cp2k/schemas/calc_types/utils.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 
 from monty.serialization import loadfn
-from pymatgen.io.cp2k.inputs import Cp2kInput, Keyword, KeywordList
+from pymatgen.io.cp2k.inputs import Keyword, KeywordList
 
 from atomate2.cp2k.schemas.calc_types import CalcType, RunType, TaskType
 
@@ -71,7 +71,7 @@ def task_type(inputs: dict) -> TaskType:
     """
     calc_type = []
     cp2k_run_type = inputs.get("cp2k_global", {}).get("Run_type", "")
-    ci = inputs['cp2k_input']
+    ci = inputs["cp2k_input"]
 
     if cp2k_run_type.upper() in (
         "ENERGY",

--- a/src/atomate2/cp2k/schemas/calculation.py
+++ b/src/atomate2/cp2k/schemas/calculation.py
@@ -16,7 +16,7 @@ from pymatgen.core.units import Ha_to_eV
 from pymatgen.electronic_structure.bandstructure import BandStructure
 from pymatgen.electronic_structure.dos import Dos
 from pymatgen.io.common import VolumetricData
-from pymatgen.io.cp2k.inputs import BasisFile, DataFile, PotentialFile, Cp2kInput
+from pymatgen.io.cp2k.inputs import BasisFile, Cp2kInput, DataFile, PotentialFile
 from pymatgen.io.cp2k.outputs import Cp2kOutput, parse_energy_file
 from typing_extensions import Self
 
@@ -71,7 +71,9 @@ class CalculationInput(BaseModel):
         None, description="Description of parameters used for each atomic kind"
     )
 
-    cp2k_input: Union[dict, Cp2kInput] = Field(None, description="The cp2k input used for this task")
+    cp2k_input: Union[dict, Cp2kInput] = Field(
+        None, description="The cp2k input used for this task"
+    )
 
     dft: dict = Field(
         None,

--- a/src/atomate2/cp2k/schemas/calculation.py
+++ b/src/atomate2/cp2k/schemas/calculation.py
@@ -16,7 +16,7 @@ from pymatgen.core.units import Ha_to_eV
 from pymatgen.electronic_structure.bandstructure import BandStructure
 from pymatgen.electronic_structure.dos import Dos
 from pymatgen.io.common import VolumetricData
-from pymatgen.io.cp2k.inputs import BasisFile, DataFile, PotentialFile
+from pymatgen.io.cp2k.inputs import BasisFile, DataFile, PotentialFile, Cp2kInput
 from pymatgen.io.cp2k.outputs import Cp2kOutput, parse_energy_file
 from typing_extensions import Self
 
@@ -71,7 +71,7 @@ class CalculationInput(BaseModel):
         None, description="Description of parameters used for each atomic kind"
     )
 
-    cp2k_input: dict = Field(None, description="The cp2k input used for this task")
+    cp2k_input: Union[dict, Cp2kInput] = Field(None, description="The cp2k input used for this task")
 
     dft: dict = Field(
         None,
@@ -170,7 +170,7 @@ class CalculationOutput(BaseModel):
     ionic_steps: list[dict[str, Any]] = Field(
         None, description="Energy, forces, and structure for each ionic step"
     )
-    locpot: dict[int, list[float]] = Field(
+    locpot: Union[dict[int, list[float]], None] = Field(
         None, description="Average of the local potential along the crystal axes"
     )
     run_stats: RunStatistics = Field(


### PR DESCRIPTION
## Summary

This PR addresses the ValidationError occurring in the TaskDocument schema due to improper handling of the cp2k_input and locpot fields. This issue is documented in issue #899 

* Changed `cp2k_input` in CalculationInput to be a union of `CP2KInput` object and dict to accommodate different possible types for cp2k_input
* Changed `locpot` in CalculationOutput to be an optional field