### PR TITLE
Fix RelaxConstVolSetGenerator

### DIFF
--- a/src/atomate2/vasp/sets/core.py
+++ b/src/atomate2/vasp/sets/core.py
@@ -16,7 +16,7 @@ from atomate2.vasp.sets.base import VaspInputGenerator
 if TYPE_CHECKING:
     from emmet.core.math import Vector3D
     from pymatgen.core import Structure
-    from pymatgen.io.vasp import Kpoints, Outcar, Vasprun
+    from pymatgen.io.vasp import Kpoints
 
 
 logger = logging.getLogger(__name__)
@@ -38,31 +38,13 @@ class RelaxSetGenerator(VaspInputGenerator):
         return {"NSW": 99, "LCHARG": False, "ISIF": 3, "IBRION": 2}
 
 
+@dataclass
 class RelaxConstVolSetGenerator(VaspInputGenerator):
     """Class to generate VASP constant volume relaxation input sets."""
 
-    def get_incar_updates(
-        self,
-        structure: Structure,
-        prev_incar: dict = None,
-        bandgap: float = None,
-        vasprun: Vasprun = None,
-        outcar: Outcar = None,
-    ) -> dict:
-        """Get updates to the INCAR for a constant volume relaxation job.
-
-        Parameters
-        ----------
-        structure
-            A structure.
-        prev_incar
-            An incar from a previous calculation.
-        bandgap
-            The band gap.
-        vasprun
-            A vasprun from a previous calculation.
-        outcar
-            An outcar from a previous calculation.
+    @property
+    def incar_updates(self) -> dict:
+        """Get updates to the INCAR for a tight constant volume relaxation job.
 
         Returns
         -------
@@ -104,7 +86,7 @@ class TightRelaxConstVolSetGenerator(VaspInputGenerator):
 
     @property
     def incar_updates(self) -> dict:
-        """Get updates to the INCAR for a static VASP job.
+        """Get updates to the INCAR for a constant volume tight relaxation job.
 
         Returns
         -------

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -2,7 +2,21 @@ import pytest
 from pymatgen.core import Lattice, Species, Structure
 from pymatgen.io.vasp.sets import MPScanRelaxSet
 
-from atomate2.vasp.sets.core import StaticSetGenerator
+from atomate2.vasp.sets.core import (
+    ElectronPhononSetGenerator,
+    HSEBSSetGenerator,
+    HSERelaxSetGenerator,
+    HSEStaticSetGenerator,
+    HSETightRelaxSetGenerator,
+    LobsterTightStaticSetGenerator,
+    MDSetGenerator,
+    NonSCFSetGenerator,
+    RelaxConstVolSetGenerator,
+    RelaxSetGenerator,
+    StaticSetGenerator,
+    TightRelaxConstVolSetGenerator,
+    TightRelaxSetGenerator,
+)
 
 
 @pytest.fixture(scope="module")
@@ -199,3 +213,82 @@ def test_set_kspacing_bandgap_tol_and_auto_ismear(
 
     actual = {key: incar[key] for key in expected_params}
     assert actual == pytest.approx(expected_params)
+
+
+def test_core(struct_no_magmoms):
+    input_gen = RelaxSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["ISIF"] == 3
+    assert incar["IBRION"] == 2
+
+    input_gen = RelaxConstVolSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["ISIF"] == 2
+    assert incar["IBRION"] == 2
+    assert incar["EDIFF"] == 1e-5
+
+    input_gen = TightRelaxSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["ISIF"] == 3
+    assert incar["IBRION"] == 2
+    assert incar["EDIFF"] == 1e-7
+
+    input_gen = TightRelaxConstVolSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["ISIF"] == 2
+    assert incar["IBRION"] == 2
+    assert incar["EDIFF"] == 1e-7
+
+    input_gen = StaticSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["ISMEAR"] == -5
+    assert incar["NSW"] == 0
+
+    input_gen = NonSCFSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["NSW"] == 0
+    assert incar["ISYM"] == 0
+
+    input_gen = HSERelaxSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["PRECFOCK"] == "Fast"
+    assert incar["HFSCREEN"] == 0.2
+    assert incar["EDIFF"] == 1e-5
+
+    input_gen = HSETightRelaxSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["PRECFOCK"] == "Fast"
+    assert incar["HFSCREEN"] == 0.2
+    assert incar["EDIFF"] == 1e-7
+
+    input_gen = HSEStaticSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["PRECFOCK"] == "Fast"
+    assert incar["HFSCREEN"] == 0.2
+    assert incar["EDIFF"] == 1e-5
+    assert incar["NSW"] == 0
+
+    input_gen = HSEBSSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["PRECFOCK"] == "Fast"
+    assert incar["HFSCREEN"] == 0.2
+    assert incar["EDIFF"] == 1e-5
+    assert incar["NSW"] == 0
+    assert incar["ISMEAR"] == 0
+
+    input_gen = ElectronPhononSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["PHON_NSTRUCT"] == 0
+    assert incar["NSW"] == 1
+    assert incar["ISMEAR"] == 0
+
+    input_gen = MDSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["TEBEG"] == 300
+    assert incar["TEEND"] == 300
+
+    input_gen = LobsterTightStaticSetGenerator()
+    incar = input_gen.get_input_set(struct_no_magmoms, potcar_spec=True)["INCAR"]
+    assert incar["EDIFF"] == 1e-7
+    assert incar["ISYM"] == 0
+    assert incar["LWAVE"] is True


### PR DESCRIPTION
## Summary

`RelaxConstVolSetGenerator` was not setting the INCAR values correctly.
Fixing this and adding tests for all the input sets in core to avoid this kind of issues.