### PR TITLE
Alternative ASE/MLFF batch mode

### DIFF
--- a/src/atomate2/ase/jobs.py
+++ b/src/atomate2/ase/jobs.py
@@ -54,8 +54,7 @@ class AseMaker(Maker, ABC):
     class EMTStaticMaker(AseMaker):
         name: str = "EMT static maker"
 
-        @property
-        def calculator(self):
+        def _get_calculator(self):
             return EMT()
     ```
 
@@ -94,6 +93,10 @@ class AseMaker(Maker, ABC):
     )
     store_trajectory: StoreTrajectoryOption = StoreTrajectoryOption.NO
     tags: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Enable caching of the ASE calculator via private attribute."""
+        self._calculator: Calculator | None = None
 
     @job(data=_ASE_DATA_OBJECTS)
     def make(
@@ -148,11 +151,18 @@ class AseMaker(Maker, ABC):
             elapsed_time=t_f - t_i,
         )
 
-    @property
     @abstractmethod
+    def _get_calculator(self) -> Calculator:
+        """Load ASE calculator, to be implemented by the user."""
+
+    @property
     def calculator(self) -> Calculator:
-        """ASE calculator, method to be implemented in subclasses."""
-        raise NotImplementedError
+        """Retrieve cached ASE calculator."""
+        if getattr(self, "_calculator", None) is None:
+            self._calculator = self._get_calculator()
+        if self._calculator is None:
+            raise ValueError("ASE calculator not properly initialized.")
+        return self._calculator
 
 
 @dataclass
@@ -208,8 +218,7 @@ class AseRelaxMaker(AseMaker):
 
     def __post_init__(self) -> None:
         """Ensure that physical relaxation settings are used."""
-        if hasattr(super(), "__post_init__"):
-            super().__post_init__()  # type: ignore[misc]
+        super().__post_init__()
         if self.relax_cell and self.relax_shape:
             raise ValueError(
                 "You have set both `relax_cell` (relaxing the cell shape and volume) "
@@ -299,8 +308,7 @@ class EmtRelaxMaker(AseRelaxMaker):
 
     name: str = "EMT relaxation"
 
-    @property
-    def calculator(self) -> Calculator:
+    def _get_calculator(self) -> Calculator:
         """EMT calculator."""
         from ase.calculators.emt import EMT
 
@@ -320,8 +328,7 @@ class LennardJonesRelaxMaker(AseRelaxMaker):
 
     name: str = "Lennard-Jones 6-12 relaxation"
 
-    @property
-    def calculator(self) -> Calculator:
+    def _get_calculator(self) -> None:
         """Lennard-Jones calculator."""
         from ase.calculators.lj import LennardJones
 
@@ -378,8 +385,7 @@ class GFNxTBRelaxMaker(AseRelaxMaker):
         }
     )
 
-    @property
-    def calculator(self) -> Calculator:
+    def _get_calculator(self) -> None:
         """GFN-xTB / TBLite calculator."""
         try:
             from tblite.ase import TBLite

--- a/src/atomate2/ase/jobs.py
+++ b/src/atomate2/ase/jobs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -164,9 +164,16 @@ class AseMaker(Maker, ABC):
             elapsed_time=t_f - t_i,
         )
 
-    @abstractmethod
     def _get_calculator(self) -> Calculator:
-        """Load ASE calculator, to be implemented by the user."""
+        """Load ASE calculator, to be implemented by the user.
+
+        NB: To avoid breaking behavior, this method by default
+        does nothing and *should not* be an `abstractmethod`.
+
+        Previously, users would define the `calculator` attr
+        directly. That is still possible but will not benefit
+        from caching the calculator.
+        """
 
     @property
     def calculator(self) -> Calculator:

--- a/src/atomate2/ase/jobs.py
+++ b/src/atomate2/ase/jobs.py
@@ -101,24 +101,37 @@ class AseMaker(Maker, ABC):
     @job(data=_ASE_DATA_OBJECTS)
     def make(
         self,
-        mol_or_struct: Molecule | Structure,
+        mol_or_struct: Molecule | Structure | list[Molecule | Structure],
         prev_dir: str | Path | None = None,
-    ) -> AseStructureTaskDoc | AseMoleculeTaskDoc:
+    ) -> (
+        AseStructureTaskDoc
+        | AseMoleculeTaskDoc
+        | list[AseStructureTaskDoc | AseMoleculeTaskDoc]
+    ):
         """
         Run ASE as job, can be re-implemented in subclasses.
 
         Parameters
         ----------
-        mol_or_struct: .Molecule or .Structure
-            pymatgen molecule or structure
+        mol_or_struct: .Molecule, .Structure, or a list thereof
+            pymatgen molecule(s) or structure(s)
         prev_dir : str or Path or None
             A previous calculation directory to copy output files from. Unused, just
                 added to match the method signature of other makers.
+
+        Returns
+        -------
+        AseStructureTaskDoc, AseMoleculeTaskDoc, or list thereof.
         """
-        return AseTaskDoc.to_mol_or_struct_metadata_doc(
-            getattr(self.calculator, "name", type(self.calculator).__name__),
-            self.run_ase(mol_or_struct, prev_dir=prev_dir),
-        )
+        batch_mode = isinstance(mol_or_struct, list)
+        results = [
+            AseTaskDoc.to_mol_or_struct_metadata_doc(
+                getattr(self.calculator, "name", type(self.calculator).__name__),
+                self.run_ase(atoms, prev_dir=prev_dir),
+            )
+            for atoms in (mol_or_struct if batch_mode else [mol_or_struct])
+        ]
+        return results if batch_mode else results[0]
 
     def run_ase(
         self,
@@ -229,38 +242,48 @@ class AseRelaxMaker(AseMaker):
     @job(data=_ASE_DATA_OBJECTS)
     def make(
         self,
-        mol_or_struct: Molecule | Structure,
+        mol_or_struct: Molecule | Structure | list[Molecule | Structure],
         prev_dir: str | Path | None = None,
-    ) -> AseStructureTaskDoc | AseMoleculeTaskDoc:
+    ) -> (
+        AseStructureTaskDoc
+        | AseMoleculeTaskDoc
+        | list[AseStructureTaskDoc | AseMoleculeTaskDoc]
+    ):
         """
         Relax a structure or molecule using ASE as a job.
 
         Parameters
         ----------
-        mol_or_struct: .Molecule or .Structure
-            pymatgen molecule or structure
+        mol_or_struct: .Molecule or .Structure, or list thereof
+            pymatgen molecule(s) or structure(s)
         prev_dir : str or Path or None
             A previous calculation directory to copy output files from. Unused, just
                 added to match the method signature of other makers.
 
         Returns
         -------
-        AseStructureTaskDoc or AseMoleculeTaskDoc
+        AseStructureTaskDoc or AseMoleculeTaskDoc, or list thereof
         """
-        return AseTaskDoc.to_mol_or_struct_metadata_doc(
-            getattr(self.calculator, "name", type(self.calculator).__name__),
-            self.run_ase(mol_or_struct, prev_dir=prev_dir),
-            self.steps,
-            relax_kwargs=self.relax_kwargs,
-            optimizer_kwargs=self.optimizer_kwargs,
-            relax_cell=self.relax_cell,
-            relax_shape=self.relax_shape,
-            fix_symmetry=self.fix_symmetry,
-            symprec=self.symprec if self.fix_symmetry else None,
-            ionic_step_data=self.ionic_step_data,
-            store_trajectory=self.store_trajectory,
-            tags=self.tags,
-        )
+        batch_mode = isinstance(mol_or_struct, list)
+
+        results = [
+            AseTaskDoc.to_mol_or_struct_metadata_doc(
+                getattr(self.calculator, "name", type(self.calculator).__name__),
+                self.run_ase(atoms, prev_dir=prev_dir),
+                self.steps,
+                relax_kwargs=self.relax_kwargs,
+                optimizer_kwargs=self.optimizer_kwargs,
+                relax_cell=self.relax_cell,
+                relax_shape=self.relax_shape,
+                fix_symmetry=self.fix_symmetry,
+                symprec=self.symprec if self.fix_symmetry else None,
+                ionic_step_data=self.ionic_step_data,
+                store_trajectory=self.store_trajectory,
+                tags=self.tags,
+            )
+            for atoms in (mol_or_struct if batch_mode else [mol_or_struct])
+        ]
+        return results if batch_mode else results[0]
 
     def run_ase(
         self,

--- a/src/atomate2/ase/md.py
+++ b/src/atomate2/ase/md.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 import time
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
@@ -189,6 +189,7 @@ class AseMDMaker(AseMaker, ABC):
 
     def __post_init__(self) -> None:
         """Ensure that ensemble is an enum."""
+        super().__post_init__()
         if isinstance(self.ensemble, str):
             self.ensemble = MDEnsemble(self.ensemble.split("MDEnsemble.")[-1])
 
@@ -444,12 +445,6 @@ class AseMDMaker(AseMaker, ABC):
             elapsed_time=t_f - t_i,
         )
 
-    @property
-    @abstractmethod
-    def calculator(self) -> Calculator:
-        """ASE calculator, to be overwritten by user."""
-        raise NotImplementedError
-
 
 @dataclass
 class LennardJonesMDMaker(AseMDMaker):
@@ -461,8 +456,7 @@ class LennardJonesMDMaker(AseMDMaker):
 
     name: str = "Lennard-Jones 6-12 MD"
 
-    @property
-    def calculator(self) -> Calculator:
+    def _get_calculator(self) -> Calculator:
         """Lennard-Jones calculator."""
         from ase.calculators.lj import LennardJones
 
@@ -495,8 +489,7 @@ class GFNxTBMDMaker(AseMDMaker):
         }
     )
 
-    @property
-    def calculator(self) -> Calculator:
+    def _get_calculator(self) -> Calculator:
         """GFN-xTB / TBLite calculator."""
         try:
             from tblite.ase import TBLite

--- a/src/atomate2/ase/neb.py
+++ b/src/atomate2/ase/neb.py
@@ -257,8 +257,7 @@ class EmtNebFromImagesMaker(AseNebFromImagesMaker):
 
     name: str = "EMT NEB from images maker"
 
-    @property
-    def calculator(self) -> Calculator:
+    def _get_calculator(self) -> Calculator:
         """EMT calculator."""
         from ase.calculators.emt import EMT
 

--- a/src/atomate2/common/flows/eos.py
+++ b/src/atomate2/common/flows/eos.py
@@ -46,6 +46,10 @@ class CommonEosMaker(Maker):
     postprocessor : .atomate2.common.jobs.EOSPostProcessor
         Optional postprocessing step, defaults to
         `atomate2.common.jobs.PostProcessEosEnergy`.
+    socket : bool
+        Whether to run in socket/batch mode (True: single job performing multiple
+        relaxations/statics). Defaults to creating separate jobs for each
+        relaxation/static (False)
     _store_transformation_information : .bool = False
         Whether to store the information about transformations. Unfortunately
         needed at present to handle issues with emmet and pydantic validation
@@ -159,25 +163,25 @@ class CommonEosMaker(Maker):
                 jobs["static"].append(static_job)
 
             for key in job_types:
-                flow_output[key].update(
-                    energy=[
-                        jobs[key][-1].output[idx].output.energy
-                        for idx in range(self.number_of_frames)
-                    ],
-                    volume=[
-                        jobs[key][-1].output[idx].output.structure.volume
-                        for idx in range(self.number_of_frames)
-                    ],
-                    stress=[
-                        jobs[key][-1].output[idx].output.stress
-                        for idx in range(self.number_of_frames)
-                    ],
-                    structure=[
-                        jobs[key][-1].output[idx].output.structure
-                        for idx in range(self.number_of_frames)
-                    ],
-                    dir_name=[jobs[key][-1].output[0].dir_name] * self.number_of_frames,
-                )
+                flow_output[key]["energy"] += [
+                    jobs[key][-1].output[idx].output.energy
+                    for idx in range(self.number_of_frames)
+                ]
+                flow_output[key]["volume"] += [
+                    jobs[key][-1].output[idx].output.structure.volume
+                    for idx in range(self.number_of_frames)
+                ]
+                flow_output[key]["stress"] += [
+                    jobs[key][-1].output[idx].output.stress
+                    for idx in range(self.number_of_frames)
+                ]
+                flow_output[key]["structure"] += [
+                    jobs[key][-1].output[idx].output.structure
+                    for idx in range(self.number_of_frames)
+                ]
+                flow_output[key]["dir_name"] += [
+                    jobs[key][-1].output[0].dir_name
+                ] * self.number_of_frames
 
         else:
             for frame_idx in range(self.number_of_frames):
@@ -224,9 +228,9 @@ class CommonEosMaker(Maker):
                     flow_output[key]["dir_name"] += [dir_name]
 
         if self.postprocessor is not None:
-            if self.number_of_frames < (
-                min_points := self.postprocessor.min_data_points
-            ):
+            if self.number_of_frames + (
+                1 if self.initial_relax_maker is not None else 0
+            ) < (min_points := self.postprocessor.min_data_points):
                 raise ValueError(
                     "To perform least squares EOS fit with "
                     f"{type(self.postprocessor).__name__}, you must specify "

--- a/src/atomate2/common/flows/eos.py
+++ b/src/atomate2/common/flows/eos.py
@@ -59,6 +59,7 @@ class CommonEosMaker(Maker):
     linear_strain: tuple[float, float] = (-0.05, 0.05)
     number_of_frames: int = 6
     postprocessor: EOSPostProcessor = field(default_factory=PostProcessEosEnergy)
+    socket: bool = False
     _store_transformation_information: bool = False
 
     def make(self, structure: Structure, prev_dir: str | Path = None) -> Flow:
@@ -142,52 +143,90 @@ class CommonEosMaker(Maker):
         transformations = apply_strain_to_structure(structure, deformation_l)
         jobs["utility"] += [transformations]
 
-        for frame_idx in range(self.number_of_frames):
-            if self._store_transformation_information:
-                with contextlib.suppress(Exception):
-                    # write details of the transformation to the
-                    # transformations.json file. This file will automatically get
-                    # added to the task document and allow the elastic builder
-                    # to reconstruct the elastic document. Note the ":"
-                    # is automatically converted to a "." in the filename.
-                    self.eos_relax_maker.write_additional_data[
-                        "transformations:json"
-                    ] = transformations.output[frame_idx]
-
+        if self.socket:
             relax_job = self.eos_relax_maker.make(
-                structure=transformations.output[frame_idx].final_structure,
-                prev_dir=prev_dir,
+                [
+                    transformations.output[idx].final_structure
+                    for idx in range(self.number_of_frames)
+                ]
             )
-            relax_job.name += f" deformation {frame_idx}"
-            try:
-                if len(relax_job.jobs) > 1:
-                    for job in relax_job.jobs:
-                        job.append_name(f" deformation {frame_idx}")
-            except AttributeError:
-                pass
             jobs["relax"].append(relax_job)
 
             if self.static_maker:
                 static_job = self.static_maker.make(
-                    structure=relax_job.output.structure,
-                    prev_dir=relax_job.output.dir_name,
+                    [relax.output.structure for relax in relax_job.output]
                 )
-                static_job.name += f" {frame_idx}"
                 jobs["static"].append(static_job)
 
-        for key in job_types:
-            for idx in range(len(jobs[key])):
-                output = jobs[key][idx].output.output
-                dir_name = jobs[key][idx].output.dir_name
-                flow_output[key]["energy"] += [output.energy]
-                flow_output[key]["volume"] += [output.structure.volume]
-                flow_output[key]["stress"] += [output.stress]
-                flow_output[key]["structure"] += [output.structure]
-                flow_output[key]["dir_name"] += [dir_name]
+            for key in job_types:
+                flow_output[key].update(
+                    energy=[
+                        jobs[key][-1].output[idx].output.energy
+                        for idx in range(self.number_of_frames)
+                    ],
+                    volume=[
+                        jobs[key][-1].output[idx].output.structure.volume
+                        for idx in range(self.number_of_frames)
+                    ],
+                    stress=[
+                        jobs[key][-1].output[idx].output.stress
+                        for idx in range(self.number_of_frames)
+                    ],
+                    structure=[
+                        jobs[key][-1].output[idx].output.structure
+                        for idx in range(self.number_of_frames)
+                    ],
+                    dir_name=[jobs[key][-1].output[0].dir_name] * self.number_of_frames,
+                )
+
+        else:
+            for frame_idx in range(self.number_of_frames):
+                if self._store_transformation_information:
+                    with contextlib.suppress(Exception):
+                        # write details of the transformation to the
+                        # transformations.json file. This file will automatically get
+                        # added to the task document and allow the elastic builder
+                        # to reconstruct the elastic document. Note the ":"
+                        # is automatically converted to a "." in the filename.
+                        self.eos_relax_maker.write_additional_data[
+                            "transformations:json"
+                        ] = transformations.output[frame_idx]
+
+                relax_job = self.eos_relax_maker.make(
+                    structure=transformations.output[frame_idx].final_structure,
+                    prev_dir=prev_dir,
+                )
+                relax_job.name += f" deformation {frame_idx}"
+                try:
+                    if len(relax_job.jobs) > 1:
+                        for job in relax_job.jobs:
+                            job.append_name(f" deformation {frame_idx}")
+                except AttributeError:
+                    pass
+                jobs["relax"].append(relax_job)
+
+                if self.static_maker:
+                    static_job = self.static_maker.make(
+                        structure=relax_job.output.structure,
+                        prev_dir=relax_job.output.dir_name,
+                    )
+                    static_job.name += f" {frame_idx}"
+                    jobs["static"].append(static_job)
+
+            for key in job_types:
+                for idx in range(len(jobs[key])):
+                    output = jobs[key][idx].output.output
+                    dir_name = jobs[key][idx].output.dir_name
+                    flow_output[key]["energy"] += [output.energy]
+                    flow_output[key]["volume"] += [output.structure.volume]
+                    flow_output[key]["stress"] += [output.stress]
+                    flow_output[key]["structure"] += [output.structure]
+                    flow_output[key]["dir_name"] += [dir_name]
 
         if self.postprocessor is not None:
-            min_points = self.postprocessor.min_data_points
-            if len(jobs["relax"]) < min_points:
+            if self.number_of_frames < (
+                min_points := self.postprocessor.min_data_points
+            ):
                 raise ValueError(
                     "To perform least squares EOS fit with "
                     f"{type(self.postprocessor).__name__}, you must specify "
@@ -199,8 +238,8 @@ class CommonEosMaker(Maker):
             flow_output = post_process.output
             jobs["utility"] += [post_process]
 
-        job_list = []
-        for val in jobs.values():
-            job_list += val
-
-        return Flow(jobs=job_list, output=flow_output, name=self.name)
+        return Flow(
+            jobs=[j for j_sub in jobs.values() for j in j_sub],
+            output=flow_output,
+            name=self.name,
+        )

--- a/src/atomate2/common/flows/phonons.py
+++ b/src/atomate2/common/flows/phonons.py
@@ -132,7 +132,7 @@ class BasePhononMaker(Maker, ABC):
     store_force_constants: bool
         if True, force constants will be stored
     socket: bool
-        If True, use the socket for the calculation
+        If True, use the socket/batch for the calculation
     """
 
     name: str = "phonon"

--- a/src/atomate2/common/jobs/phonons.py
+++ b/src/atomate2/common/jobs/phonons.py
@@ -21,8 +21,11 @@ from pymatgen.io.phonopy import get_phonopy_structure, get_pmg_structure
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.dos import PhononDos
 
+from atomate2.ase.jobs import AseRelaxMaker
 from atomate2.common.schemas.phonons import ForceConstants, PhononBSDOSDoc, get_factor
 from atomate2.common.utils import get_supercell_matrix
+from atomate2.forcefields.jobs import ForceFieldRelaxMaker
+from atomate2.vasp.jobs.base import BaseVaspMaker
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -30,9 +33,6 @@ if TYPE_CHECKING:
     from emmet.core.math import Matrix3D
 
     from atomate2.aims.jobs.base import BaseAimsMaker
-    from atomate2.forcefields.jobs import ForceFieldStaticMaker
-    from atomate2.vasp.jobs.base import BaseVaspMaker
-
 
 logger = logging.getLogger(__name__)
 
@@ -253,7 +253,10 @@ def run_phonon_displacements(
     displacements: list[Structure],
     structure: Structure,
     supercell_matrix: Matrix3D,
-    phonon_maker: BaseVaspMaker | ForceFieldStaticMaker | BaseAimsMaker = None,
+    phonon_maker: BaseVaspMaker
+    | AseRelaxMaker
+    | ForceFieldRelaxMaker
+    | BaseAimsMaker = None,
     prev_dir: str | Path = None,
     prev_dir_argname: str = None,
     socket: bool = False,
@@ -272,14 +275,16 @@ def run_phonon_displacements(
         Fully optimized structure used for phonon computations.
     supercell_matrix: Matrix3D
         supercell matrix for meta data
-    phonon_maker : .BaseVaspMaker or .ForceFieldStaticMaker or .BaseAimsMaker
-        A maker to use to generate dispacement calculations
+    phonon_maker : .BaseVaspMaker, .AseRelaxMaker,
+        .ForceFieldRelaxMaker, or .BaseAimsMaker
+        A maker to use to generate dispacement calculations.
+        NB: this should be a static maker.
     prev_dir: str or Path
         The previous working directory
     prev_dir_argname: str
         argument name for the prev_dir variable
     socket: bool
-        If True use the socket-io interface to increase performance
+        If True use the socket-io (batch-mode) interface to increase performance
     """
     phonon_jobs = []
     outputs: dict[str, list] = {
@@ -292,28 +297,39 @@ def run_phonon_displacements(
     if prev_dir is not None and prev_dir_argname is not None:
         phonon_job_kwargs[prev_dir_argname] = prev_dir
 
+    num_disp = len(displacements)
     if socket:
+        if isinstance(phonon_maker, BaseVaspMaker):
+            raise ValueError("VASP makers do not currently support socket/batch mode.")
+
         phonon_job = phonon_maker.make(displacements, **phonon_job_kwargs)
         info = {
             "original_structure": structure,
             "supercell_matrix": supercell_matrix,
             "displaced_structures": displacements,
         }
-        phonon_job.update_maker_kwargs(
-            {"_set": {"write_additional_data->phonon_info:json": info}}, dict_mod=True
-        )
+        if not isinstance(phonon_maker, AseRelaxMaker | ForceFieldRelaxMaker):
+            phonon_job.update_maker_kwargs(
+                {"_set": {"write_additional_data->phonon_info:json": info}},
+                dict_mod=True,
+            )
+
         phonon_jobs.append(phonon_job)
-        outputs["displacement_number"] = list(range(len(displacements)))
-        outputs["uuids"] = [phonon_job.output.uuid] * len(displacements)
-        outputs["dirs"] = [phonon_job.output.dir_name] * len(displacements)
-        outputs["forces"] = phonon_job.output.output.all_forces
+        outputs["displacement_number"] = list(range(num_disp))
+        if isinstance(phonon_maker, AseRelaxMaker | ForceFieldRelaxMaker):
+            outputs["uuids"] = [phonon_job.output[0].uuid] * num_disp
+            outputs["dirs"] = [phonon_job.output[0].dir_name] * num_disp
+            outputs["forces"] = [
+                phonon_job.output[idx].output.forces for idx in range(num_disp)
+            ]
+        else:
+            outputs["uuids"] = [phonon_job.output.uuid] * num_disp
+            outputs["dirs"] = [phonon_job.output.dir_name] * num_disp
+            outputs["forces"] = phonon_job.output.output.all_forces
     else:
         for idx, displacement in enumerate(displacements):
-            if prev_dir is not None:
-                phonon_job = phonon_maker.make(displacement, prev_dir=prev_dir)
-            else:
-                phonon_job = phonon_maker.make(displacement)
-            phonon_job.append_name(f" {idx + 1}/{len(displacements)}")
+            phonon_job = phonon_maker.make(displacement, prev_dir=prev_dir)
+            phonon_job.append_name(f" {idx + 1}/{num_disp}")
 
             # we will add some meta data
             info = {
@@ -323,10 +339,11 @@ def run_phonon_displacements(
                 "displaced_structure": displacement,
             }
             with contextlib.suppress(Exception):
-                phonon_job.update_maker_kwargs(
-                    {"_set": {"write_additional_data->phonon_info:json": info}},
-                    dict_mod=True,
-                )
+                if not isinstance(phonon_maker, AseRelaxMaker | ForceFieldRelaxMaker):
+                    phonon_job.update_maker_kwargs(
+                        {"_set": {"write_additional_data->phonon_info:json": info}},
+                        dict_mod=True,
+                    )
             phonon_jobs.append(phonon_job)
             outputs["displacement_number"].append(idx)
             outputs["uuids"].append(phonon_job.output.uuid)

--- a/src/atomate2/forcefields/jobs.py
+++ b/src/atomate2/forcefields/jobs.py
@@ -122,21 +122,29 @@ class ForceFieldRelaxMaker(ForceFieldMixin, AseRelaxMaker):
 
     @forcefield_job
     def make(
-        self, structure: Molecule | Structure, prev_dir: str | Path | None = None
-    ) -> ForceFieldTaskDocument | ForceFieldMoleculeTaskDocument:
+        self,
+        structure: Molecule | Structure | list[Molecule | Structure],
+        prev_dir: str | Path | None = None,
+    ) -> (
+        ForceFieldTaskDocument
+        | ForceFieldMoleculeTaskDocument
+        | list[ForceFieldTaskDocument | ForceFieldMoleculeTaskDocument]
+    ):
         """
         Perform a relaxation of a structure using a force field.
 
         Parameters
         ----------
-        structure: .Structure or Molecule
-            pymatgen structure or molecule.
+        structure: .Molecule or .Structure, or a list thereof
+            pymatgen molecule(s) or structure(s)
         prev_dir : str or Path or None
             A previous calculation directory to copy output files from. Unused, just
                 added to match the method signature of other makers.
-        """
-        ase_result = self._run_ase_safe(structure, prev_dir=prev_dir)
 
+        Returns
+        -------
+            ForceFieldTaskDocument, ForceFieldMoleculeTaskDocument, or a list thereof
+        """
         if len(self.task_document_kwargs) > 0:
             warnings.warn(
                 "`task_document_kwargs` is now deprecated, please use the top-level "
@@ -145,22 +153,33 @@ class ForceFieldRelaxMaker(ForceFieldMixin, AseRelaxMaker):
                 stacklevel=1,
             )
 
-        return ForceFieldTaskDocument.from_ase_compatible_result(
-            self.ase_calculator_name,
-            ase_result,
-            self.steps,
-            calculator_meta=self.calculator_meta,
-            relax_kwargs=self.relax_kwargs,
-            optimizer_kwargs=self.optimizer_kwargs,
-            relax_cell=self.relax_cell,
-            relax_shape=self.relax_shape,
-            fix_symmetry=self.fix_symmetry,
-            symprec=self.symprec if self.fix_symmetry else None,
-            ionic_step_data=self.ionic_step_data,
-            store_trajectory=self.store_trajectory,
-            tags=self.tags,
-            **self.task_document_kwargs,
-        )
+        batch_mode = isinstance(structure, list)
+
+        ase_results = [
+            self._run_ase_safe(atoms, prev_dir=prev_dir)
+            for atoms in (structure if batch_mode else [structure])
+        ]
+
+        task_docs = [
+            ForceFieldTaskDocument.from_ase_compatible_result(
+                self.ase_calculator_name,
+                ase_result,
+                self.steps,
+                calculator_meta=self.calculator_meta,
+                relax_kwargs=self.relax_kwargs,
+                optimizer_kwargs=self.optimizer_kwargs,
+                relax_cell=self.relax_cell,
+                relax_shape=self.relax_shape,
+                fix_symmetry=self.fix_symmetry,
+                symprec=self.symprec if self.fix_symmetry else None,
+                ionic_step_data=self.ionic_step_data,
+                store_trajectory=self.store_trajectory,
+                tags=self.tags,
+                **self.task_document_kwargs,
+            )
+            for ase_result in ase_results
+        ]
+        return task_docs if batch_mode else task_docs[0]
 
 
 @dataclass

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -250,8 +250,7 @@ class ForceFieldMixin:
         with revert_default_dtype():
             return self.run_ase(*args, **kwargs)
 
-    @property
-    def calculator(self) -> Calculator:
+    def _get_calculator(self) -> Calculator:
         """ASE calculator, can be overwritten by user."""
         return ase_calculator(
             self.calculator_meta,

--- a/tests/ase/test_jobs.py
+++ b/tests/ase/test_jobs.py
@@ -30,8 +30,7 @@ except ImportError:
 class EMTStaticMaker(AseMaker):
     name: str = "EMT static maker"
 
-    @property
-    def calculator(self):
+    def _get_calculator(self):
         return EMT()
 
 
@@ -39,8 +38,7 @@ class EMTStaticMaker(AseMaker):
 class EMTRelaxMaker(AseRelaxMaker):
     name: str = "EMT relax maker"
 
-    @property
-    def calculator(self):
+    def _get_calculator(self):
         return EMT()
 
 

--- a/tests/ase/test_jobs.py
+++ b/tests/ase/test_jobs.py
@@ -35,10 +35,13 @@ class EMTStaticMaker(AseMaker):
 
 
 @dataclass
-class EMTRelaxMaker(AseRelaxMaker):
-    name: str = "EMT relax maker"
+class LegacyEMTRelaxMaker(AseRelaxMaker):
+    """Test backwards compatibility with direct `calculator` definition."""
 
-    def _get_calculator(self):
+    name: str = "EMT legacy relax maker"
+
+    @property
+    def calculator(self):
         return EMT()
 
 
@@ -60,7 +63,7 @@ def test_filters_and_kwargs(test_dir, constant_vol):
     structure = Structure.from_file(test_dir / "structures" / "Al2Au.cif")
     structure = structure.scale_lattice(1.1 * structure.volume)
 
-    job = EMTRelaxMaker(
+    job = LegacyEMTRelaxMaker(
         relax_kwargs={"filter_kwargs": {"constant_volume": constant_vol}}
     ).make(structure)
     resp = run_locally(job)

--- a/tests/ase/test_jobs.py
+++ b/tests/ase/test_jobs.py
@@ -89,6 +89,27 @@ def test_lennard_jones_relax_maker(lj_fcc_ne_pars, fcc_ne_structure):
     )
 
 
+def test_lennard_jones_batch_relax_maker(
+    lj_fcc_ne_pars, fcc_ne_structure, memory_jobstore
+):
+    job = LennardJonesRelaxMaker(
+        calculator_kwargs=lj_fcc_ne_pars, relax_kwargs={"fmax": 0.001}
+    ).make([fcc_ne_structure, fcc_ne_structure])
+
+    response = run_locally(job, store=memory_jobstore)
+
+    output = response[job.uuid][1].output
+
+    assert [calc.output.structure.volume for calc in output] == pytest.approx(
+        [22.304245, 22.304245]
+    )
+    assert [calc.output.energy for calc in output] == pytest.approx(
+        [-0.018494767, -0.018494767]
+    )
+    assert all(isinstance(calc, AseStructureTaskDoc) for calc in output)
+    assert fcc_ne_structure.matches(output[0].output.structure)
+
+
 def test_lennard_jones_static_maker(lj_fcc_ne_pars, fcc_ne_structure):
     job = LennardJonesStaticMaker(calculator_kwargs=lj_fcc_ne_pars).make(
         fcc_ne_structure

--- a/tests/ase/test_neb.py
+++ b/tests/ase/test_neb.py
@@ -47,8 +47,7 @@ class EmtNebFromEndpointsMaker(AseNebFromEndpointsMaker):
         default_factory=EmtRelaxMaker,
     )
 
-    @property
-    def calculator(self):
+    def _get_calculator(self):
         return EMT(**self.calculator_kwargs)
 
 

--- a/tests/forcefields/flows/test_eos.py
+++ b/tests/forcefields/flows/test_eos.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import pytest
 from jobflow import run_locally
 from monty.serialization import loadfn
@@ -10,9 +12,14 @@ from ..conftest import mlff_is_installed  # noqa: TID252
 
 
 @pytest.mark.parametrize(
-    "mlff", [mlff for mlff in ["CHGNet", "MACE"] if mlff_is_installed(mlff)]
+    "mlff,batch_mode",
+    product(
+        [mlff for mlff in ["CHGNet", "MACE"] if mlff_is_installed(mlff)], [True, False]
+    ),
 )
-def test_ml_ff_eos_makers(mlff: str, si_structure, clean_dir, test_dir):
+def test_ml_ff_eos_makers(
+    mlff: str, batch_mode: bool, si_structure, clean_dir, test_dir
+):
 
     calculator_kwargs = {}
     if mlff == "CHGNet":
@@ -21,7 +28,9 @@ def test_ml_ff_eos_makers(mlff: str, si_structure, clean_dir, test_dir):
         calculator_kwargs = {"model": "medium-0b3"}
 
     maker = ForceFieldEosMaker.from_force_field_name(
-        mlff, calculator_kwargs=calculator_kwargs
+        mlff,
+        calculator_kwargs=calculator_kwargs,
+        socket=batch_mode,
     )
 
     # Note that some calculator_kwargs, like stress_unit, are set by `ase_calculator`

--- a/tests/forcefields/flows/test_eos.py
+++ b/tests/forcefields/flows/test_eos.py
@@ -25,7 +25,7 @@ def test_ml_ff_eos_makers(
     if mlff == "CHGNet":
         calculator_kwargs = {"path": "CHGNet-MatPES-PBE-2025.2.10-2.7M-PES"}
     elif mlff == "MACE":
-        calculator_kwargs = {"model": "medium-0b3"}
+        calculator_kwargs = {"model": "medium-0b3", "default_dtype": "float32"}
 
     maker = ForceFieldEosMaker.from_force_field_name(
         mlff,

--- a/tests/forcefields/flows/test_phonon.py
+++ b/tests/forcefields/flows/test_phonon.py
@@ -1,5 +1,6 @@
 import os
 from importlib.util import find_spec
+from itertools import product
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -109,10 +110,12 @@ def test_phonon_maker_initialization_with_all_mlff(
         ) from exc
 
 
-@pytest.mark.skipif(not mlff_is_installed("CHGNet"), reason="matgl is not installed")
-@pytest.mark.parametrize("from_name", [False, True])
+@pytest.mark.skipif(
+    not mlff_is_installed("CHGNet"), reason="matgl/chgnet is not installed"
+)
+@pytest.mark.parametrize("from_name, socket", list(product(*[[True, False]] * 2)))
 def test_phonon_wf_force_field(
-    clean_dir, si_structure: Structure, tmp_path: Path, from_name: bool
+    clean_dir, si_structure: Structure, tmp_path: Path, from_name: bool, socket: bool
 ):
     # TODO brittle due to inability to adjust dtypes in CHGNetRelaxMaker
 
@@ -148,6 +151,7 @@ def test_phonon_wf_force_field(
             "filename_bs": (filename_bs := f"{tmp_path}/phonon_bs_test.png"),
             "filename_dos": (filename_dos := f"{tmp_path}/phonon_dos_test.pdf"),
         },
+        socket=socket,
     )
 
     if from_name:

--- a/tests/forcefields/test_jobs.py
+++ b/tests/forcefields/test_jobs.py
@@ -171,6 +171,36 @@ def test_chgnet_relax_maker(
     assert Path(responses[job.uuid][1].output.dir_name).exists()
 
 
+@pytest.mark.skipif(
+    not mlff_is_installed("CHGNet"),
+    reason="Required packages (chgnet or matgl/dgl) are not installed",
+)
+def test_chgnet_batch_static_maker(si_structure: Structure, memory_jobstore):
+    # translate one atom to ensure a small number of relaxation steps are taken
+    si_structure2 = si_structure.copy()
+    si_structure.translate_sites(0, [0, 0, 0.1])
+    si_structure2.translate_sites(0, [0.1, 0, 0.1])
+
+    # generate job
+    job = ForceFieldStaticMaker(
+        force_field_name="CHGNet",
+    ).make([si_structure, si_structure2])
+
+    # run the flow or job and ensure that it finished running successfully
+    responses = run_locally(job, ensure_success=True, store=memory_jobstore)
+    # validate job outputs
+    output = responses[job.uuid][1].output
+    assert all(isinstance(calc, ForceFieldTaskDocument) for calc in output)
+
+    assert len(output) == 2
+    assert [calc.output.energy for calc in output] == approx(
+        [-9.96250, -9.4781], rel=1e-2
+    )
+
+    # check the force_field_task_doc attributes
+    assert all(Path(calc.dir_name).exists() for calc in output)
+
+
 @pytest.mark.xfail(
     reason="M3GNet tests not working consistently in CI vs local",
     strict=False,


### PR DESCRIPTION
Possibly supersedes [#1196](https://github.com/materialsproject/atomate2/pull/1196). Tagging @naik-aakash and @JaGeo for thoughts.

The goal here is to make smaller structural changes overall to the jobs/workflows and ensure that each calculation maps to one output document

Changes:
- Allow for submission of a list of pymatgen Molecule or Structure to `AseRelaxMaker` and thus `ForceFieldRelaxMaker` / `ForceFieldStaticMaker`
- When submitting a list, a list of `TaskDocument`s are returned
- Cache ASE calculator once loaded to permit batch mode