### PR TITLE
ASE MD NPT bug fixes

### DIFF
--- a/src/atomate2/ase/md.py
+++ b/src/atomate2/ase/md.py
@@ -28,7 +28,6 @@ from jobflow import job
 from pymatgen.core.structure import Molecule, Structure
 from pymatgen.io.ase import AseAtomsAdaptor
 from scipy.interpolate import interp1d
-from scipy.linalg import schur
 
 from atomate2.ase.jobs import _ASE_DATA_OBJECTS, AseMaker
 from atomate2.ase.schemas import AseResult, AseTaskDoc
@@ -237,11 +236,31 @@ class AseMDMaker(AseMaker, metaclass=ABCMeta):
             self.ase_md_kwargs.pop("temperature_K", None)
             self.ase_md_kwargs.pop("externalstress", None)
         elif self.ensemble == MDEnsemble.nvt:
-            self.ase_md_kwargs["temperature_K"] = self.t_schedule[0]
+            self.ase_md_kwargs["temperature_K"] = self.ase_md_kwargs.get(
+                "temperature_K", self.t_schedule[0]
+            )
             self.ase_md_kwargs.pop("externalstress", None)
         elif self.ensemble == MDEnsemble.npt:
-            self.ase_md_kwargs["temperature_K"] = self.t_schedule[0]
-            self.ase_md_kwargs["externalstress"] = self.p_schedule[0] * 1e3 * units.bar
+            self.ase_md_kwargs["temperature_K"] = self.ase_md_kwargs.get(
+                "temperature_K", self.t_schedule[0]
+            )
+
+            # These use different kwargs for pressure
+            if (
+                isinstance(self.dynamics, str | DynamicsPresets)
+                and DynamicsPresets(self.dynamics) == DynamicsPresets.npt_berendsen
+            ) or (
+                isinstance(self.dynamics, type)
+                and issubclass(self.dynamics, MolecularDynamics)
+                and self.dynamics.__name__ == "NPTBerendsen"
+            ):
+                stress_kwarg = "pressure_au"
+            else:
+                stress_kwarg = "externalstress"
+
+            self.ase_md_kwargs[stress_kwarg] = self.ase_md_kwargs.get(
+                stress_kwarg, self.p_schedule[0] * 1e3 * units.bar
+            )
 
         if isinstance(self.dynamics, str) and self.dynamics.lower() == "langevin":
             self.ase_md_kwargs["friction"] = self.ase_md_kwargs.get(
@@ -338,8 +357,7 @@ class AseMDMaker(AseMaker, metaclass=ABCMeta):
             # `isinstance(dynamics,NPT)` is False
 
             # ASE NPT implementation requires upper triangular cell
-            schur_decomp, _ = schur(atoms.get_cell(complete=True), output="complex")
-            atoms.set_cell(schur_decomp.real, scale_atoms=True)
+            atoms.set_cell(atoms.cell.standard_form(form="upper")[0])
 
         if initial_velocities:
             atoms.set_velocities(initial_velocities)

--- a/src/atomate2/ase/md.py
+++ b/src/atomate2/ase/md.py
@@ -247,7 +247,7 @@ class AseMDMaker(AseMaker, metaclass=ABCMeta):
 
             # These use different kwargs for pressure
             if (
-                isinstance(self.dynamics, str | DynamicsPresets)
+                isinstance(self.dynamics, DynamicsPresets)
                 and DynamicsPresets(self.dynamics) == DynamicsPresets.npt_berendsen
             ) or (
                 isinstance(self.dynamics, type)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from fireworks import LaunchPad
 from jobflow import JobStore
 from jobflow.settings import JobflowSettings
 from maggma.stores import MemoryStore
@@ -69,6 +68,12 @@ def debug_mode():
 
 @pytest.fixture(scope="session")
 def lpad(database, debug_mode):
+    try:
+        from fireworks import LaunchPad
+    except ImportError as exc:
+        raise ImportError(
+            "Please pip install fireworks to use this test fixture."
+        ) from exc
     lpad = LaunchPad(name=database)
     lpad.reset("", require_password=False)
     yield lpad


### PR DESCRIPTION
Closes #1254 using the changes proposed by @fraricci:
1. Cell transformation to upper triangular
2. Berendsen NPT using a different kwarg than Nose-Hoover for the ensemble pressure

Ensure that the `AseMDMaker` does not overwrite user-specified kwargs