### PR TITLE
Docs update, forcefield elastic convenience maker, forcefield enum hydration

### DIFF
--- a/docs/user/codes/vasp.md
+++ b/docs/user/codes/vasp.md
@@ -270,23 +270,39 @@ Afterwards, equation of state fits are performed with phonopy.
 
 ### Equation of State Workflow
 
-An equation of state workflow is implemented. First, a tight relaxation is performed. Subsequently, several optimizations at different constant
+An equation of state (EOS) workflow is implemented. First, a tight relaxation is performed. Subsequently, several optimizations at different constant
 volumes are performed. Additional static calculations might be performed afterwards to arrive at more
-accurate energies. Then, an equation of state fit is performed with pymatgen.
-The output of the workflow is, by default, a dictionary containing the energy and volume data generated
-with DFT, in addition to fitted equation of state parameters for all models currently available in
-pymatgen (Murnaghan, Birch-Murnaghan, Poirier-Tarantola, and Vinet/UBER).
+accurate energies. Then, an EOS fit is performed with pymatgen.
 
-If the user wishes to reproduce the equation of state data currently in the Materials Project,
-they should use the atomate 1-compatible `MPLegacy`-prefixed flows (and jobs and input sets).
-For performing updated PBE-GGA equation of state flows with Materials Project-compliant parameters,
-the user should use the `MPGGA`-prefixed classes.
-Last, the `MPMetaGGA`-prefixed classes allow the user to perform Materials Project-compliant r<sup>2</sup>SCAN
-equation of state workflows.
+The output of the workflow is, by default, a dictionary containing the energy and volume data generated with DFT, in addition to fitted equation of state parameters for all models currently available in pymatgen (Murnaghan, Birch-Murnaghan, Poirier-Tarantola, and Vinet/UBER).
 
