### PR TITLE
CP2K tweaks

### DIFF
--- a/src/atomate2/common/jobs/mpmorph.py
+++ b/src/atomate2/common/jobs/mpmorph.py
@@ -73,7 +73,7 @@ def get_average_volume_from_mp_api(
     Returns
     -------
     float
-        The average volume per atom for the composition.
+        The average volume per atom for the composition in Angstrom^3.
     """
     from mp_api.client import MPRester
 

--- a/src/atomate2/cp2k/files.py
+++ b/src/atomate2/cp2k/files.py
@@ -65,22 +65,24 @@ def copy_cp2k_outputs(
     additional_cp2k_files = additional_cp2k_files or []
 
     # find required files
-    o = Cp2kOutput(src_dir / get_zfile(directory_listing, "cp2k.out"), auto_load=False)
-    o.parse_files()
+    cp2k_output = Cp2kOutput(
+        src_dir / get_zfile(directory_listing, "cp2k.out"), auto_load=False
+    )
+    cp2k_output.parse_files()
     if restart_to_input:
         additional_cp2k_files += ("restart",)
 
     # copy files
     additional_cp2k_files += ("wfn",)
     files = ["cp2k.inp", "cp2k.out"]
-    for f in set(additional_cp2k_files):
-        if f in o.filenames and o.filenames.get(f):
-            if isinstance(o.filenames[f], str):
-                files.append(Path(o.filenames[f]).name)
+    for file in set(additional_cp2k_files):
+        if file in cp2k_output.filenames and cp2k_output.filenames.get(file):
+            if isinstance(cp2k_output.filenames[file], str):
+                files.append(Path(cp2k_output.filenames[file]).name)
             else:
-                files.append(Path(o.filenames[f][-1]).name)
+                files.append(Path(cp2k_output.filenames[file][-1]).name)
         else:
-            files.append(Path(f).name)
+            files.append(Path(file).name)
     all_files = [
         get_zfile(directory_listing, r + relax_ext, allow_missing=True) for r in files
     ]

--- a/src/atomate2/cp2k/flows/core.py
+++ b/src/atomate2/cp2k/flows/core.py
@@ -222,7 +222,7 @@ class HybridFlowMaker(Maker):
     initialize_with_pbe
         Whether or not to attach a pre-hybrid flow that can be used to
         kickstart the hybrid flow. This is treated differently than just
-        stiching flows together, because of the screening done in
+        stitching flows together, because of the screening done in
         __post_init__
     pbe_maker
         Maker for the initialization

--- a/src/atomate2/cp2k/run.py
+++ b/src/atomate2/cp2k/run.py
@@ -112,7 +112,7 @@ def run_cp2k(
     else:
         raise ValueError(f"Unsupported {job_type=}")
 
-    c = Custodian(
+    custodian = Custodian(
         handlers,
         jobs,
         validators=validators,
@@ -122,7 +122,7 @@ def run_cp2k(
     )
 
     logger.info("Running CP2K using custodian.")
-    c.run()
+    custodian.run()
 
 
 def should_stop_children(

--- a/src/atomate2/cp2k/sets/base.py
+++ b/src/atomate2/cp2k/sets/base.py
@@ -390,6 +390,15 @@ class Cp2kInputGenerator(InputGenerator):
         """Get the kpoints object."""
         kpoints_updates = kpoints_updates or {}
 
+        # don't write kpoints if user_kpoints_settings or base KPOINTS config is None
+        # KPOINTS are not compatible with orbital transformation mode and CP2K will
+        # crash if found
+        if (
+            self.user_kpoints_settings is None
+            or self.config_dict.get("KPOINTS") is None
+        ):
+            return None
+
         # use user setting if set otherwise default to base config settings
         if self.user_kpoints_settings != {}:
             kpt_config = deepcopy(self.user_kpoints_settings)

--- a/src/atomate2/cp2k/sets/base.py
+++ b/src/atomate2/cp2k/sets/base.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from importlib.resources import files as get_mod_path
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 from monty.io import zopen
@@ -40,7 +40,7 @@ class Cp2kInputSet(InputSet):
     def __init__(
         self,
         cp2k_input: Cp2kInput,
-        optional_files: dict | None = None,
+        optional_files: dict | None | Literal[False] = None,
     ) -> None:
         """Initialize the set.
 
@@ -187,7 +187,7 @@ class Cp2kInputGenerator(InputGenerator):
         self,
         structure: Structure | Molecule = None,
         prev_dir: str | Path = None,
-        optional_files: dict | None = None,
+        optional_files: dict | None | Literal[False] = None,
     ) -> Cp2kInputSet:
         """Get a CP2K input set.
 
@@ -202,6 +202,8 @@ class Cp2kInputGenerator(InputGenerator):
             A previous directory to generate the input set from.
         optional_files
             Additional files (e.g. vdw kernel file) to be included in the input set.
+            If False, no optional files will be included. Defaults to writing a BASIS
+            and POTENTIAL file.
 
         Returns
         -------
@@ -229,15 +231,16 @@ class Cp2kInputGenerator(InputGenerator):
             prev_input,
             input_updates,
         )
-        optional_files = optional_files or {}
-        optional_files["basis"] = {
-            "filename": "BASIS",
-            "object": self._get_basis_file(cp2k_input=cp2k_input),
-        }
-        optional_files["potential"] = {
-            "filename": "POTENTIAL",
-            "object": self._get_potential_file(cp2k_input=cp2k_input),
-        }
+        if optional_files is not False:
+            optional_files = optional_files or {}
+            optional_files["basis"] = {
+                "filename": "BASIS",
+                "object": self._get_basis_file(cp2k_input=cp2k_input),
+            }
+            optional_files["potential"] = {
+                "filename": "POTENTIAL",
+                "object": self._get_potential_file(cp2k_input=cp2k_input),
+            }
 
         return Cp2kInputSet(cp2k_input=cp2k_input, optional_files=optional_files)
 

--- a/src/atomate2/cp2k/sets/base.py
+++ b/src/atomate2/cp2k/sets/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from copy import deepcopy
 from dataclasses import dataclass, field
 from importlib.resources import files as get_mod_path
@@ -144,6 +145,10 @@ class Cp2kInputSet(InputSet):
     @property
     def is_valid(self) -> bool:
         """Whether the input set is valid."""
+        warnings.warn(
+            "Cp2kInputSet.is_valid is not yet implemented and will always return True.",
+            stacklevel=2,
+        )
         return True
 
 
@@ -323,11 +328,7 @@ class Cp2kInputGenerator(InputGenerator):
         # Generate base input but override with user input settings
         input_settings = recursive_update(input_settings, input_updates)
         input_settings = recursive_update(input_settings, self.user_input_settings)
-        overrides = (
-            input_settings.pop("override_default_params")
-            if "override_default_params" in input_settings
-            else {}
-        )
+        overrides = input_settings.pop("override_default_params", {})
         cp2k_input = DftSet(structure=structure, kpoints=kpoints, **input_settings)
 
         for setting in input_settings:

--- a/src/atomate2/cp2k/sets/core.py
+++ b/src/atomate2/cp2k/sets/core.py
@@ -161,11 +161,13 @@ class NonSCFSetGenerator(Cp2kInputGenerator):
 
     def __post_init__(self) -> None:
         """Ensure mode is set correctly."""
-        self.mode = self.mode.lower()
+        mode = self.mode = self.mode.lower()
 
         supported_modes = ("line", "uniform")
         if self.mode not in supported_modes:
-            raise ValueError(f"Supported modes are: {', '.join(supported_modes)}")
+            raise ValueError(
+                f"Invalid {mode=}, valid modes are: {', '.join(supported_modes)}"
+            )
 
     def get_kpoints_updates(
         self,

--- a/src/atomate2/openff/utils.py
+++ b/src/atomate2/openff/utils.py
@@ -198,7 +198,7 @@ def calculate_elyte_composition(
     }
 
     # Combine solvent and salt mass ratios
-    combined_mass_ratio = {**mass_ratio, **salt_mass_ratio}
+    combined_mass_ratio = mass_ratio | salt_mass_ratio
 
     # Calculate the total mass
     total_mass = sum(combined_mass_ratio.values())

--- a/src/atomate2/openmm/jobs/base.py
+++ b/src/atomate2/openmm/jobs/base.py
@@ -423,7 +423,7 @@ class BaseOpenMMMaker(Maker):
         else:
             prev_input = None
 
-        defaults = {**OPENMM_MAKER_DEFAULTS, **(add_defaults or {})}
+        defaults = OPENMM_MAKER_DEFAULTS | (add_defaults or {})
 
         if getattr(self, attr, None) is not None:
             attr_value = getattr(self, attr)

--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -279,4 +279,4 @@ class Atomate2Settings(BaseSettings):
                 f"{env_var_name} at {config_file_path} does not exist", stacklevel=2
             )
 
-        return {**new_values, **values}
+        return new_values | values

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from pymatgen.io.vasp import Kpoints
     from pymatgen.io.vasp.sets import UserPotcarFunctional
 
-_BASE_VASP_SET = {**MPScanRelaxSet()._config_dict, "KPOINTS": {}}  # noqa: SLF001
+_BASE_VASP_SET = MPScanRelaxSet()._config_dict | {"KPOINTS": {}}  # noqa: SLF001
 _ATOMATE2_BASE_VASP_SET_UPDATES = {
     "INCAR": {
         "ALGO": "Fast",

--- a/tests/cp2k/test_drones.py
+++ b/tests/cp2k/test_drones.py
@@ -1,6 +1,24 @@
+import pytest
+
+
 def test_structure_optimization(cp2k_test_dir):
     from atomate2.cp2k.drones import Cp2kDrone
+    from atomate2.cp2k.schemas.task import TaskDocument
 
     drone = Cp2kDrone()
     doc = drone.assimilate(cp2k_test_dir / "Si_band_structure" / "static" / "outputs")
-    assert doc
+    assert isinstance(doc, TaskDocument)
+    assert doc.output.energy == pytest.approx(-197.4, abs=1e-1)
+    assert doc.output.forces == pytest.approx(
+        [(-1e-08, -1e-08, -1e-08), (2e-08, 2e-08, 2e-08)], abs=1e-1
+    )
+    assert doc.output.stress is None
+    assert doc.output.bandgap is None
+    assert doc.output.cbm == pytest.approx(7.65104451, abs=1e-1)
+    assert doc.output.vbm == pytest.approx(5.09595793, abs=1e-1)
+    assert doc.output.structure.lattice.a == pytest.approx(3.8669, abs=1e-1)
+    assert doc.completed_at == "2023-11-18 00:05:01.267082+00:00"
+    assert doc.state.value == "successful"
+    assert doc.task_label is None
+    assert doc.tags is None
+    assert {*doc.run_stats} == {"overall", "standard"}

--- a/tests/vasp/flows/test_eos.py
+++ b/tests/vasp/flows/test_eos.py
@@ -19,14 +19,11 @@ expected_incar_relax = {
     "KSPACING": 0.22,
 }
 
-expected_incar_relax_1 = {
-    **expected_incar_relax,
-    "EDIFFG": -0.05,
-}
+expected_incar_relax_1 = expected_incar_relax | {"EDIFFG": -0.05}
 
-expected_incar_deform = {**expected_incar_relax, "ISIF": 2}
+expected_incar_deform = expected_incar_relax | {"ISIF": 2}
 
-expected_incar_static = {**expected_incar_relax, "NSW": 0, "IBRION": -1, "ISMEAR": -5}
+expected_incar_static = expected_incar_relax | {"NSW": 0, "IBRION": -1, "ISMEAR": -5}
 expected_incar_static.pop("ISIF")
 
 

--- a/tests/vasp/jobs/test_eos.py
+++ b/tests/vasp/jobs/test_eos.py
@@ -17,7 +17,7 @@ expected_incar_relax = {
     "KSPACING": 0.22,
 }
 
-expected_incar_static = {**expected_incar_relax, "NSW": 0, "IBRION": -1, "ISMEAR": -5}
+expected_incar_static = expected_incar_relax | {"NSW": 0, "IBRION": -1, "ISMEAR": -5}
 expected_incar_static.pop("ISIF")
 
 


### PR DESCRIPTION
this PR fixes some issues with running CP2K in orbital transformation (OT) mode which crashes if it finds a `KPOINTS` file which the current `Cp2kInputGenerator` does not allow to disable.

it goes hand in hand with https://github.com/materialsproject/pymatgen/pull/4169 that fixes a number of bugs in `pymatgen` CP2K modules

pinging @chiang-yuan and @utf