### PR TITLE
Add MatPES forcefields

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install  "setuptools<78"
+          pip install "setuptools==77.0.3"
           pip install .[strict,docs]
 
       - name: Copy tutorials

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install  "setuptools<78"
           pip install .[strict,docs]
 
       - name: Copy tutorials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42", "versioningit >= 1,< 4", "wheel"]
+requires = ["setuptools >= 42, < 78.0.1", "versioningit >= 1,< 4", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -83,7 +83,6 @@ docs = [
     "sphinx==8.1.3",
     "sphinx_design==0.6.1",
     "jupyterlab==4.3.4",
-    "typing==3.10.0.0",
 ]
 dev = ["pre-commit>=2.12.1"]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42, < 78.0.1", "versioningit >= 1,< 4", "wheel"]
+requires = ["setuptools >= 42, < 78.0.0", "versioningit >= 1,< 4", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42, < 78.0.0", "versioningit >= 1,< 4", "wheel"]
+requires = ["setuptools >= 42", "versioningit >= 1,< 4", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -36,6 +36,7 @@ dependencies = [
     "pydantic>=2.0.1",
     "pymatgen>=2024.11.13",
     "pymongo<=4.10.1",
+    "setuptools<78",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ docs = [
     "sphinx==8.1.3",
     "sphinx_design==0.6.1",
     "jupyterlab==4.3.4",
+    "typing==3.10.0.0",
 ]
 dev = ["pre-commit>=2.12.1"]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ forcefields = [
     "calorine>=3.0",
     "chgnet>=0.2.2",
     "mace-torch>=0.3.3",
-    "matgl>=1.1.3",
+    "matgl>=1.2.1",
     "torchdata<=0.7.1",
     # quippy-ase support for py3.12 tracked in https://github.com/libAtoms/QUIP/issues/645
     "quippy-ase>=0.9.14; python_version < '3.12'",
@@ -129,7 +129,7 @@ strict-forcefields = [
     "calorine==3.0",
     "chgnet==0.4.0",
     "mace-torch==0.3.10",
-    "matgl==1.1.3",
+    "matgl==1.2.1",
     "quippy-ase==0.9.14; python_version < '3.12'",
     "sevenn==0.10.3",
     "torch==2.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42", "versioningit >= 1,< 4", "wheel"]
+requires = ["setuptools >= 42, <78", "versioningit >= 1,< 4", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -36,7 +36,6 @@ dependencies = [
     "pydantic>=2.0.1",
     "pymatgen>=2024.11.13",
     "pymongo<=4.10.1",
-    "setuptools<78",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ tests = [
 ]
 strict = [
     "PyYAML==6.0.2",
-    "ase==3.23.0",
+    "ase==3.24.0",
     "cclib==1.8.1",
     "click==8.1.7",
     "custodian==2024.10.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ strict-forcefields = [
     "matgl==1.2.1",
     "quippy-ase==0.9.14; python_version < '3.12'",
     "sevenn==0.10.3",
-    "torch==2.6.0",
+    "torch==2.2.0",
     "torchdata==0.7.1",                            # TODO: remove when issue fixed
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ strict-openff = [
 ]
 strict-forcefields = [
     "calorine==3.0",
-    "chgnet==0.4.0",
+    "chgnet==0.3.8",
     "mace-torch==0.3.10",
     "matgl==1.2.1",
     "quippy-ase==0.9.14; python_version < '3.12'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ strict = [
     "typing-extensions==4.12.2",
 ]
 strict-openff = [
+    "mdanalysis==2.7.0",
     "monty==2025.3.3",
     "openmm-mdanalysis-reporter==0.1.0",
     "openmm==8.1.1",

--- a/src/atomate2/ase/jobs.py
+++ b/src/atomate2/ase/jobs.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
-import time
 from typing import TYPE_CHECKING
 
 from ase.io import Trajectory as AseTrajectory
@@ -38,18 +38,19 @@ class AseMaker(Maker, metaclass=ABCMeta):
     This class defines relevant attributes for the ASE TaskDoc
     schemas, and one method that must be implemented in subclasses:
     `calculator`: the ASE .Calculator object
-    
+
     The intent of this class is twofold: if users wish to have a
-    high-throughput way to access a calculator, they need only 
+    high-throughput way to access a calculator, they need only
     subclass this class with a calculator defined, e.g., the following
     is sufficient to define an EMT static calculator with basic I/O:
-    
+
     ```python
     from ase.calculators.emt import EMT
 
+
     @dataclass
     class EMTStaticMaker(AseMaker):
-        name : str = "EMT static maker"
+        name: str = "EMT static maker"
 
         @property
         def calculator(self):
@@ -111,7 +112,7 @@ class AseMaker(Maker, metaclass=ABCMeta):
         """
         return AseTaskDoc.to_mol_or_struct_metadata_doc(
             getattr(self.calculator, "name", type(self.calculator).__name__),
-            self.run_ase(mol_or_struct, prev_dir=prev_dir)
+            self.run_ase(mol_or_struct, prev_dir=prev_dir),
         )
 
     def run_ase(
@@ -130,8 +131,7 @@ class AseMaker(Maker, metaclass=ABCMeta):
             A previous calculation directory to copy output files from. Unused, just
                 added to match the method signature of other makers.
         """
-
-        is_mol = isinstance(mol_or_struct,Molecule)
+        is_mol = isinstance(mol_or_struct, Molecule)
         adaptor = AseAtomsAdaptor()
         atoms = adaptor.get_atoms(mol_or_struct)
         atoms.calc = self.calculator
@@ -139,9 +139,11 @@ class AseMaker(Maker, metaclass=ABCMeta):
         final_energy = atoms.get_potential_energy()
         t_f = time.perf_counter()
         return AseResult(
-            final_mol_or_struct = getattr(adaptor,f"get_{'molecule' if is_mol else 'structure'}")(atoms),
-            final_energy = final_energy,
-            elapsed_time=t_f - t_i
+            final_mol_or_struct=getattr(
+                adaptor, f"get_{'molecule' if is_mol else 'structure'}"
+            )(atoms),
+            final_energy=final_energy,
+            elapsed_time=t_f - t_i,
         )
 
     @property

--- a/src/atomate2/ase/md.py
+++ b/src/atomate2/ase/md.py
@@ -180,7 +180,7 @@ class AseMDMaker(AseMaker, metaclass=ABCMeta):
     def __post_init__(self) -> None:
         """Ensure that ensemble is an enum."""
         if isinstance(self.ensemble, str):
-            self.ensemble = MDEnsemble(self.ensemble)
+            self.ensemble = MDEnsemble(self.ensemble.split("MDEnsemble.")[-1])
 
     @staticmethod
     def _interpolate_quantity(values: Sequence | np.ndarray, n_pts: int) -> np.ndarray:

--- a/src/atomate2/ase/schemas.py
+++ b/src/atomate2/ase/schemas.py
@@ -43,7 +43,7 @@ class AseResult(BaseModel):
         None, description="The molecule or structure in the final trajectory frame."
     )
 
-    final_energy : float | None = Field(
+    final_energy: float | None = Field(
         None, description="The final total energy from the calculation."
     )
 
@@ -96,9 +96,7 @@ class AseBaseModel(BaseModel):
     mol_or_struct: Structure | Molecule | None = Field(
         None, description="The molecule or structure at this step."
     )
-    structure: Structure | None = Field(
-        None, description="The structure at this step."
-    )
+    structure: Structure | None = Field(None, description="The structure at this step.")
     molecule: Molecule | None = Field(None, description="The molecule at this step.")
 
     def model_post_init(self, _context: Any) -> None:
@@ -117,9 +115,7 @@ class IonicStep(AseBaseModel):
         None, description="The forces on each atom."
     )
     stress: Matrix3D | None = Field(None, description="The stress on the lattice.")
-    magmoms: list[float] | None = Field(
-        None, description="On-site magnetic moments."
-    )
+    magmoms: list[float] | None = Field(None, description="On-site magnetic moments.")
 
 
 class OutputDoc(AseBaseModel):
@@ -127,7 +123,7 @@ class OutputDoc(AseBaseModel):
 
     energy: float | None = Field(None, description="Total energy in units of eV.")
 
-    energy_per_atom: float | None= Field(
+    energy_per_atom: float | None = Field(
         None,
         description="Energy per atom of the final molecule or structure "
         "in units of eV/atom.",
@@ -409,11 +405,13 @@ class AseTaskDoc(AseBaseModel):
         if n_steps:
             for idx in range(n_steps):
                 if trajectory.frame_properties[idx].get("stress") is not None:
-                    trajectory.frame_properties[idx]["stress"] = voigt_6_to_full_3x3_stress(
-                        [
-                            val * -10 / GPa
-                            for val in trajectory.frame_properties[idx]["stress"]
-                        ]
+                    trajectory.frame_properties[idx]["stress"] = (
+                        voigt_6_to_full_3x3_stress(
+                            [
+                                val * -10 / GPa
+                                for val in trajectory.frame_properties[idx]["stress"]
+                            ]
+                        )
                     )
 
             input_mol_or_struct = trajectory[0]
@@ -453,7 +451,7 @@ class AseTaskDoc(AseBaseModel):
             final_forces = None
             final_stress = None
             ionic_steps = None
-            
+
         else:
             final_energy = trajectory.frame_properties[-1]["energy"]
             final_forces = trajectory.frame_properties[-1]["forces"]
@@ -480,7 +478,7 @@ class AseTaskDoc(AseBaseModel):
                         else None
                     )
 
-                    # include "magmoms" in :obj:`ionic_step` if the trajectory has "magmoms"
+                    # include "magmoms" in `ionic_step` if the trajectory has "magmoms"
                     if "magmoms" in trajectory.frame_properties[idx]:
                         _ionic_step_data.update(
                             {
@@ -498,7 +496,6 @@ class AseTaskDoc(AseBaseModel):
                     )
 
                     ionic_steps.append(ionic_step)
-
 
         objects: dict[AseObject, Any] = {}
         if store_trajectory != StoreTrajectoryOption.NO:

--- a/src/atomate2/ase/schemas.py
+++ b/src/atomate2/ase/schemas.py
@@ -11,9 +11,8 @@ Copyright (c) 2022, Materials Virtual Lab.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
-from ase.io import Trajectory as AseTrajectory
 from ase.stress import voigt_6_to_full_3x3_stress
 from ase.units import GPa
 from emmet.core.math import Matrix3D, Vector3D
@@ -40,22 +39,26 @@ _task_doc_translation_keys = {
 class AseResult(BaseModel):
     """Schema to store outputs in AseTaskDocument."""
 
-    final_mol_or_struct: Optional[Union[Structure, Molecule]] = Field(
+    final_mol_or_struct: Structure | Molecule | None = Field(
         None, description="The molecule or structure in the final trajectory frame."
     )
 
-    trajectory: Optional[Union[AseTrajectory, PmgTrajectory]] = Field(
+    final_energy : float | None = Field(
+        None, description="The final total energy from the calculation."
+    )
+
+    trajectory: PmgTrajectory | None = Field(
         None, description="The relaxation or molecular dynamics trajectory."
     )
 
-    is_force_converged: Optional[bool] = Field(
+    is_force_converged: bool | None = Field(
         None,
         description=(
             "Whether the calculation is converged with respect to interatomic forces."
         ),
     )
 
-    energy_downhill: Optional[bool] = Field(
+    energy_downhill: bool | None = Field(
         None,
         description=(
             "Whether the final trajectory frame has lower total "
@@ -63,11 +66,11 @@ class AseResult(BaseModel):
         ),
     )
 
-    dir_name: Optional[Union[str, Path]] = Field(
+    dir_name: str | Path | None = Field(
         None, description="The directory where the calculation was run"
     )
 
-    elapsed_time: Optional[float] = Field(
+    elapsed_time: float | None = Field(
         None, description="The time taken to run the ASE calculation in seconds."
     )
 
@@ -90,13 +93,13 @@ class AseObject(ValueEnum):
 class AseBaseModel(BaseModel):
     """Base document class for ASE input and output."""
 
-    mol_or_struct: Optional[Union[Structure, Molecule]] = Field(
+    mol_or_struct: Structure | Molecule | None = Field(
         None, description="The molecule or structure at this step."
     )
-    structure: Optional[Structure] = Field(
+    structure: Structure | None = Field(
         None, description="The structure at this step."
     )
-    molecule: Optional[Molecule] = Field(None, description="The molecule at this step.")
+    molecule: Molecule | None = Field(None, description="The molecule at this step.")
 
     def model_post_init(self, _context: Any) -> None:
         """Establish alias to structure and molecule fields."""
@@ -109,12 +112,12 @@ class AseBaseModel(BaseModel):
 class IonicStep(AseBaseModel):
     """Document defining the information at each ionic step."""
 
-    energy: Optional[float] = Field(None, description="The free energy.")
-    forces: Optional[list[list[float]]] = Field(
+    energy: float | None = Field(None, description="The free energy.")
+    forces: list[list[float]] | None = Field(
         None, description="The forces on each atom."
     )
-    stress: Optional[Matrix3D] = Field(None, description="The stress on the lattice.")
-    magmoms: Optional[list[float]] = Field(
+    stress: Matrix3D | None = Field(None, description="The stress on the lattice.")
+    magmoms: list[float] | None = Field(
         None, description="On-site magnetic moments."
     )
 
@@ -122,15 +125,15 @@ class IonicStep(AseBaseModel):
 class OutputDoc(AseBaseModel):
     """The outputs of this job."""
 
-    energy: float = Field(None, description="Total energy in units of eV.")
+    energy: float | None = Field(None, description="Total energy in units of eV.")
 
-    energy_per_atom: float = Field(
+    energy_per_atom: float | None= Field(
         None,
         description="Energy per atom of the final molecule or structure "
         "in units of eV/atom.",
     )
 
-    forces: Optional[list[Vector3D]] = Field(
+    forces: list[Vector3D] | None = Field(
         None,
         description=(
             "The force on each atom in units of eV/A for the final molecule "
@@ -140,21 +143,21 @@ class OutputDoc(AseBaseModel):
 
     # NOTE: units for stresses were converted to kbar (* -10 from standard output)
     #       to comply with MP convention
-    stress: Optional[Matrix3D] = Field(
+    stress: Matrix3D | None = Field(
         None, description="The stress on the cell in units of kbar (in Voigt notation)."
     )
 
     # NOTE: the ionic_steps can also be a dict when these are in blob storage and
     #       retrieved as objects.
-    ionic_steps: Union[list[IonicStep], dict] = Field(
+    ionic_steps: list[IonicStep] | dict | None = Field(
         None, description="Step-by-step trajectory of the relaxation."
     )
 
-    elapsed_time: Optional[float] = Field(
+    elapsed_time: float | None = Field(
         None, description="The time taken to run the ASE calculation in seconds."
     )
 
-    n_steps: int = Field(
+    n_steps: int | None = Field(
         None, description="total number of steps needed in the relaxation."
     )
 
@@ -162,27 +165,27 @@ class OutputDoc(AseBaseModel):
 class InputDoc(AseBaseModel):
     """The inputs used to run this job."""
 
-    relax_cell: Optional[bool] = Field(
+    relax_cell: bool | None = Field(
         None,
         description="Whether cell lattice was allowed to change during relaxation.",
     )
-    fix_symmetry: bool = Field(
+    fix_symmetry: bool | None = Field(
         None,
         description=(
             "Whether to fix the symmetry of the atoms during relaxation. "
             "Refines the symmetry of the initial molecule or structure."
         ),
     )
-    symprec: Optional[float] = Field(
+    symprec: float | None = Field(
         None, description="Tolerance for symmetry finding in case of fix_symmetry."
     )
-    steps: int = Field(
+    steps: int | None = Field(
         None, description="Maximum number of steps allowed during relaxation."
     )
-    relax_kwargs: Optional[dict] = Field(
+    relax_kwargs: dict | None = Field(
         None, description="Keyword arguments that passed to the relaxer function."
     )
-    optimizer_kwargs: Optional[dict] = Field(
+    optimizer_kwargs: dict | None = Field(
         None, description="Keyword arguments passed to the relaxer's optimizer."
     )
 
@@ -205,25 +208,25 @@ class AseStructureTaskDoc(StructureMetadata):
         description="name of the ASE calculator used in the calculation.",
     )
 
-    dir_name: Optional[str] = Field(
+    dir_name: str | None = Field(
         None, description="Directory where the ASE calculations are performed."
     )
 
-    included_objects: Optional[list[AseObject]] = Field(
+    included_objects: list[AseObject] | None = Field(
         None, description="list of ASE objects included with this task document"
     )
-    objects: Optional[dict[AseObject, Any]] = Field(
+    objects: dict[AseObject, Any] | None = Field(
         None, description="ASE objects associated with this task"
     )
 
-    is_force_converged: Optional[bool] = Field(
+    is_force_converged: bool | None = Field(
         None,
         description=(
             "Whether the calculation is converged with respect to interatomic forces."
         ),
     )
 
-    energy_downhill: Optional[bool] = Field(
+    energy_downhill: bool | None = Field(
         None,
         description=(
             "Whether the final trajectory frame has lower total "
@@ -231,7 +234,7 @@ class AseStructureTaskDoc(StructureMetadata):
         ),
     )
 
-    tags: Optional[list[str]] = Field(None, description="List of tags for the task.")
+    tags: list[str] | None = Field(None, description="List of tags for the task.")
 
     @classmethod
     def from_ase_task_doc(
@@ -271,25 +274,25 @@ class AseMoleculeTaskDoc(MoleculeMetadata):
         description="name of the ASE calculator used in the calculation.",
     )
 
-    dir_name: Optional[str] = Field(
+    dir_name: str | None = Field(
         None, description="Directory where the ASE calculations are performed."
     )
 
-    included_objects: Optional[list[AseObject]] = Field(
+    included_objects: list[AseObject] | None = Field(
         None, description="list of ASE objects included with this task document"
     )
-    objects: Optional[dict[AseObject, Any]] = Field(
+    objects: dict[AseObject, Any] | None = Field(
         None, description="ASE objects associated with this task"
     )
 
-    is_force_converged: Optional[bool] = Field(
+    is_force_converged: bool | None = Field(
         None,
         description=(
             "Whether the calculation is converged with respect to interatomic forces."
         ),
     )
 
-    energy_downhill: Optional[bool] = Field(
+    energy_downhill: bool | None = Field(
         None,
         description=(
             "Whether the total energy in the final frame "
@@ -297,7 +300,7 @@ class AseMoleculeTaskDoc(MoleculeMetadata):
         ),
     )
 
-    tags: Optional[list[str]] = Field(None, description="List of tags for the task.")
+    tags: list[str] | None = Field(None, description="List of tags for the task.")
 
 
 class AseTaskDoc(AseBaseModel):
@@ -314,25 +317,25 @@ class AseTaskDoc(AseBaseModel):
         description="name of the ASE calculator used for this job.",
     )
 
-    dir_name: Optional[str] = Field(
+    dir_name: str | None = Field(
         None, description="Directory where the ASE calculations are performed."
     )
 
-    included_objects: Optional[list[AseObject]] = Field(
+    included_objects: list[AseObject] | None = Field(
         None, description="list of ASE objects included with this task document"
     )
-    objects: Optional[dict[AseObject, Any]] = Field(
+    objects: dict[AseObject, Any] | None = Field(
         None, description="ASE objects associated with this task"
     )
 
-    is_force_converged: Optional[bool] = Field(
+    is_force_converged: bool | None = Field(
         None,
         description=(
             "Whether the calculation is converged with respect to interatomic forces."
         ),
     )
 
-    energy_downhill: Optional[bool] = Field(
+    energy_downhill: bool | None = Field(
         None,
         description=(
             "Whether the total energy in the final frame "
@@ -340,7 +343,7 @@ class AseTaskDoc(AseBaseModel):
         ),
     )
 
-    tags: Optional[list[str]] = Field(None, description="A list of tags for the task.")
+    tags: list[str] | None = Field(None, description="A list of tags for the task.")
 
     @classmethod
     def from_ase_compatible_result(
@@ -396,20 +399,24 @@ class AseTaskDoc(AseBaseModel):
         """
         trajectory = result.trajectory
 
-        n_steps = len(trajectory)
+        n_steps = None
+        input_mol_or_struct = None
+        if trajectory:
+            n_steps = len(trajectory)
 
         # NOTE: convert stress units from eV/A³ to kBar (* -1 from standard output)
         # and to 3x3 matrix to comply with MP convention
-        for idx in range(n_steps):
-            if trajectory.frame_properties[idx].get("stress") is not None:
-                trajectory.frame_properties[idx]["stress"] = voigt_6_to_full_3x3_stress(
-                    [
-                        val * -10 / GPa
-                        for val in trajectory.frame_properties[idx]["stress"]
-                    ]
-                )
+        if n_steps:
+            for idx in range(n_steps):
+                if trajectory.frame_properties[idx].get("stress") is not None:
+                    trajectory.frame_properties[idx]["stress"] = voigt_6_to_full_3x3_stress(
+                        [
+                            val * -10 / GPa
+                            for val in trajectory.frame_properties[idx]["stress"]
+                        ]
+                    )
 
-        input_mol_or_struct = trajectory[0]
+            input_mol_or_struct = trajectory[0]
 
         input_doc = InputDoc(
             mol_or_struct=input_mol_or_struct,
@@ -423,7 +430,7 @@ class AseTaskDoc(AseBaseModel):
 
         # Workaround for cases where the ASE optimizer does not correctly limit the
         # number of steps for static calculations.
-        if steps <= 1:
+        if (steps is not None) and steps <= 1:
             steps = 1
             n_steps = 1
 
@@ -441,50 +448,57 @@ class AseTaskDoc(AseBaseModel):
         else:
             output_mol_or_struct = result.final_mol_or_struct
 
-        final_energy = trajectory.frame_properties[-1]["energy"]
-        final_energy_per_atom = final_energy / len(input_mol_or_struct)
-        final_forces = trajectory.frame_properties[-1]["forces"]
-        final_stress = trajectory.frame_properties[-1].get("stress")
+        if trajectory is None:
+            final_energy = result.final_energy
+            final_forces = None
+            final_stress = None
+            ionic_steps = None
+            
+        else:
+            final_energy = trajectory.frame_properties[-1]["energy"]
+            final_forces = trajectory.frame_properties[-1]["forces"]
+            final_stress = trajectory.frame_properties[-1].get("stress")
 
-        ionic_steps = []
-        if ionic_step_data is not None and len(ionic_step_data) > 0:
-            for idx in range(n_steps):
-                _ionic_step_data = {
-                    key: (
-                        trajectory.frame_properties[idx].get(key)
-                        if key in ionic_step_data
+            ionic_steps = []
+            if ionic_step_data is not None and len(ionic_step_data) > 0:
+                for idx in range(n_steps):
+                    _ionic_step_data = {
+                        key: (
+                            trajectory.frame_properties[idx].get(key)
+                            if key in ionic_step_data
+                            else None
+                        )
+                        for key in ("energy", "forces", "stress")
+                    }
+
+                    current_mol_or_struct = (
+                        trajectory[idx]
+                        if any(
+                            v in ionic_step_data
+                            for v in ("mol_or_struct", "structure", "molecule")
+                        )
                         else None
                     )
-                    for key in ("energy", "forces", "stress")
-                }
 
-                current_mol_or_struct = (
-                    trajectory[idx]
-                    if any(
-                        v in ionic_step_data
-                        for v in ("mol_or_struct", "structure", "molecule")
-                    )
-                    else None
-                )
+                    # include "magmoms" in :obj:`ionic_step` if the trajectory has "magmoms"
+                    if "magmoms" in trajectory.frame_properties[idx]:
+                        _ionic_step_data.update(
+                            {
+                                "magmoms": (
+                                    trajectory.frame_properties[idx]["magmoms"]
+                                    if "magmoms" in ionic_step_data
+                                    else None
+                                )
+                            }
+                        )
 
-                # include "magmoms" in :obj:`ionic_step` if the trajectory has "magmoms"
-                if "magmoms" in trajectory.frame_properties[idx]:
-                    _ionic_step_data.update(
-                        {
-                            "magmoms": (
-                                trajectory.frame_properties[idx]["magmoms"]
-                                if "magmoms" in ionic_step_data
-                                else None
-                            )
-                        }
+                    ionic_step = IonicStep(
+                        mol_or_struct=current_mol_or_struct,
+                        **_ionic_step_data,
                     )
 
-                ionic_step = IonicStep(
-                    mol_or_struct=current_mol_or_struct,
-                    **_ionic_step_data,
-                )
+                    ionic_steps.append(ionic_step)
 
-                ionic_steps.append(ionic_step)
 
         objects: dict[AseObject, Any] = {}
         if store_trajectory != StoreTrajectoryOption.NO:
@@ -497,7 +511,7 @@ class AseTaskDoc(AseBaseModel):
         output_doc = OutputDoc(
             mol_or_struct=output_mol_or_struct,
             energy=final_energy,
-            energy_per_atom=final_energy_per_atom,
+            energy_per_atom=final_energy / len(output_mol_or_struct),
             forces=final_forces,
             stress=final_stress,
             ionic_steps=ionic_steps,
@@ -524,9 +538,9 @@ class AseTaskDoc(AseBaseModel):
         cls,
         ase_calculator_name: str,
         result: AseResult,
-        steps: int,
+        steps: int | None = None,
         **task_document_kwargs,
-    ) -> Union[AseStructureTaskDoc, AseMoleculeTaskDoc]:
+    ) -> AseStructureTaskDoc | AseMoleculeTaskDoc:
         """
         Get structure and molecule specific ASE task docs.
 

--- a/src/atomate2/ase/utils.py
+++ b/src/atomate2/ase/utils.py
@@ -365,7 +365,7 @@ class AseRelaxer:
             atoms = self.ase_adaptor.get_atoms(atoms)
         if self.fix_symmetry:
             atoms.set_constraint(FixSymmetry(atoms, symprec=self.symprec))
-        atoms.set_calculator(self.calculator)
+        atoms.calc = self.calculator
         with contextlib.redirect_stdout(sys.stdout if verbose else io.StringIO()):
             obs = TrajectoryObserver(atoms)
             if self.relax_cell and (not is_mol):

--- a/src/atomate2/forcefields/__init__.py
+++ b/src/atomate2/forcefields/__init__.py
@@ -24,6 +24,8 @@ class MLFF(Enum):  # TODO inherit from StrEnum when 3.11+
     NEP = "NEP"
     Nequip = "Nequip"
     SevenNet = "SevenNet"
+    MATPES_R2SCAN = "MatPES-r2SCAN"
+    MATPES_PBE = "MatPES-PBE"
 
     @classmethod
     def _missing_(cls, value: Any) -> Any:

--- a/src/atomate2/forcefields/jobs.py
+++ b/src/atomate2/forcefields/jobs.py
@@ -38,6 +38,8 @@ _DEFAULT_CALCULATOR_KWARGS = {
     MLFF.MACE_MP_0: {"model": "medium"},
     MLFF.MACE_MPA_0: {"model": "medium-mpa-0"},
     MLFF.MACE_MP_0B3: {"model": "medium-0b3"},
+    MLFF.MATPES_PBE: {"architecture": "TensorNet", "version": "2025.1"},
+    MLFF.MATPES_R2SCAN: {"architecture": "TensorNet", "version": "2025.1"},
 }
 
 

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -50,11 +50,17 @@ def ase_calculator(calculator_meta: str | dict, **kwargs: Any) -> Calculator | N
 
             calculator = CHGNetCalculator(**kwargs)
 
-        elif calculator_name == MLFF.M3GNet:
+        elif calculator_name in (MLFF.M3GNet, MLFF.MATPES_R2SCAN, MLFF.MATPES_PBE,):
             import matgl
             from matgl.ext.ase import PESCalculator
 
-            path = kwargs.get("path", "M3GNet-MP-2021.2.8-PES")
+            if calculator_name == MLFF.M3GNet:
+                path = kwargs.get("path", "M3GNet-MP-2021.2.8-PES")
+            elif calculator_name in (MLFF.MATPES_R2SCAN, MLFF.MATPES_PBE):
+                architecture = kwargs.pop("architecture", "TensorNet")
+                matpes_version = kwargs.pop("version", "2025.1")
+                path = f"{architecture}-{calculator_name.value}-v{matpes_version}-PES"
+
             potential = matgl.load_model(path)
             calculator = PESCalculator(potential, **kwargs)
 

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -50,7 +50,7 @@ def ase_calculator(calculator_meta: str | dict, **kwargs: Any) -> Calculator | N
 
             calculator = CHGNetCalculator(**kwargs)
 
-        elif calculator_name in (MLFF.M3GNet, MLFF.MATPES_R2SCAN, MLFF.MATPES_PBE,):
+        elif calculator_name in (MLFF.M3GNet, MLFF.MATPES_R2SCAN, MLFF.MATPES_PBE):
             import matgl
             from matgl.ext.ase import PESCalculator
 

--- a/tests/ase/test_jobs.py
+++ b/tests/ase/test_jobs.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+
 import pytest
+from ase.calculators.emt import EMT
 from jobflow import run_locally
 from pymatgen.core import Molecule, Structure
-
-from ase.calculators.emt import EMT
 
 from atomate2.ase.jobs import (
     AseMaker,
@@ -17,35 +17,34 @@ from atomate2.ase.jobs import (
     LennardJonesRelaxMaker,
     LennardJonesStaticMaker,
 )
-from atomate2.ase.schemas import AseResult, AseMoleculeTaskDoc, AseStructureTaskDoc
+from atomate2.ase.schemas import AseMoleculeTaskDoc, AseResult, AseStructureTaskDoc
 
 try:
     from tblite.ase import TBLite
 except ImportError:
     TBLite = None
 
+
 @dataclass
 class EMTStaticMaker(AseMaker):
-    name : str = "EMT static maker"
+    name: str = "EMT static maker"
 
     @property
     def calculator(self):
         return EMT()
 
-def test_base_maker(test_dir):
 
-    structure = Structure.from_file(
-        test_dir / "structures" / "Al2Au.cif"
-    )
+def test_base_maker(test_dir):
+    structure = Structure.from_file(test_dir / "structures" / "Al2Au.cif")
     ase_res = EMTStaticMaker().run_ase(structure)
-    assert isinstance(ase_res,AseResult)
+    assert isinstance(ase_res, AseResult)
     assert ase_res.final_mol_or_struct == structure
-    assert ase_res.elapsed_time > 0.
+    assert ase_res.elapsed_time > 0.0
 
     job = EMTStaticMaker().make(structure)
     resp = run_locally(job)
     output = resp[job.uuid][1].output
-    assert isinstance(output,AseStructureTaskDoc)
+    assert isinstance(output, AseStructureTaskDoc)
 
 
 def test_lennard_jones_relax_maker(lj_fcc_ne_pars, fcc_ne_structure):

--- a/tests/ase/test_utils.py
+++ b/tests/ase/test_utils.py
@@ -18,7 +18,7 @@ from atomate2.ase.utils import AseRelaxer, TrajectoryObserver
 
 def test_trajectory_observer(si_structure: Structure, test_dir, tmp_dir):
     atoms = si_structure.to_ase_atoms()
-    atoms.calc(LennardJones())
+    atoms.calc = LennardJones()
 
     traj = TrajectoryObserver(atoms)
 

--- a/tests/ase/test_utils.py
+++ b/tests/ase/test_utils.py
@@ -9,17 +9,16 @@ from ase.calculators.lj import LennardJones
 from ase.optimize import BFGS
 from ase.spacegroup.symmetrize import check_symmetry
 from numpy.testing import assert_allclose
-
+    
 if TYPE_CHECKING:
     from pymatgen.core import Structure
-
 
 from atomate2.ase.utils import AseRelaxer, TrajectoryObserver
 
 
 def test_trajectory_observer(si_structure: Structure, test_dir, tmp_dir):
     atoms = si_structure.to_ase_atoms()
-    atoms.set_calculator(LennardJones())
+    atoms.calc(LennardJones())
 
     traj = TrajectoryObserver(atoms)
 

--- a/tests/ase/test_utils.py
+++ b/tests/ase/test_utils.py
@@ -9,7 +9,7 @@ from ase.calculators.lj import LennardJones
 from ase.optimize import BFGS
 from ase.spacegroup.symmetrize import check_symmetry
 from numpy.testing import assert_allclose
-    
+
 if TYPE_CHECKING:
     from pymatgen.core import Structure
 

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -644,5 +644,5 @@ def test_matpes_relax_makers(
         < 1e-6
     )
     assert np.all(
-        np.abs(np.array(output.output.stress) - np.array(ref["stress"])) < 1e-2
+        np.abs(np.array(output.output.stress) - np.array(ref["stress"])) < 1e-1
     )

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import torch
 from jobflow import run_locally
 from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
@@ -26,8 +25,6 @@ from atomate2.forcefields.jobs import (
     NequipStaticMaker,
 )
 from atomate2.forcefields.schemas import ForceFieldTaskDocument
-
-torch.set_num_threads(1)
 
 
 def test_maker_initialization():
@@ -647,5 +644,5 @@ def test_matpes_relax_makers(
         < 1e-6
     )
     assert np.all(
-        np.abs(np.array(output.output.stress) - np.array(ref["stress"])) < 1e-6
+        np.abs(np.array(output.output.stress) - np.array(ref["stress"])) < 1e-2
     )

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -1,7 +1,7 @@
 from importlib.metadata import version as get_imported_version
 from pathlib import Path
-import numpy as np
 
+import numpy as np
 import pytest
 from jobflow import run_locally
 from pymatgen.core import Structure
@@ -560,15 +560,13 @@ def test_nequip_relax_maker(
     with pytest.warns(FutureWarning):
         NequipRelaxMaker()
 
-@pytest.mark.parametrize(
-    "ref_func", ["PBE","r2SCAN"]
-)
+
+@pytest.mark.parametrize("ref_func", ["PBE", "r2SCAN"])
 def test_matpes_relax_makers(
     sr_ti_o3_structure: Structure,
     test_dir: Path,
-    ref_func : str,
+    ref_func: str,
 ):
-    
     importorskip("matgl")
 
     refs = {
@@ -576,38 +574,58 @@ def test_matpes_relax_makers(
             "energy": -39.84724807739258,
             "volume": 61.41011257095997,
             "forces": [
-                [-3.8073078911793345e-08, -3.715077578902992e-09, 1.567575935723653e-08],
+                [
+                    -3.8073078911793345e-08,
+                    -3.715077578902992e-09,
+                    1.567575935723653e-08,
+                ],
                 [-3.306195139884949e-08, 2.2859808268549386e-08, 6.367918103933334e-08],
                 [1.334119588136673e-07, -6.594927981495857e-08, 1.9208528101444244e-09],
-                [-1.2636883184313774e-07, 1.2200325727462769e-07, -1.0713119991123676e-07],
-                [-1.30385160446167e-08, -5.2666791816591285e-08, 5.960902882407026e-08]
+                [
+                    -1.2636883184313774e-07,
+                    1.2200325727462769e-07,
+                    -1.0713119991123676e-07,
+                ],
+                [-1.30385160446167e-08, -5.2666791816591285e-08, 5.960902882407026e-08],
             ],
             "stress": [
                 [57.4752333887927, -0.00020727562869236117, 7.977679617705125e-05],
                 [-0.00020727562869236117, 57.47495286586068, 6.531438391807446e-05],
-                [7.977679617705125e-05, 6.531438391807446e-05, 57.47190889361951]
-            ]
+                [7.977679617705125e-05, 6.531438391807446e-05, 57.47190889361951],
+            ],
         },
         "r2SCAN": {
             "energy": -63.093711853027344,
             "volume": 60.01868572299112,
             "forces": [
-                [-2.518166652976106e-08, 7.450580596923828e-09, -2.9341576279762194e-08],
-                [7.450580596923828e-08, -2.3764563650274795e-08, 4.1701653685777273e-08],
+                [
+                    -2.518166652976106e-08,
+                    7.450580596923828e-09,
+                    -2.9341576279762194e-08,
+                ],
+                [
+                    7.450580596923828e-08,
+                    -2.3764563650274795e-08,
+                    4.1701653685777273e-08,
+                ],
                 [1.5013409182529358e-08, 6.05359673500061e-09, -6.597362656179939e-09],
-                [-1.3317912817001343e-07, -8.288770914077759e-08, -1.0840228270581065e-08],
-                [-5.029141902923584e-08, 4.439064227312883e-09, -6.960369169917158e-09]
+                [
+                    -1.3317912817001343e-07,
+                    -8.288770914077759e-08,
+                    -1.0840228270581065e-08,
+                ],
+                [-5.029141902923584e-08, 4.439064227312883e-09, -6.960369169917158e-09],
             ],
             "stress": [
                 [54.37895257366562, -0.0002788105282469702, -0.0007690944765072764],
                 [-0.0002788105282469702, 54.393605420434355, -0.00024891766395251344],
-                [-0.0007690944765072764, -0.00024891766395251344, 54.39318762032282]
-            ]
-        }
+                [-0.0007690944765072764, -0.00024891766395251344, 54.39318762032282],
+            ],
+        },
     }
 
     struct = Structure.from_dict(sr_ti_o3_structure.as_dict())
-    struct = struct.scale_lattice(1.2*struct.volume)
+    struct = struct.scale_lattice(1.2 * struct.volume)
 
     job = ForceFieldRelaxMaker(
         force_field_name=f"MatPES-{ref_func}",
@@ -616,18 +634,15 @@ def test_matpes_relax_makers(
     resp = run_locally(job)
     output = resp[job.uuid][1].output
 
-    assert isinstance(output,ForceFieldTaskDocument)
-    
+    assert isinstance(output, ForceFieldTaskDocument)
+
     ref = refs[ref_func]
     assert output.output.energy == approx(ref["energy"])
     assert output.structure.volume == approx(ref["volume"])
     assert np.all(
-        np.abs(
-            np.array(output.output.ionic_steps[-1].forces) - np.array(ref["forces"])
-        ) < 1e-6
+        np.abs(np.array(output.output.ionic_steps[-1].forces) - np.array(ref["forces"]))
+        < 1e-6
     )
     assert np.all(
-        np.abs(
-            np.array(output.output.stress) - np.array(ref["stress"])
-        ) < 1e-6
+        np.abs(np.array(output.output.stress) - np.array(ref["stress"])) < 1e-6
     )

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import torch
 from jobflow import run_locally
 from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
@@ -25,6 +26,8 @@ from atomate2.forcefields.jobs import (
     NequipStaticMaker,
 )
 from atomate2.forcefields.schemas import ForceFieldTaskDocument
+
+torch.set_num_threads(1)
 
 
 def test_maker_initialization():

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -1,5 +1,6 @@
 from importlib.metadata import version as get_imported_version
 from pathlib import Path
+import numpy as np
 
 import pytest
 from jobflow import run_locally
@@ -558,3 +559,75 @@ def test_nequip_relax_maker(
 
     with pytest.warns(FutureWarning):
         NequipRelaxMaker()
+
+@pytest.mark.parametrize(
+    "ref_func", ["PBE","r2SCAN"]
+)
+def test_matpes_relax_makers(
+    sr_ti_o3_structure: Structure,
+    test_dir: Path,
+    ref_func : str,
+):
+    
+    importorskip("matgl")
+
+    refs = {
+        "PBE": {
+            "energy": -39.84724807739258,
+            "volume": 61.41011257095997,
+            "forces": [
+                [-3.8073078911793345e-08, -3.715077578902992e-09, 1.567575935723653e-08],
+                [-3.306195139884949e-08, 2.2859808268549386e-08, 6.367918103933334e-08],
+                [1.334119588136673e-07, -6.594927981495857e-08, 1.9208528101444244e-09],
+                [-1.2636883184313774e-07, 1.2200325727462769e-07, -1.0713119991123676e-07],
+                [-1.30385160446167e-08, -5.2666791816591285e-08, 5.960902882407026e-08]
+            ],
+            "stress": [
+                [57.4752333887927, -0.00020727562869236117, 7.977679617705125e-05],
+                [-0.00020727562869236117, 57.47495286586068, 6.531438391807446e-05],
+                [7.977679617705125e-05, 6.531438391807446e-05, 57.47190889361951]
+            ]
+        },
+        "r2SCAN": {
+            "energy": -63.093711853027344,
+            "volume": 60.01868572299112,
+            "forces": [
+                [-2.518166652976106e-08, 7.450580596923828e-09, -2.9341576279762194e-08],
+                [7.450580596923828e-08, -2.3764563650274795e-08, 4.1701653685777273e-08],
+                [1.5013409182529358e-08, 6.05359673500061e-09, -6.597362656179939e-09],
+                [-1.3317912817001343e-07, -8.288770914077759e-08, -1.0840228270581065e-08],
+                [-5.029141902923584e-08, 4.439064227312883e-09, -6.960369169917158e-09]
+            ],
+            "stress": [
+                [54.37895257366562, -0.0002788105282469702, -0.0007690944765072764],
+                [-0.0002788105282469702, 54.393605420434355, -0.00024891766395251344],
+                [-0.0007690944765072764, -0.00024891766395251344, 54.39318762032282]
+            ]
+        }
+    }
+
+    struct = Structure.from_dict(sr_ti_o3_structure.as_dict())
+    struct = struct.scale_lattice(1.2*struct.volume)
+
+    job = ForceFieldRelaxMaker(
+        force_field_name=f"MatPES-{ref_func}",
+        steps=25,
+    ).make(struct)
+    resp = run_locally(job)
+    output = resp[job.uuid][1].output
+
+    assert isinstance(output,ForceFieldTaskDocument)
+    
+    ref = refs[ref_func]
+    assert output.output.energy == approx(ref["energy"])
+    assert output.structure.volume == approx(ref["volume"])
+    assert np.all(
+        np.abs(
+            np.array(output.output.ionic_steps[-1].forces) - np.array(ref["forces"])
+        ) < 1e-6
+    )
+    assert np.all(
+        np.abs(
+            np.array(output.output.stress) - np.array(ref["stress"])
+        ) < 1e-6
+    )

--- a/tests/forcefields/test_md.py
+++ b/tests/forcefields/test_md.py
@@ -79,6 +79,8 @@ def test_ml_ff_md_maker(
         MLFF.NEP: -3.966232215741286,
         MLFF.Nequip: -8.84670181274414,
         MLFF.SevenNet: -5.394115447998047,
+        MLFF.MATPES_PBE: -5.4188947677612305,
+        MLFF.MATPES_R2SCAN: -8.707625389099121,
     }
 
     # ASE can slightly change tolerances on structure positions


### PR DESCRIPTION
- Adds MatPES-trained PBE and r<sup>2</sup>SCAN MLFFs with options to use different pre-trained model architectures
- Adds tests
- Slight tweak to base `AseMaker` class per the atomate2 workshop - this class just now needs a calculator plugged in to run a static / external interface to another code. Useful for examples in training / simple ASE stuff

Would also close #1156