### PR TITLE
fix mismatch between pymatgen and atomate2 key for Clarke thermal con…

### DIFF
--- a/src/atomate2/common/schemas/elastic.py
+++ b/src/atomate2/common/schemas/elastic.py
@@ -74,7 +74,7 @@ class DerivedProperties(BaseModel):
     snyder_total: float | None = Field(
         None, description="Synder's total sound velocity (SI units)."
     )
-    clark_thermalcond: float | None = Field(
+    clarke_thermalcond: float | None = Field(
         None, description="Clarke's thermal conductivity (SI units)."
     )
     cahill_thermalcond: float | None = Field(


### PR DESCRIPTION
## Summary

* Fix 1 -- This PR fixes an issue where `clark_thermalcond` is always `None` in the
elastic tensor workflow output.
pymatgen returns:
  - `clarke_thermalcond` (note the "e")
atomate2 schema expects:
  - `clark_thermalcond`

  -- Standardize the field name to `clarke_thermalcond` in atomate2

Before a pull request can be merged, the following items must be checked:

* [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [X] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [X] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [X] Tests have been added for any new functionality or bug fixes.
* [X] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
