### PR TITLE
Fix docstrings in `ForceFieldQhaMaker`

### DIFF
--- a/src/atomate2/forcefields/flows/qha.py
+++ b/src/atomate2/forcefields/flows/qha.py
@@ -44,7 +44,7 @@ class ForceFieldQhaMaker(CommonQhaMaker):
     t_max: float | None
         Maximum temperature until which the QHA will be performed
     pressure: float | None
-        Pressure at which the QHA will be performed (default None, no pressure)
+        Pressure (GPa) at which the QHA will be performed (default None, no pressure)
     skip_analysis: bool
         Skips the analysis step and only performs EOS and phonon computations.
     ignore_imaginary_modes: bool
@@ -109,7 +109,7 @@ class ForceFieldQhaMaker(CommonQhaMaker):
         run_eos_flow : bool = True
             Whether to perform an EOS fit.
         **kwargs
-            Additional kwargs to pass to ForceFieldEosMaker
+            Additional kwargs to pass to ForceFieldQhaMaker
 
         Returns
         -------


### PR DESCRIPTION
1. Adds units to the `pressure` keyword argument (GPa)
2. Fixes docstring for `**kwargs` in `from_force_field_name`
