### PR TITLE
Orb_support

### DIFF
--- a/src/atomate2/forcefields/__init__.py
+++ b/src/atomate2/forcefields/__init__.py
@@ -16,6 +16,7 @@ class MLFF(Enum):  # TODO inherit from StrEnum when 3.11+
     NEP = "NEP"
     Nequip = "Nequip"
     SevenNet = "SevenNet"
+    Orb = "Orb"
 
 
 def _get_formatted_ff_name(force_field_name: str | MLFF) -> str:

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -83,6 +83,13 @@ def ase_calculator(calculator_meta: str | dict, **kwargs: Any) -> Calculator | N
 
             calculator = SevenNetCalculator(**{"model": "7net-0"} | kwargs)
 
+        elif calculator_name == MLFF.Orb:
+            from orb_models.forcefield import pretrained
+            from orb_models.forcefield.calculator import ORBCalculator
+
+            orbff = pretrained.orb_v2()
+            calculator = ORBCalculator(orbff)
+
     elif isinstance(calculator_meta, dict):
         calc_cls = MontyDecoder().decode(json.dumps(calculator_meta))
         calculator = calc_cls(**kwargs)

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -215,6 +215,25 @@ def test_mace_static_maker(si_structure: Structure, test_dir: Path, model):
         MACEStaticMaker()
 
 
+def test_orb_static_maker(si_structure: Structure):
+    importorskip("orb_models")
+
+    # generate job
+    # NOTE the test model is not trained on Si, so the energy is not accurate
+    job = ForceFieldStaticMaker(
+        force_field_name="Orb",
+        ionic_step_data=("structure", "energy"),
+    ).make(si_structure)
+
+    # run the flow or job and ensure that it finished running successfully
+    responses = run_locally(job, ensure_success=True)
+
+    # validation the outputs of the job
+    output1 = responses[job.uuid][1].output
+    assert isinstance(output1, ForceFieldTaskDocument)
+    assert output1.output.n_steps == 1
+
+
 @pytest.mark.parametrize(
     "fix_symmetry, symprec", [(True, 1e-2), (False, 1e-2), (True, 1e-1)]
 )

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -217,6 +217,7 @@ def test_mace_static_maker(si_structure: Structure, test_dir: Path, model):
 
 def test_orb_static_maker(si_structure: Structure):
     importorskip("orb_models")
+    importorskip("pynanoflann")
 
     # generate job
     # NOTE the test model is not trained on Si, so the energy is not accurate


### PR DESCRIPTION
## Summary

Add support for the Orb forcefield calculator

## Additional dependencies introduced (if any)

This adds a dependency for `orb_models` and `pynanonflann`. The `orb_models` repo has a strict dependency on torch 2.2.0, though locally I have it working with 2.4.0. I wrote a test and added an `importorskip` call but did not modify the pyproject.toml. Having all models tested and installed in a single environment feels increasingly untenable. I don't want to add a new dependency that will mess with the resolver.

## Linting

* [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [ ] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [ ] Tests have been added for any new functionality or bug fixes.
* [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
