### PR TITLE
feat: add dedicated fireworks optional dependency (Fix #1033).

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ docs = [
 ]
 dev = ["pre-commit>=2.12.1"]
 tests = [
-    "FireWorks==2.0.3", 
+    "FireWorks==2.0.3",
     "nbmake==1.5.4",
     "pytest-cov==5.0.0",
     "pytest-mock==3.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ openmm = [
 ]
 fireworks = ["FireWorks==2.0.3"]
 docs = [
+    "FireWorks==2.0.3",
     "autodoc_pydantic==2.2.0",
     "furo==2024.8.6",
     "ipython==8.29.0",
@@ -82,6 +83,7 @@ docs = [
 ]
 dev = ["pre-commit>=2.12.1"]
 tests = [
+    "FireWorks==2.0.3", 
     "nbmake==1.5.4",
     "pytest-cov==5.0.0",
     "pytest-mock==3.14.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,8 @@ openmm = [
     "openmm-mdanalysis-reporter>=0.1.0",
     "openmm>=8.1.0",
 ]
+fireworks = ["FireWorks==2.0.3"]
 docs = [
-    "FireWorks==2.0.3",
     "autodoc_pydantic==2.2.0",
     "furo==2024.8.6",
     "ipython==8.29.0",
@@ -82,7 +82,6 @@ docs = [
 ]
 dev = ["pre-commit>=2.12.1"]
 tests = [
-    "FireWorks==2.0.3",
     "nbmake==1.5.4",
     "pytest-cov==5.0.0",
     "pytest-mock==3.14.0",


### PR DESCRIPTION
Add FireWorks dependency as a separate optional dependency
group. This allows users to explicitly install FireWorks components with
`pip install atomate2[fireworks]` and makes the dependency structure more
modular and clear.

Fix https://github.com/materialsproject/atomate2/issues/1033