### PR TITLE
Remove `VASP_VDW_KERNEL_DIR`

### DIFF
--- a/src/atomate2/settings.py
+++ b/src/atomate2/settings.py
@@ -55,9 +55,6 @@ class Atomate2Settings(BaseSettings):
     VASP_NCL_CMD: str = Field(
         "vasp_ncl", description="Command to run non-collinear version of VASP."
     )
-    VASP_VDW_KERNEL_DIR: Optional[str] = Field(
-        None, description="Path to VDW VASP kernel."
-    )
     VASP_INCAR_UPDATES: dict = Field(
         default_factory=dict, description="Updates to apply to VASP INCAR files."
     )


### PR DESCRIPTION
Currently, it does nothing as noted in https://github.com/materialsproject/atomate2/issues/959. The better PR would be to make it work, but we shouldn't have an unused setting around since that will confused users more.
