### PR TITLE
add openmm description to docs

### DIFF
--- a/docs/user/codes/index.md
+++ b/docs/user/codes/index.md
@@ -6,4 +6,5 @@ The section gives the instructions for codes supported by atomate2.
 
 ```{toctree}
 vasp
+openmm
 ```


### PR DESCRIPTION
## Summary

Currently, OpenMM is not showing up under docs as it is not part of the index.md