### PR TITLE
Generalize `download_opls_xml` Function

### DIFF
--- a/src/atomate2/openmm/utils.py
+++ b/src/atomate2/openmm/utils.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import io
 import re
+import shutil
 import tempfile
 import time
 import warnings
-import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -23,16 +23,18 @@ if TYPE_CHECKING:
 
 
 def download_opls_xml(
-    names_params: dict[str, dict[str, str]], output_dir: str | Path, overwrite_files: bool = False
+    names_params: dict[str, dict[str, str]],
+    output_dir: str | Path,
+    overwrite_files: bool = False,
 ) -> None:
     """Download an OPLS-AA/M XML file from the LigParGen website using Selenium."""
     try:
         from selenium import webdriver
         from selenium.webdriver.chrome.service import Service as ChromeService
         from selenium.webdriver.common.by import By
-        from webdriver_manager.chrome import ChromeDriverManager
+        from selenium.webdriver.support import expected_conditions as ec
         from selenium.webdriver.support.ui import WebDriverWait
-        from selenium.webdriver.support import expected_conditions as EC
+        from webdriver_manager.chrome import ChromeDriverManager
     except ImportError:
         warnings.warn(
             "The `selenium` package is not installed. "
@@ -69,22 +71,22 @@ def download_opls_xml(
 
                 # Find the SMILES input box and enter the SMILES code
                 smiles_input = WebDriverWait(driver, 10).until(
-                        EC.presence_of_element_located((By.ID, "smiles"))
-                        )
+                    ec.presence_of_element_located((By.ID, "smiles"))
+                )
                 smiles_input.send_keys(smiles)
-                
-                # Find Molecule Optimization Iterations dropdown menu and select 
+
+                # Find Molecule Optimization Iterations dropdown menu and select
                 checkopt_input = WebDriverWait(driver, 10).until(
-                        EC.presence_of_element_located((By.NAME, "checkopt"))
-                        )
+                    ec.presence_of_element_located((By.NAME, "checkopt"))
+                )
                 checkopt_input.send_keys(checkopt)
 
-                # Find Charge dropdown menu and select 
+                # Find Charge dropdown menu and select
                 charge_input = WebDriverWait(driver, 10).until(
-                        EC.presence_of_element_located((By.NAME, "dropcharge"))
-                        )
+                    ec.presence_of_element_located((By.NAME, "dropcharge"))
+                )
                 charge_input.send_keys(charge)
-                
+
                 # Find and click the "Submit Molecule" button
                 submit_button = driver.find_element(
                     By.XPATH,
@@ -93,7 +95,9 @@ def download_opls_xml(
                 submit_button.click()
 
                 # Wait for the second page to load
-                time.sleep(2+0.5*checkopt)  # Adjust this delay as needed based on the loading time & optimization iterations
+                time.sleep(
+                    2 + 0.5 * int(checkopt)
+                )  # Adjust based on loading time & optimization iterations
 
                 # Find and click the "XML" button under Downloads and OpenMM
                 xml_button = driver.find_element(
@@ -106,7 +110,7 @@ def download_opls_xml(
 
                 file = next(Path(tmpdir).iterdir())
                 # copy downloaded file to output_file using os
-                shutil.copy(file, final_file) 
+                shutil.copy(file, final_file)
 
         except Exception as e:  # noqa: BLE001
             warnings.warn(


### PR DESCRIPTION
## Summary

Include a summary of major changes in bullet points:

* Feature 1: `src/atomate2/openmm` contains utils.py, for which the LigParGen [server](https://traken.chem.yale.edu/ligpargen/) is accessed; currently, the `download_opla_xml` function allows only SMILES string inputs. This feature generalizes this by modifying the input dictionary (`dict[str, str]`) to a dictionary of dictionaries (`dict[str, dict[str, str]]`), where the new input handles the molecule's charge and number of optimization iterations. A working dictionary, then, follows:

```python
mols = {
        'benzene':{
            'smiles':'c1ccccc1'
            },
        'TMA':{
            'smiles':'C[N+](C)(C)C',
            'checkopt':3,
            'charge':"+1"
            }
        }
```
* Fix 1: The LigParGen server output creates an .XML file that results in an error while copying it to the new file, so  `shutil.copy(file, final_file)` resolves this issue. 

## Additional dependencies introduced (if any)

* shutil: code like `Path(file).rename(final_file)` can fail for environments where the .XML file from LigParGen is created in a `/tmp` folder. `shutil` allows a standard copy; it is possible that, in a high-throughput test case, this results in performance loss.
* selenium.webdriver.support.ui.WebDriverWait and selenium.webdriver.support.expected_conditions: both are from selenium and safeguard from LigParGen server crashes

## TODO (if any)

If this is a work-in-progress, write something about what else needs to be done.

* Feature 1 supports `utils.py`, but has not been updated in `tests/openmm_md/test_utils.py`.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

* [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [ ] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [ ] Tests have been added for any new functionality or bug fixes.
* [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