-**To summarize:** for MP compliant equation of state workflows, the user should use `MPGGAEosMaker` for faster,
-lower-accuracy calculations; `MPMetaGGAEosMaker` for higher-accuracy but slower calculations;
-and `MPLegacyEosMaker` for consistency with the data currently hosted by the Materials Project.
+#### Materials Project-compliant workflows
+
+If the user wishes to reproduce the EOS data currently in the Materials Project, they should use the atomate 1-compatible `MPLegacy`-prefixed flows (and jobs and input sets). For performing updated PBE-GGA EOS flows with Materials Project-compliant parameters, the user should use the `MPGGA`-prefixed classes. Lastly, the `MPMetaGGA`-prefixed classes allow the user to perform Materials Project-compliant r<sup>2</sup>SCAN EOS workflows.
+
+**Summary:** For Materials Project-compliant equation of state (EOS) workflows, the user should use:
+* `MPGGAEosMaker` for faster, lower-accuracy calculation with the PBE-GGA
+* `MPMetaGGAEosMaker` for higher-accuracy but slower calculations with the r<sup>2</sup>SCAN meta-GGA
+* `MPLegacyEosMaker` for consistency with the PBE-GGA data currently distributed by the Materials Project
+
+#### Implementation details
+
+The Materials Project-compliant EOS flows, jobs, and sets currently use three prefixes to indicate their usage.
+* `MPGGA`: MP-compatible PBE-GGA (current)
+* `MPMetaGGA`: MP-compatible r<sup>2</sup>SCAN meta-GGA (current)
+* `MPLegacy`: a reproduction of the atomate 1 implementation, described in
+  K. Latimer, S. Dwaraknath, K. Mathew, D. Winston, and K.A. Persson, npj Comput. Materials **vol. 4**, p. 40 (2018), DOI: 10.1038/s41524-018-0091-x
+
+  For reference, the original atomate workflows can be found here:
+    * [`atomate.vasp.workflows.base.wf_bulk_modulus`](https://github.com/hackingmaterials/atomate/blob/main/atomate/vasp/workflows/presets/core.py#L564)
+    * [`atomate.vasp.workflows.base.bulk_modulus.get_wf_bulk_modulus`](https://github.com/hackingmaterials/atomate/blob/main/atomate/vasp/workflows/base/bulk_modulus.py#L21)
+
+In the original atomate 1 workflow and the atomate2 `MPLegacyEosMaker`, the k-point density is **extremely** high. This is despite the convergence tests in the supplementary information
+of Latimer *et al.* not showing strong sensitivity when the "number of ***k***-points per reciprocal atom" (KPPRA) is at least 3,000.
+
+To make the `MPGGAEosMaker` and `MPMetaGGAEosMaker` more tractable for high-throughput jobs, their input sets (`MPGGAEos{Relax,Static}SetGenerator` and `MPMetaGGAEos{Relax,Static}SetGenerator` respectively) still use the highest ***k***-point density in standard Materials Project jobs, `KSPACING = 0.22` Å<sup>-1</sup>, which is comparable to KPPRA = 3,000.
+
+This choice is justified by Fig. S12 of the supplemantary information of Latimer *et al.*, which shows that all fitted EOS parameters (equilibrium energy $E_0$, equilibrium volume $V_0$, bulk modulus $B_0$, and bulk modulus pressure derivative $B_1$) do not deviate by more than 1.5%, and typically by less than 0.1%, from well-converged values when KPPRA = 3,000.
 
 ### LOBSTER
 

--- a/docs/user/codes/vasp.md
+++ b/docs/user/codes/vasp.md
@@ -273,6 +273,20 @@ Afterwards, equation of state fits are performed with phonopy.
 An equation of state workflow is implemented. First, a tight relaxation is performed. Subsequently, several optimizations at different constant
 volumes are performed. Additional static calculations might be performed afterwards to arrive at more
 accurate energies. Then, an equation of state fit is performed with pymatgen.
+The output of the workflow is, by default, a dictionary containing the energy and volume data generated
+with DFT, in addition to fitted equation of state parameters for all models currently available in
+pymatgen (Murnaghan, Birch-Murnaghan, Poirier-Tarantola, and Vinet/UBER).
+
+If the user wishes to reproduce the equation of state data currently in the Materials Project,
+they should use the atomate 1-compatible `MPLegacy`-prefixed flows (and jobs and input sets).
+For performing updated PBE-GGA equation of state flows with Materials Project-compliant parameters,
+the user should use the `MPGGA`-prefixed classes.
+Last, the `MPMetaGGA`-prefixed classes allow the user to perform Materials Project-compliant r<sup>2</sup>SCAN
+equation of state workflows.
+
+**To summarize:** for MP compliant equation of state workflows, the user should use `MPGGAEosMaker` for faster,
+lower-accuracy calculations; `MPMetaGGAEosMaker` for higher-accuracy but slower calculations;
+and `MPLegacyEosMaker` for consistency with the data currently hosted by the Materials Project.
 
 ### LOBSTER
 

--- a/src/atomate2/forcefields/__init__.py
+++ b/src/atomate2/forcefields/__init__.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 class MLFF(Enum):  # TODO inherit from StrEnum when 3.11+
@@ -18,13 +22,14 @@ class MLFF(Enum):  # TODO inherit from StrEnum when 3.11+
     SevenNet = "SevenNet"
 
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, value: Any) -> Any:
         """Allow input of str(MLFF) as valid enum."""
         if isinstance(value, str):
             value = value.split("MLFF.")[-1]
         for member in cls:
             if member.value == value:
                 return member
+        return None
 
 
 def _get_formatted_ff_name(force_field_name: str | MLFF) -> str:

--- a/src/atomate2/forcefields/__init__.py
+++ b/src/atomate2/forcefields/__init__.py
@@ -17,6 +17,15 @@ class MLFF(Enum):  # TODO inherit from StrEnum when 3.11+
     Nequip = "Nequip"
     SevenNet = "SevenNet"
 
+    @classmethod
+    def _missing_(cls, value):
+        """Allow input of str(MLFF) as valid enum."""
+        if isinstance(value, str):
+            value = value.split("MLFF.")[-1]
+        for member in cls:
+            if member.value == value:
+                return member
+
 
 def _get_formatted_ff_name(force_field_name: str | MLFF) -> str:
     """

--- a/src/atomate2/forcefields/flows/elastic.py
+++ b/src/atomate2/forcefields/flows/elastic.py
@@ -13,11 +13,12 @@ from atomate2.forcefields.jobs import ForceFieldRelaxMaker
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-# default options for the forcefield makers in ElasticMaker 
+# default options for the forcefield makers in ElasticMaker
 _DEFAULT_RELAX_KWARGS = {
     "force_field_name": "CHGNet",
-    "relax_kwargs": {"fmax": 0.00001}
+    "relax_kwargs": {"fmax": 0.00001},
 }
+
 
 @dataclass
 class ElasticMaker(BaseElasticMaker):
@@ -72,14 +73,12 @@ class ElasticMaker(BaseElasticMaker):
     symprec: float = SETTINGS.SYMPREC
     bulk_relax_maker: ForceFieldRelaxMaker | None = field(
         default_factory=lambda: ForceFieldRelaxMaker(
-            relax_cell=True,
-            **_DEFAULT_RELAX_KWARGS
+            relax_cell=True, **_DEFAULT_RELAX_KWARGS
         )
     )
     elastic_relax_maker: ForceFieldRelaxMaker | None = field(
         default_factory=lambda: ForceFieldRelaxMaker(
-            relax_cell=False,
-            **_DEFAULT_RELAX_KWARGS
+            relax_cell=False, **_DEFAULT_RELAX_KWARGS
         )
     )  # constant volume relaxation
     max_failed_deformations: int | float | None = None
@@ -102,7 +101,7 @@ class ElasticMaker(BaseElasticMaker):
     def from_force_field_name(
         cls,
         force_field_name: str | MLFF,
-        mlff_kwargs : dict | None = None,
+        mlff_kwargs: dict | None = None,
         **kwargs,
     ) -> Self:
         """
@@ -121,21 +120,20 @@ class ElasticMaker(BaseElasticMaker):
         -------
         ElasticMaker
         """
-
         default_kwargs = {
             **_DEFAULT_RELAX_KWARGS,
             **(mlff_kwargs or {}),
             "force_field_name": _get_formatted_ff_name(force_field_name),
         }
         return cls(
-            name = f"{force_field_name.split('MLFF.')[-1]} elastic",
-            bulk_relax_maker = ForceFieldRelaxMaker(
+            name=f"{force_field_name.split('MLFF.')[-1]} elastic",
+            bulk_relax_maker=ForceFieldRelaxMaker(
                 relax_cell=True,
                 **default_kwargs,
             ),
-            elastic_relax_maker = ForceFieldRelaxMaker(
+            elastic_relax_maker=ForceFieldRelaxMaker(
                 relax_cell=False,
                 **default_kwargs,
             ),
-            **kwargs
+            **kwargs,
         )

--- a/src/atomate2/forcefields/flows/elastic.py
+++ b/src/atomate2/forcefields/flows/elastic.py
@@ -11,10 +11,12 @@ from atomate2.forcefields import MLFF, _get_formatted_ff_name
 from atomate2.forcefields.jobs import ForceFieldRelaxMaker
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from typing_extensions import Self
 
 # default options for the forcefield makers in ElasticMaker
-_DEFAULT_RELAX_KWARGS = {
+_DEFAULT_RELAX_KWARGS: dict[str, Any] = {
     "force_field_name": "CHGNet",
     "relax_kwargs": {"fmax": 0.00001},
 }
@@ -120,13 +122,13 @@ class ElasticMaker(BaseElasticMaker):
         -------
         ElasticMaker
         """
-        default_kwargs = {
+        default_kwargs: dict[str, Any] = {
             **_DEFAULT_RELAX_KWARGS,
             **(mlff_kwargs or {}),
             "force_field_name": _get_formatted_ff_name(force_field_name),
         }
         return cls(
-            name=f"{force_field_name.split('MLFF.')[-1]} elastic",
+            name=f"{str(force_field_name).split('MLFF.')[-1]} elastic",
             bulk_relax_maker=ForceFieldRelaxMaker(
                 relax_cell=True,
                 **default_kwargs,

--- a/src/atomate2/forcefields/flows/eos.py
+++ b/src/atomate2/forcefields/flows/eos.py
@@ -1,4 +1,4 @@
-"""Flows to generate EOS fits using CHGNet, M3GNet, or MACE."""
+"""Flows to generate EOS fits using machine learned interatomic potentials."""
 
 from __future__ import annotations
 
@@ -62,6 +62,7 @@ class ForceFieldEosMaker(CommonEosMaker):
         cls,
         force_field_name: str | MLFF,
         relax_initial_structure: bool = True,
+        **kwargs,
     ) -> Self:
         """
         Create an EOS flow from a forcefield name.
@@ -72,7 +73,10 @@ class ForceFieldEosMaker(CommonEosMaker):
             The name of the force field.
         relax_initial_structure: bool = True
             Whether to relax the initial structure before performing an EOS fit.
-
+        **kwargs
+            Additional kwargs to pass to ElasticMaker
+            
+            
         Returns
         -------
         ForceFieldEosMaker
@@ -89,6 +93,7 @@ class ForceFieldEosMaker(CommonEosMaker):
                 force_field_name=force_field_name, relax_cell=False
             ),
             static_maker=None,
+            **kwargs,
         )
 
 

--- a/src/atomate2/forcefields/flows/eos.py
+++ b/src/atomate2/forcefields/flows/eos.py
@@ -75,8 +75,8 @@ class ForceFieldEosMaker(CommonEosMaker):
             Whether to relax the initial structure before performing an EOS fit.
         **kwargs
             Additional kwargs to pass to ElasticMaker
-            
-            
+
+
         Returns
         -------
         ForceFieldEosMaker

--- a/tests/forcefields/flows/test_elastic.py
+++ b/tests/forcefields/flows/test_elastic.py
@@ -3,13 +3,14 @@ from jobflow import run_locally
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from atomate2.common.schemas.elastic import ElasticDocument
-from atomate2.forcefields import MLFF
 from atomate2.forcefields.flows.elastic import ElasticMaker
 from atomate2.forcefields.jobs import ForceFieldRelaxMaker
 
 
 @pytest.mark.parametrize("convenience_constructor", [True, False])
-def test_elastic_wf_with_mace(clean_dir, si_structure, test_dir, convenience_constructor : bool):
+def test_elastic_wf_with_mace(
+    clean_dir, si_structure, test_dir, convenience_constructor: bool
+):
     si_prim = SpacegroupAnalyzer(si_structure).get_primitive_standard_structure()
     model_path = f"{test_dir}/forcefields/mace/MACE.model"
     common_kwds = {
@@ -21,8 +22,8 @@ def test_elastic_wf_with_mace(clean_dir, si_structure, test_dir, convenience_con
     if convenience_constructor:
         common_kwds.pop("force_field_name")
         flow = ElasticMaker.from_force_field_name(
-            force_field_name = "MACE",
-            mlff_kwargs = common_kwds,
+            force_field_name="MACE",
+            mlff_kwargs=common_kwds,
         ).make(si_prim)
     else:
         flow = ElasticMaker(

--- a/tests/forcefields/test_utils.py
+++ b/tests/forcefields/test_utils.py
@@ -4,6 +4,12 @@ from atomate2.forcefields import MLFF
 from atomate2.forcefields.utils import ase_calculator
 
 
+@pytest.mark.parametrize(("force_field"), [mlff.value for mlff in MLFF])
+def test_mlff(force_field: str):
+    mlff = MLFF(force_field)
+    assert mlff == MLFF(str(mlff)) == MLFF(str(mlff).split(".")[-1])
+
+
 @pytest.mark.parametrize(("force_field"), ["CHGNet", "MACE"])
 def test_ext_load(force_field: str):
     decode_dict = {


### PR DESCRIPTION
Three smaller changes:
- Update VASP EOS section of the docs to explain the makers / sets there, close issue [#1071](https://github.com/materialsproject/atomate2/issues/1071#issuecomment-2500931796)
- Add a convenience constructor method, `from_force_field_name` to `ElasticMaker` as suggested by @utf  in [#999](https://github.com/materialsproject/atomate2/pull/999#issuecomment-2382426247)
- Allow the forcefield name enum `MLFF` to permit `str(MLFF.<member>)` as valid input. This should hopefully resolve some issues noted by @tjaffrel when running forcefield jobs from fireworks 