### PR TITLE
Move pre-commit in dev for automatic install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[strict,docs]
+          pip install .[strict] --group docs
 
       - name: Build
         run: sphinx-build docs docs_build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install "setuptools==77.0.3"
-          pip install .[strict,docs]
+          pip install .[strict] --group docs
 
       - name: Copy tutorials
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -67,7 +67,7 @@ jobs:
           python -m pip install --upgrade pip
           mkdir -p ~/.abinit/pseudos
           cp -r tests/test_data/abinit/pseudos/ONCVPSP-PBE-SR-PDv0.4 ~/.abinit/pseudos
-          uv pip install .[strict,strict-forcefields,tests,abinit,approxneb,aims]
+          uv pip install .[strict,strict-forcefields,abinit,approxneb,aims] --group tests
           uv pip install torch-runstats torch_dftd
           uv pip install --no-deps nequip==0.5.6
 
@@ -139,7 +139,7 @@ jobs:
         run: |
           micromamba activate a2
           python -m pip install --upgrade pip
-          uv pip install .[strict-openff,tests]
+          uv pip install .[strict-openff] --group tests
 
       - name: Install pymatgen from master if triggered by pymatgen repo dispatch
         if: github.event_name == 'repository_dispatch' && github.event.action == 'pymatgen-ci-trigger'
@@ -201,7 +201,7 @@ jobs:
         run: |
           micromamba activate a2
           python -m pip install --upgrade pip
-          uv pip install .[strict,tests,aims]
+          uv pip install .[strict,aims] --group tests
           uv pip install tblite>=0.4.0
 
       - name: Install pymatgen from master if triggered by pymatgen repo dispatch
@@ -271,7 +271,7 @@ jobs:
           python -m pip install --upgrade pip
           mkdir -p ~/.abinit/pseudos
           cp -r tests/test_data/abinit/pseudos/ONCVPSP-PBE-SR-PDv0.4 ~/.abinit/pseudos
-          uv pip install .[strict,strict-forcefields,tests,abinit,aims]
+          uv pip install .[strict,strict-forcefields,abinit,aims] --group tests
           uv pip install torch-runstats
           uv pip install --no-deps nequip==0.5.6
 
@@ -319,7 +319,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[strict,strict-forcefields,docs]
+          pip install .[strict,strict-forcefields] --group docs
 
       - name: Build
         run: sphinx-build docs docs_build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,18 @@ strict-forcefields = [
     "tensorflow-cpu==2.16.2",
 ]
 strict = [
-    "atomate2[strict-forcefields, docs, cclib, phonons, lobster, openmm, mp, defects, ase, ase-ext]",
+    "atomate2[strict-forcefields, cclib, phonons, lobster, openmm, mp, defects, ase, ase-ext]",
     "numpy<2.0",
 ]
+
+[project.scripts]
+atm = "atomate2.cli:cli"
+
+[project.urls]
+homepage = "https://materialsproject.github.io/atomate2/"
+repository = "https://github.com/materialsproject/atomate2"
+documentation = "https://materialsproject.github.io/atomate2/"
+changelog = "https://github.com/materialsproject/atomate2/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = ["pre-commit>=4.5.1"]
@@ -123,15 +132,6 @@ docs = [
     "sphinx_design==0.6.1",
     "jupyterlab==4.5.0",
 ]
-
-[project.scripts]
-atm = "atomate2.cli:cli"
-
-[project.urls]
-homepage = "https://materialsproject.github.io/atomate2/"
-repository = "https://github.com/materialsproject/atomate2"
-documentation = "https://materialsproject.github.io/atomate2/"
-changelog = "https://github.com/materialsproject/atomate2/blob/main/CHANGELOG.md"
 
 [tool.setuptools.package-data]
 atomate2 = ["py.typed"]


### PR DESCRIPTION
## Summary

In current installation, you need to run `uv sync --extra dev` to use pre-commit. I've just installed it using `uv add --dev pre-commit`so that this dev group is automatically installed when running uv sync.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

* [ ] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [ ] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [ ] Tests have been added for any new functionality or bug fixes.
* [ ] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
