### PR TITLE
Add back `symprec` kwarg to MP and MatPES set generators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,7 @@ ignore = [
     "S324",    # use of insecure hash function
     "S507",    # paramiko auto trust
     "S603",    # use of insecure subprocess
-    "TD",      # TODOs
+    "TD",      # todos
     "TRY003",  # long message outside exception class
 ]
 pydocstyle.convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ forcefields = [
     "calorine<=2.2.1",
     "chgnet>=0.2.2",
     "mace-torch>=0.3.3",
-    "matgl>=1.1.1",
+    "matgl>=1.1.3",
     "quippy-ase>=0.9.14",
     "sevenn>=0.9.3",
     "torch<=2.2.1",       # incompatibility with dgl if newer versions are used
@@ -93,7 +93,7 @@ strict = [
     "jobflow==0.1.18",
     "lobsterpy==0.4.5",
     "mace-torch>=0.3.3",
-    "matgl==1.1.2",
+    "matgl==1.1.3",
     "monty==2024.7.30",
     "mp-api==0.41.2",
     "numpy",

--- a/src/atomate2/vasp/sets/matpes.py
+++ b/src/atomate2/vasp/sets/matpes.py
@@ -24,9 +24,12 @@ class MatPesGGAStaticSetGenerator(MatPESStaticSet):
     xc_functional: Literal["R2SCAN", "PBE", "PBE+U"] = "PBE"
     auto_ismear: bool = False
     auto_kspacing: bool = False
+    symprec: float | None = None
 
     def __post_init__(self) -> None:
         """Raise deprecation warning and validate."""
+        if self.symprec is not None:
+            self.sym_prec = self.symprec
         super().__post_init__()
 
 
@@ -42,9 +45,12 @@ class MatPesMetaGGAStaticSetGenerator(MatPESStaticSet):
     xc_functional: Literal["R2SCAN", "PBE", "PBE+U"] = "R2SCAN"
     auto_ismear: bool = False
     auto_kspacing: bool = False
+    symprec: float | None = None
 
     def __post_init__(self) -> None:
         """Raise deprecation warning and validate."""
+        if self.symprec is not None:
+            self.sym_prec = self.symprec
         super().__post_init__()
 
     @property

--- a/src/atomate2/vasp/sets/mp.py
+++ b/src/atomate2/vasp/sets/mp.py
@@ -40,9 +40,12 @@ class MPGGARelaxSetGenerator(MPRelaxSet):
     bandgap_tol: float = None
     force_gamma: bool = True
     auto_metal_kpoints: bool = True
+    symprec: float | None = None
 
     def __post_init__(self) -> None:
         """Raise deprecation warning and validate."""
+        if self.symprec is not None:
+            self.sym_prec = self.symprec
         super().__post_init__()
 
 
@@ -57,9 +60,12 @@ class MPGGAStaticSetGenerator(MPStaticSet):
     inherit_incar: bool | None = False
     force_gamma: bool = True
     auto_metal_kpoints: bool = True
+    symprec: float | None = None
 
     def __post_init__(self) -> None:
         """Raise deprecation warning and validate."""
+        if self.symprec is not None:
+            self.sym_prec = self.symprec
         super().__post_init__()
 
 
@@ -72,9 +78,12 @@ class MPMetaGGAStaticSetGenerator(MPScanStaticSet):
     auto_kspacing: bool = True
     bandgap_tol: float = 1e-4
     inherit_incar: bool | None = False
+    symprec: float | None = None
 
     def __post_init__(self) -> None:
         """Raise deprecation warning and validate."""
+        if self.symprec is not None:
+            self.sym_prec = self.symprec
         super().__post_init__()
 
     @property
@@ -118,9 +127,12 @@ class MPMetaGGARelaxSetGenerator(MPScanRelaxSet):
     auto_ismear: bool = False
     auto_kspacing: bool = True
     inherit_incar: bool | None = False
+    symprec: float | None = None
 
     def __post_init__(self) -> None:
         """Raise deprecation warning and validate."""
+        if self.symprec is not None:
+            self.sym_prec = self.symprec
         super().__post_init__()
 
     @property


### PR DESCRIPTION
following input set migration to `pymatgen` in #854, flows serialized to a database before that PR can no longer be instantiated and launched with the latest `atomate2` resulting in a `TypeError`

```py
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 790, in process_decoded                                                 
    return cls_.from_dict(data)                                              
           ^^^^^^^^^^^^^^^^^^^^                                              
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 245, in from_dict                                                       
    k: MontyDecoder().process_decoded(v)                                     
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                     
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 738, in process_decoded                                                 
    obj = self.process_decoded(d["@bound"])                                  
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                  
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 790, in process_decoded                                                 
    return cls_.from_dict(data)                                              
           ^^^^^^^^^^^^^^^^^^^^                                              
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 245, in from_dict                                                       
    k: MontyDecoder().process_decoded(v)                                     
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                     
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 790, in process_decoded                                                 
    return cls_.from_dict(data)                                              
           ^^^^^^^^^^^^^^^^^^^^                                              
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 249, in from_dict                                                       
    return cls(**decoded)                                                    
           ^^^^^^^^^^^^^^                                                    
TypeError: MatPesGGAStaticSetGenerator.__init__() got an unexpected keyword  
argument 'symprec'   currently, trying to launch a job that was created before the 

```py
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 790, in process_decoded                                                 
    return cls_.from_dict(data)                                              
           ^^^^^^^^^^^^^^^^^^^^                                              
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 245, in from_dict                                                       
    k: MontyDecoder().process_decoded(v)                                     
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                     
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 738, in process_decoded                                                 
    obj = self.process_decoded(d["@bound"])                                  
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                  
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 790, in process_decoded                                                 
    return cls_.from_dict(data)                                              
           ^^^^^^^^^^^^^^^^^^^^                                              
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 245, in from_dict                                                       
    k: MontyDecoder().process_decoded(v)                                     
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                     
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 790, in process_decoded                                                 
    return cls_.from_dict(data)                                              
           ^^^^^^^^^^^^^^^^^^^^                                              
  File                                                                       
"/lambdafs/janosh/.venv/p312/lib/python3.12/site-packages/monty/json.py",    
line 249, in from_dict                                                       
    return cls(**decoded)                                                    
           ^^^^^^^^^^^^^^                                                    
TypeError: MatPesGGAStaticSetGenerator.__init__() got an unexpected keyword  
argument 'symprec'   
```