### PR TITLE
Openff tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -132,8 +132,8 @@ jobs:
         run: micromamba run -n a2 pip install uv
 
       - name: Install conda dependencies
-        run: |
-          micromamba install -n a2 -c conda-forge enumlib packmol bader openbabel openff-toolkit==0.16.2 openff-interchange==0.3.22 --yes
+        run: |  # TODO: migrate openff tests to use non smirnoff99frosst forcefields - requires old setuptools / pkg_resources
+          micromamba install -n a2 -c conda-forge enumlib packmol bader openbabel openff-toolkit==0.16.2 openff-interchange==0.3.22 'setuptools<81' --yes
 
       - name: Install dependencies
         run: |
@@ -194,8 +194,8 @@ jobs:
         run: micromamba run -n a2 pip install uv
 
       - name: Install conda dependencies
-        run: | # TODO: migrate openff tests to use non smirnoff99frosst forcefields - requires old setuptools / pkg_resources
-          micromamba install -n a2 -c conda-forge enumlib packmol bader openbabel openff-toolkit==0.16.2 openff-interchange==0.3.22 'setuptools<81' --yes
+        run: |
+          micromamba install -n a2 -c conda-forge enumlib packmol openbabel --yes
 
       - name: Install dependencies
         run: |
@@ -262,10 +262,6 @@ jobs:
 
       - name: Install uv
         run: micromamba run -n a2 pip install uv
-
-      - name: Install conda dependencies
-        run: |
-          micromamba install -n a2 -c conda-forge enumlib packmol bader openbabel openff-toolkit==0.16.2 openff-interchange==0.3.22 --yes
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Pin setuptools < 81 in openff tests because the `smirnoff99frosst` package used in those tests requires `pkg_resources`. Will need to migrate these tests to a newer forcefield upon a new release of openff