### PR TITLE
Fix MPID assignment in electrode workflow

### DIFF
--- a/src/atomate2/common/jobs/electrode.py
+++ b/src/atomate2/common/jobs/electrode.py
@@ -171,7 +171,7 @@ def get_structure_group_doc(
 ) -> Response:
     """Take in `ComputedEntry` and return a `StructureGroupDoc`."""
     for ient in computed_entries:
-        if not (entry_id := str(entry_id)).startswith("mp-"):
+        if not (entry_id := str(ient.entry_id)).startswith("mp-"):
             entry_id = "mp-0000000"
         ient.data["material_id"] = entry_id
     return StructureGroupDoc.from_grouped_entries(
@@ -185,7 +185,7 @@ def get_insertion_electrode_doc(
 ) -> Response:
     """Return a `InsertionElectrodeDoc`."""
     for ient in computed_entries:
-        if not (entry_id := str(entry_id)).startswith("mp-"):
+        if not (entry_id := str(ient.entry_id)).startswith("mp-"):
             entry_id = "mp-0000000"
         ient.data["material_id"] = entry_id
     return InsertionElectrodeDoc.from_entries(

--- a/src/atomate2/common/jobs/electrode.py
+++ b/src/atomate2/common/jobs/electrode.py
@@ -154,13 +154,13 @@ def get_computed_entries(
         return multi
     # keep the [1] for now, if jobflow supports NamedTuple, we can do this much cleaner
     s_ = RelaxJobSummary._make(single)
-    s_.entry.entry_id = s_.uuid
+    s_.entry.entry_id = "mp-0000000"
     ent = ComputedStructureEntry(
         structure=s_.structure,
         energy=s_.entry.energy,
         parameters=s_.entry.parameters,
         data=s_.entry.data,
-        entry_id=s_.uuid,
+        entry_id="mp-0000000",
     )
     return [*multi, ent]
 
@@ -171,7 +171,9 @@ def get_structure_group_doc(
 ) -> Response:
     """Take in `ComputedEntry` and return a `StructureGroupDoc`."""
     for ient in computed_entries:
-        ient.data["material_id"] = ient.entry_id
+        if not (entry_id := str(entry_id)).startswith("mp-"):
+            entry_id = "mp-0000000"
+        ient.data["material_id"] = entry_id
     return StructureGroupDoc.from_grouped_entries(
         computed_entries, ignored_specie=ignored_species
     )
@@ -183,7 +185,9 @@ def get_insertion_electrode_doc(
 ) -> Response:
     """Return a `InsertionElectrodeDoc`."""
     for ient in computed_entries:
-        ient.data["material_id"] = ient.entry_id
+        if not (entry_id := str(entry_id)).startswith("mp-"):
+            entry_id = "mp-0000000"
+        ient.data["material_id"] = entry_id
     return InsertionElectrodeDoc.from_entries(
         computed_entries, working_ion_entry, battery_id=None
     )

--- a/src/atomate2/common/jobs/electrode.py
+++ b/src/atomate2/common/jobs/electrode.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import logging
-from ulid import ULID
 from typing import TYPE_CHECKING, Callable, NamedTuple
 
 from emmet.core.electrode import InsertionElectrodeDoc
-from emmet.core.structure_group import StructureGroupDoc
 from emmet.core.mpid import MPID
+from emmet.core.structure_group import StructureGroupDoc
 from jobflow import Flow, Maker, Response, job
 from pymatgen.analysis.defects.generators import ChargeInterstitialGenerator
 from pymatgen.entries.computed_entries import ComputedStructureEntry
+from ulid import ULID
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/atomate2/common/jobs/electrode.py
+++ b/src/atomate2/common/jobs/electrode.py
@@ -154,13 +154,14 @@ def get_computed_entries(
         return multi
     # keep the [1] for now, if jobflow supports NamedTuple, we can do this much cleaner
     s_ = RelaxJobSummary._make(single)
-    s_.entry.entry_id = "mp-0000000"
+    temp_mpid = f"mp-{len(multi) + 1}"
+    s_.entry.entry_id = temp_mpid
     ent = ComputedStructureEntry(
         structure=s_.structure,
         energy=s_.entry.energy,
         parameters=s_.entry.parameters,
         data=s_.entry.data,
-        entry_id="mp-0000000",
+        entry_id=temp_mpid,
     )
     return [*multi, ent]
 
@@ -170,9 +171,9 @@ def get_structure_group_doc(
     computed_entries: list[ComputedEntry], ignored_species: str
 ) -> Response:
     """Take in `ComputedEntry` and return a `StructureGroupDoc`."""
-    for ient in computed_entries:
+    for idx, ient in enumerate(computed_entries):
         if not (entry_id := str(ient.entry_id)).startswith("mp-"):
-            entry_id = "mp-0000000"
+            entry_id = f"mp-{idx+1}"
         ient.data["material_id"] = entry_id
     return StructureGroupDoc.from_grouped_entries(
         computed_entries, ignored_specie=ignored_species
@@ -184,9 +185,9 @@ def get_insertion_electrode_doc(
     computed_entries: ComputedEntry, working_ion_entry: ComputedEntry
 ) -> Response:
     """Return a `InsertionElectrodeDoc`."""
-    for ient in computed_entries:
+    for idx, ient in enumerate(computed_entries):
         if not (entry_id := str(ient.entry_id)).startswith("mp-"):
-            entry_id = "mp-0000000"
+            entry_id =f"mp-{idx+1}"
         ient.data["material_id"] = entry_id
     return InsertionElectrodeDoc.from_entries(
         computed_entries, working_ion_entry, battery_id=None

--- a/src/atomate2/common/jobs/electrode.py
+++ b/src/atomate2/common/jobs/electrode.py
@@ -187,7 +187,7 @@ def get_insertion_electrode_doc(
     """Return a `InsertionElectrodeDoc`."""
     for idx, ient in enumerate(computed_entries):
         if not (entry_id := str(ient.entry_id)).startswith("mp-"):
-            entry_id =f"mp-{idx+1}"
+            entry_id = f"mp-{idx+1}"
         ient.data["material_id"] = entry_id
     return InsertionElectrodeDoc.from_entries(
         computed_entries, working_ion_entry, battery_id=None

--- a/tests/vasp/flows/test_electrode.py
+++ b/tests/vasp/flows/test_electrode.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+
 def test_electrode_makers(mock_vasp, clean_dir, test_dir, mock_jobflow_settings):
     from emmet.core.electrode import InsertionElectrodeDoc
     from jobflow import OutputReference, run_locally

--- a/tests/vasp/flows/test_electrode.py
+++ b/tests/vasp/flows/test_electrode.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-def test_electrode_makers(mock_vasp, clean_dir, test_dir, mock_jobflow_settings):
+def test_electrode_makers(mock_vasp, clean_dir, test_dir):
     from emmet.core.electrode import InsertionElectrodeDoc
     from jobflow import OutputReference, run_locally
     from monty.serialization import loadfn
@@ -14,7 +14,6 @@ def test_electrode_makers(mock_vasp, clean_dir, test_dir, mock_jobflow_settings)
         update_user_incar_settings,
         update_user_kpoints_settings,
     )
-    # mock the default setting
 
     # mapping from job name to directory containing test files
     ref_paths = {

--- a/tests/vasp/flows/test_electrode.py
+++ b/tests/vasp/flows/test_electrode.py
@@ -1,24 +1,5 @@
 from __future__ import annotations
 
-from unittest import mock
-
-import pytest
-from jobflow.settings import JobflowSettings
-
-
-@pytest.fixture()
-def mock_jobflow_settings(memory_jobstore):
-    """Set the UID_TYPE to "ulid" to make sure the documents can be sorted.
-
-    See: https://github.com/materialsproject/jobflow/issues/519#issuecomment-1906850096
-    """
-
-    settings = JobflowSettings(JOB_STORE=memory_jobstore, UID_TYPE="ulid")
-
-    with mock.patch("jobflow.SETTINGS", settings):
-        yield
-
-
 def test_electrode_makers(mock_vasp, clean_dir, test_dir, mock_jobflow_settings):
     from emmet.core.electrode import InsertionElectrodeDoc
     from jobflow import OutputReference, run_locally


### PR DESCRIPTION
Minor bugfix: in `atomate2.common.jobs.electrode`, the utility functions `get_computed_entries`, `get_structure_group_doc`, and `get_insertion_electrode_doc` assign MPIDs via UUIDs, which leads to pydantic errors when the documents are serialized (an MPID has to have the form `mp-<int>`).

Thanks to @RobertaPascazio for catching this. Copy @jmmshn  to make sure this is still compliant with the flow format.