### PR TITLE
Remove walrus operator to avoid unassigned vmax

### DIFF
--- a/src/atomate2/common/flows/mpmorph.py
+++ b/src/atomate2/common/flows/mpmorph.py
@@ -130,11 +130,9 @@ class EquilibriumVolumeMaker(Maker):
                 return Response(output=flow_output, stop_children=True)
 
             # Check if equilibrium volume is in range of attempted volumes
-            v0_in_range = (
-                (vmin := working_outputs.get("Vmin"))
-                <= v0
-                <= (vmax := working_outputs.get("Vmax"))
-            )
+            vmin = working_outputs.get("Vmin")
+            vmax = working_outputs.get("Vmax")
+            v0_in_range = (vmin <= v0 <= vmax)
 
             # Check if maximum number of refinement NVT runs is set,
             # and if so, if that limit has been reached

--- a/src/atomate2/common/flows/mpmorph.py
+++ b/src/atomate2/common/flows/mpmorph.py
@@ -112,9 +112,7 @@ class EquilibriumVolumeMaker(Maker):
                 *self.initial_strain, self.postprocessor.min_data_points
             )
             working_outputs = {
-                "relax": {
-                    key: [] for key in ("energies", "volume", "stress", "pressure")
-                }
+                "relax": {key: [] for key in ("energy", "volume", "stress", "pressure")}
             }
 
         else:
@@ -122,7 +120,7 @@ class EquilibriumVolumeMaker(Maker):
             self.postprocessor.fit(working_outputs)
             working_outputs = dict(self.postprocessor.results)
             flow_output = {"working_outputs": working_outputs.copy(), "structure": None}
-            for k in ("pressure", "energy"):
+            for k in ("pressure",):
                 working_outputs["relax"].pop(k, None)
 
             # Stop flow here if EOS cannot be fit
@@ -165,7 +163,7 @@ class EquilibriumVolumeMaker(Maker):
             relaxed_vol = len(working_outputs["relax"]["volume"])
             md_job.name = f"{self.name} {md_job.name} {relaxed_vol + 1}"
 
-            working_outputs["relax"]["energies"].append(md_job.output.output.energy)
+            working_outputs["relax"]["energy"].append(md_job.output.output.energy)
             working_outputs["relax"]["volume"].append(md_job.output.structure.volume)
             working_outputs["relax"]["stress"].append(md_job.output.output.stress)
             eos_jobs.append(md_job)

--- a/src/atomate2/common/jobs/eos.py
+++ b/src/atomate2/common/jobs/eos.py
@@ -299,7 +299,7 @@ class PostProcessEosPressure(EOSPostProcessor):
             radicand = poly_pars[1] ** 2 - 4.0 * poly_pars[0] * poly_pars[2]
             if radicand < 0.0:
                 v0 = self.results[jobtype]["volume"][
-                    np.argmin(self.results[jobtype]["energy"])
+                    np.argmin(self.results[jobtype]["energies"])
                 ]
             else:
                 min_abs_pressure = 1e20

--- a/src/atomate2/common/jobs/eos.py
+++ b/src/atomate2/common/jobs/eos.py
@@ -299,7 +299,7 @@ class PostProcessEosPressure(EOSPostProcessor):
             radicand = poly_pars[1] ** 2 - 4.0 * poly_pars[0] * poly_pars[2]
             if radicand < 0.0:
                 v0 = self.results[jobtype]["volume"][
-                    np.argmin(self.results[jobtype]["energies"])
+                    np.argmin(self.results[jobtype]["energy"])
                 ]
             else:
                 min_abs_pressure = 1e20

--- a/tests/ase/flows/test_mpmorph.py
+++ b/tests/ase/flows/test_mpmorph.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 from jobflow import run_locally
 
-from atomate2.ase.jobs import LennardJonesRelaxMaker
+from atomate2.ase.jobs import LennardJonesStaticMaker
 from atomate2.common.flows.mpmorph import EquilibriumVolumeMaker
 
 if TYPE_CHECKING:
@@ -28,10 +28,8 @@ def test_vol_scale(
     test_structure = test_structure * (2, 2, 2)
 
     flow = EquilibriumVolumeMaker(
-        md_maker=LennardJonesRelaxMaker(
+        md_maker=LennardJonesStaticMaker(
             calculator_kwargs=lj_fcc_ne_pars,
-            ionic_step_data=("structure",),
-            relax_cell=False,
         ),
         min_strain=0.05,
         initial_strain=0.05,

--- a/tests/ase/flows/test_mpmorph.py
+++ b/tests/ase/flows/test_mpmorph.py
@@ -1,0 +1,58 @@
+"""Test MPMoprh flow using Lennard-Jones."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from jobflow import run_locally
+
+from atomate2.ase.jobs import LennardJonesRelaxMaker
+from atomate2.common.flows.mpmorph import EquilibriumVolumeMaker
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
+
+
+@pytest.mark.parametrize("vol_scale", [2.0, 0.75])
+def test_vol_scale(
+    lj_fcc_ne_pars: dict[str, float], fcc_ne_structure: Structure, vol_scale: float
+) -> None:
+    # Perform relaxations here instead of MD for
+    # (1) time cost and (2) reliability of output
+    # This is a coarse test to ensure that the volume up and down scaling can occur
+
+    init_vol_per_atom = fcc_ne_structure.volume / len(fcc_ne_structure)
+    test_structure = fcc_ne_structure.to_conventional()
+    test_structure = test_structure.scale_lattice(vol_scale * test_structure.volume)
+    test_structure = test_structure * (2, 2, 2)
+
+    flow = EquilibriumVolumeMaker(
+        md_maker=LennardJonesRelaxMaker(
+            calculator_kwargs=lj_fcc_ne_pars,
+            ionic_step_data=("structure",),
+            relax_cell=False,
+        ),
+        min_strain=0.05,
+        initial_strain=0.05,
+    ).make(test_structure)
+
+    resp = run_locally(flow, ensure_success=True)
+    output = None
+    for _output in resp.values():
+        if isinstance(_output[1].output, dict) and (
+            output := _output[1].output.get("working_outputs")
+        ):
+            break
+
+    # ensure that at least one refinement on the volume range was undertaken
+    assert len(output["relax"]["volume"]) > 3
+
+    if vol_scale > 1.0:
+        # When we start with a structure that is too large, the MPMorph equilibration
+        # only approaches the equilibrium volume from above
+        assert output["V0"] / test_structure.num_sites > init_vol_per_atom
+    elif vol_scale < 1.0:
+        # When we start with a structure that is too small, the MPMorph equilibration
+        # only approaches the equilibrium volume from below
+        assert output["V0"] / test_structure.num_sites < init_vol_per_atom


### PR DESCRIPTION
## Summary

Fixes a bug in `mpmorph.py`. 

```Python
v0_in_range = (
    (vmin := working_outputs.get("Vmin"))
    <= v0
    <= (vmax := working_outputs.get("Vmax"))
)
```
If `v0 > vmin`, the expression evaluates to false and the second comparison is skipped, leaving `vmax` unassigned. 

I moved the two assignments out of the expression, avoid the walrus operators. 


## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

* [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [ ] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [ ] Tests have been added for any new functionality or bug fixes.
* [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
