### PR TITLE
[WIP] Minor fixes to ASE tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
   rev: v2.3.0
   hooks:
   - id: codespell
-    stages: [commit, commit-msg]
+    stages: [pre-commit, commit-msg]
     args: [--ignore-words-list, 'titel,statics,ba,nd,te,atomate']
     types_or: [python, rst, markdown]
 - repo: https://github.com/kynan/nbstripout

--- a/tests/ase/test_md.py
+++ b/tests/ase/test_md.py
@@ -42,7 +42,7 @@ def test_ase_nvt_maker(calculator_name, lj_fcc_ne_pars, fcc_ne_structure, clean_
         store_trajectory="partial",
     ).make(fcc_ne_structure)
 
-    response = run_locally(md_job)
+    response = run_locally(md_job, ensure_success=True)
     output = response[md_job.uuid][1].output
 
     assert isinstance(output, AseStructureTaskDoc)
@@ -77,13 +77,15 @@ def test_ase_npt_maker(calculator_name, lj_fcc_ne_pars, fcc_ne_structure, tmp_di
         ionic_step_data=("energy", "stress"),
     ).make(structure)
 
-    response = run_locally(md_job)
+    response = run_locally(md_job, ensure_success=True)
     output = response[md_job.uuid][1].output
 
     assert isinstance(output, AseStructureTaskDoc)
     assert output.output.energy_per_atom == pytest.approx(
         reference_energies[calculator_name]
     )
+    assert output.dir_name is not None
+    assert output.formula_pretty is not None 
 
     # TODO: improve XDATCAR parsing test when class is fixed in pmg
     assert os.path.isfile("XDATCAR")


### PR DESCRIPTION
# Minor fixes to ASE tests

Since the `ForceFieldTaskDocument` requires a `dir_name` now we should check that the ase calculator is able to serialize that properly.

I've notice some inconsistent behavior on our end and this might be the culprit.