### PR TITLE
Update jobflow-remote link in documentation

### DIFF
--- a/docs/user/jobflow-remote.md
+++ b/docs/user/jobflow-remote.md
@@ -42,4 +42,4 @@ submit_flow(
 
 
 
-[jobflow-remote]: https://materialsproject.github.io/fireworks/
+[jobflow-remote]: https://matgenix.github.io/jobflow-remote/


### PR DESCRIPTION
## Summary

Only update in documentation for jobflow-remote no code edits. Currently it wrongly points to Fireworks. 

Fix:
Update Jobflow-remote link to point to the right documentation.

## Additional dependencies introduced (if any)

None


## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

* [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [ ] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [ ] Tests have been added for any new functionality or bug fixes.
* [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
