### PR TITLE
Add key concept tutorial to tutorial list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ started:
 
 - [Introduction to running workflows][running-workflows]
 - [Using atomate2 with FireWorks][atomate2_fireworks]
-- [Overview of key concepts][key_concepts_overview]
+- [Overview of key concepts][key-concepts-in-atomate2-job-flow-makers-inputset-taskdocument-and-builder]
 - [List of VASP workflows][vasp_workflows]
 
 ## Need help?

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ started:
 
 - [Introduction to running workflows][running-workflows]
 - [Using atomate2 with FireWorks][atomate2_fireworks]
-- [Overview of key concepts][key-concepts-in-atomate2-job-flow-makers-inputset-taskdocument-and-builder]
+- [Overview of key concepts][key-concepts]
 - [List of VASP workflows][vasp_workflows]
 
 ## Need help?
@@ -152,6 +152,7 @@ A journal submission of `atomate2` is undergoing peer review. In the meantime, p
 [contributors]: https://materialsproject.github.io/atomate2/about/contributors.html
 [license]: https://raw.githubusercontent.com/materialsproject/atomate2/main/LICENSE
 [running-workflows]: https://materialsproject.github.io/atomate2/user/running-workflows.html
+[key-concepts]: https://materialsproject.github.io/atomate2/user/key_concepts_overview.html#key-concepts-in-atomate2-job-flow-makers-inputset-taskdocument-and-builder
 [atomate2_fireworks]: https://materialsproject.github.io/atomate2/user/fireworks.html
 [vasp_workflows]: https://materialsproject.github.io/atomate2/user/codes/vasp.html
 [RelaxBandStructure]: https://materialsproject.github.io/atomate2/user/codes/vasp.html#relax-and-band-structure

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ started:
 
 - [Introduction to running workflows][running-workflows]
 - [Using atomate2 with FireWorks][atomate2_fireworks]
+- [Overview of key concepts][key_concepts_overview]
 - [List of VASP workflows][vasp_workflows]
 
 ## Need help?

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 user/index
 user/install
 user/running-workflows
+user/key_concepts_overview
 user/docs-schemas-emmet
 user/fireworks
 user/atomate-1-vs-2


### PR DESCRIPTION
## Summary

A while ago I had written [this tutorial](https://materialsproject.github.io/atomate2/user/key_concepts_overview.html#key-concepts-in-atomate2-job-flow-makers-inputset-taskdocument-and-builder) (https://github.com/materialsproject/atomate2/pull/757) but didn't link it somewhere to be found. 😅  
