### PR TITLE
Add try/except import on LobsterSet module from pymatgen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Other/Nonlisted Topic",
     "Topic :: Scientific/Engineering",
 ]
@@ -48,7 +48,7 @@ amset = ["amset>=0.4.15", "pydash"]
 cclib = ["cclib>=1.8.1"]
 mp = ["mp-api>=0.37.5"]
 phonons = ["phonopy>=2.43.6", "seekpath>=2.0.0"]
-lobster = ["ijson>=3.2.2", "lobsterpy>=0.4.0"]
+lobster = ["ijson>=3.2.2", "lobsterpy>=0.6.0"]
 defects = [
     "dscribe>=1.2.0",
     "pymatgen-analysis-defects>=2024.5.11",

--- a/src/atomate2/vasp/flows/mp.py
+++ b/src/atomate2/vasp/flows/mp.py
@@ -13,7 +13,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from jobflow import Flow, Maker
-from pymatgen.io.vasp.sets import LobsterSet
+
+try:
+    from pymatgen.io.vasp.sets import LobsterSet  # type: ignore[attr-defined]
+except ImportError:
+    from pymatgen.io.lobster.sets import LobsterSet  # type: ignore[attr-defined]
 
 from atomate2.common.jobs.utils import remove_workflow_files
 from atomate2.common.utils import _recursive_get_dir_names

--- a/src/atomate2/vasp/sets/core.py
+++ b/src/atomate2/vasp/sets/core.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pymatgen.core.periodic_table import Element
-from pymatgen.io.vasp.sets import LobsterSet
+
+try:
+    from pymatgen.io.vasp.sets import LobsterSet  # type: ignore[attr-defined]
+except ImportError:
+    from pymatgen.io.lobster.sets import LobsterSet  # type: ignore[attr-defined]
 
 from atomate2.vasp.sets.base import VaspInputGenerator
 


### PR DESCRIPTION
Due to the recent pymatgen changes the LobsterSet class have been displaced without deprecation, for now a try/except approach seems like the best (but ugly) compromise. Fix https://github.com/materialsproject/atomate2/issues/1436 