### PR TITLE
Fix JSONStore and add MemoryStore option in Installation Docs

### DIFF
--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -270,8 +270,19 @@ from) by clicking "Network Access" (under "Security" in the left hand menu) and 
 ````
 
 ````{note}
-If you do not have access to a Mongo database, you can run `atomate2` using a local `.json` file
-to store outputs using the following `jobflow.yaml` file.
+If you do not have access to a Mongo database, you can run `atomate2` without setting anything. Under the hood,
+`jobflow` will use MemoryStore to store everything in memory. You can explicitly set this too:
+
+```yaml
+JOB_STORE:
+  docs_store:
+    type: MemoryStore
+  additional_stores:
+    data:
+      type: MemoryStore
+```
+
+You can also use a local `.json` file to store outputs using the following `jobflow.yaml` file.
 
 ```yaml
 JOB_STORE:
@@ -290,17 +301,6 @@ The user doesn't need to have the file at the given `<<PATH>>`, since we have se
 In case the file isn't available, a new file with the name mentioned in the `<<PATH>>` will be generated.
 
 **Note that this approach has limitations - it cannot handle simultaneous writes and so is not suitable for high-throughput work.**
-
-Optionally, you can also test your installation with a MemoryStore, which stores everything in memory.
-
-```yaml
-JOB_STORE:
-  docs_store:
-    type: MemoryStore
-  additional_stores:
-    data:
-      type: MemoryStore
-```
 ````
 
 


### PR DESCRIPTION
## Summary

Fix the installation JSONStore (__init__ requires paths and not uri). Also add MemoryStore in order to quickly test the installation as JSONStore does not work with all workflows (failing with PhononMaker with TypeError: Type is not JSON serializable: ScalarFloat).

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

* [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [ ] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [ ] Tests have been added for any new functionality or bug fixes.
* [X] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
