### PR TITLE
Nequip API change

### DIFF
--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -267,7 +267,12 @@ def ase_calculator(
         elif calculator_name == MLFF.Nequip:
             from nequip.ase import NequIPCalculator
 
-            calculator = NequIPCalculator.from_deployed_model(**kwargs)
+            calculator = getattr(
+                NequIPCalculator,
+                "from_compiled_model"
+                if hasattr(NequIPCalculator, "from_compiled_model")
+                else "from_deployed_model",
+            )(**kwargs)
 
         elif calculator_name == MLFF.SevenNet:
             from sevenn.sevennet_calculator import SevenNetCalculator


### PR DESCRIPTION
Close #1346 by updating nequip API to use new `from_compiled_model` syntax if available in the current version, and fall back to existing API otherwise