### PR TITLE
New Lobster workflow with additional speedup due to two subsequent Lobster runs

### DIFF
--- a/src/atomate2/lobster/flows.py
+++ b/src/atomate2/lobster/flows.py
@@ -1,0 +1,83 @@
+"""Module defining lobster jobs."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from jobflow import Maker, job
+from pymatgen.electronic_structure.cohp import CompleteCohp
+from pymatgen.electronic_structure.dos import LobsterCompleteDos
+from pymatgen.io.lobster import Bandoverlaps, Icohplist, Lobsterin
+
+from atomate2 import SETTINGS
+from atomate2.common.files import gzip_output_folder
+from atomate2.lobster.files import (
+    LOBSTEROUTPUT_FILES,
+    VASP_OUTPUT_FILES,
+    copy_lobster_files,
+)
+from atomate2.lobster.jobs import LobsterMaker
+from atomate2.lobster.run import run_lobster
+from atomate2.lobster.schemas import LobsterTaskDocument
+
+logger = logging.getLogger(__name__)
+
+
+_FILES_TO_ZIP = [*LOBSTEROUTPUT_FILES, "lobsterin", *VASP_OUTPUT_FILES]
+
+
+
+@dataclass
+class AdvancedLobsterMaker(Maker):
+    """
+    LOBSTER job maker with additional speedup.
+
+    1. The maker copies DFT output files necessary for the LOBSTER run.
+    2. It will create all lobsterin files, run LOBSTER several times,
+        zip the outputs and parse the LOBSTER outputs. In this step, the COHP/COBI/COOP
+        curves will only be written with a limited accuracy.
+    3. After an analysis of the most important bonds, COHP/COBI/COOP curves for those will
+        be computed with high accuracy.
+
+    In the future, this workflow could also benefit from further symmetry considerations.
+
+    Parameters
+    ----------
+    name : str
+        Name of jobs produced by this maker.
+    task_document_kwargs : dict
+        Keyword arguments passed to :obj:`.LobsterTaskDocument.from_directory`.
+    user_lobsterin_settings : dict
+        Dict including additional information on the Lobster settings.
+    run_lobster_kwargs : dict
+        Keyword arguments that will get passed to :obj:`.run_lobster`.
+    calculation_type : str
+        Type of calculation for the Lobster run that will get passed to
+        :obj:`.Lobsterin.standard_calculations_from_vasp_files`.
+    """
+    name: str = "lobster"
+    lobster_maker_1: LobsterMaker=field(default_factory=lambda:LobsterMaker(user_lobsterin_settings={"cohpsteps":1}))
+    lobster_maker_2: LobsterMaker=field(default_factory=LobsterMaker)
+
+    def make(
+            self,
+            wavefunction_dir: str | Path = None,
+            basis_dict: dict | None = None,
+    ) -> LobsterTaskDocument:
+        """Run a LOBSTER calculation.
+
+        Parameters
+        ----------
+        wavefunction_dir : str or Path
+            A directory containing a WAVEFUNCTION and other outputs needed for Lobster
+        basis_dict: dict
+            A dict including information on the basis set
+        """
+        jobs=[]
+        lobster_maker=LobsterMaker().make(wavefunction_dir, basis_dict)
+        jobs.append(lobster_maker)
+
+        # code to postprocess the lobster data and identify relevant bonds
+

--- a/src/atomate2/lobster/jobs.py
+++ b/src/atomate2/lobster/jobs.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 _FILES_TO_ZIP = [*LOBSTEROUTPUT_FILES, "lobsterin", *VASP_OUTPUT_FILES]
 
 
+
 @dataclass
 class LobsterMaker(Maker):
     """

--- a/tests/vasp/lobster/flows/test_lobster.py
+++ b/tests/vasp/lobster/flows/test_lobster.py
@@ -327,3 +327,88 @@ def test_mp_vasp_lobstermaker(
     )
 
     assert isinstance(task_doc, LobsterTaskDocument)
+
+def test_improved_lobster_maker(
+    mock_vasp, mock_lobster, clean_dir, memory_jobstore, si_structure: Structure
+):
+    # mapping from job name to directory containing test files
+    ref_paths = {
+        "relax 1": "Si_lobster_uniform/relax_1",
+        "relax 2": "Si_lobster_uniform/relax_2",
+        "static": "Si_lobster_uniform/static",
+        "non-scf uniform": "Si_lobster_uniform/non-scf_uniform",
+    }
+
+    # settings passed to fake_run_vasp; adjust these to check for certain INCAR settings
+    fake_run_vasp_kwargs = {
+        "relax 1": {"incar_settings": ["NSW", "ISMEAR"]},
+        "relax 2": {"incar_settings": ["NSW", "ISMEAR"]},
+        "static": {
+            "incar_settings": [
+                "NSW",
+                "LWAVE",
+                "ISMEAR",
+                "ISYM",
+                "NBANDS",
+                "ISPIN",
+                "LCHARG",
+            ],
+            # TODO restore POSCAR input checking e.g. when next updating test files
+            "check_inputs": ["potcar", "kpoints", "incar"],
+        },
+        "non-scf uniform": {
+            "incar_settings": [
+                "NSW",
+                "LWAVE",
+                "ISMEAR",
+                "ISYM",
+                "NBANDS",
+                "ISPIN",
+                "ICHARG",
+            ],
+            # TODO restore POSCAR input checking e.g. when next updating test files
+            "check_inputs": ["potcar", "kpoints", "incar"],
+        },
+    }
+
+    ref_paths_lobster = {
+        "lobster_run_0": "Si_lobster/lobster_0",
+    }
+
+    # settings passed to fake_run_vasp; adjust these to check for certain INCAR settings
+    fake_run_lobster_kwargs = {
+        "lobster_run_0": {"lobsterin_settings": ["basisfunctions"]},
+    }
+
+    # automatically use fake VASP and write POTCAR.spec during the test
+    mock_vasp(ref_paths, fake_run_vasp_kwargs)
+    mock_lobster(ref_paths_lobster, fake_run_lobster_kwargs)
+
+    job = VaspLobsterMaker(
+        lobster_maker=LobsterMaker(
+            task_document_kwargs={
+                "calc_quality_kwargs": {"potcar_symbols": ["Si"], "n_bins": 10},
+                "add_coxxcar_to_task_document": True,
+            },
+            user_lobsterin_settings={
+                "COHPstartEnergy": -5.0,
+                "COHPEndEnergy": 5.0,
+                "cohpGenerator": "from 0.1 to 3.0 orbitalwise",
+            },
+        ),
+        delete_wavecars=False,
+    ).make(si_structure)
+    job = update_user_incar_settings(job, {"NPAR": 4})
+
+    # run the flow or job and ensure that it finished running successfully
+    responses = run_locally(
+        job, store=memory_jobstore, create_folders=True, ensure_success=True
+    )
+
+    assert isinstance(
+        responses[job.jobs[-1].uuid][1]
+        .replace.output["lobster_task_documents"][0]
+        .resolve(memory_jobstore),
+        LobsterTaskDocument,
+    )
+


### PR DESCRIPTION
## Summary

The new Lobster workflow will first compute all ICOHPs (this is fast) and only generate very small COHPCAR files (1 cohpstep). In a second step, COHPCARs for relevant bonds according to the ICOHPs will be generated. This should lead to a significant speedup. Additionally, it will save data storage capacity. 