### PR TITLE
Update reading output files in FHI-aims SocketIO workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ abinit = [
     "abipy>=0.9.3",
     "netCDF4<1.7.5", # TODO: latest NetCDF missing 3.12 support: https://github.com/Unidata/netcdf4-python/issues/1461
 ]
-aims = ["pymatgen-io-aims>=0.0.5", "pymatgen>=2025.10.7","pyfhiaims<0.1.0"]
+aims = ["pymatgen-io-aims>=0.0.5", "pymatgen>=2025.10.7"]
 amset = ["amset>=0.4.15", "pydash"]
 cclib = ["cclib>=1.8.1"]
 mp = ["mp-api>=0.37.5"]

--- a/src/atomate2/aims/jobs/core.py
+++ b/src/atomate2/aims/jobs/core.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/src/atomate2/aims/jobs/core.py
+++ b/src/atomate2/aims/jobs/core.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from jobflow import Response, job
 from monty.serialization import dumpfn
-from pyfhiaims.external_interfaces.ase.io import read_aims_output
+from pymatgen.io.aims.outputs import AimsOutput
 from pymatgen.io.aims.sets.bs import BandStructureSetGenerator, GWSetGenerator
 from pymatgen.io.aims.sets.core import (
     RelaxSetGenerator,
@@ -140,12 +140,8 @@ class SocketIOStaticMaker(BaseAimsMaker):
         from_prev = prev_dir is not None
         if from_prev:
             hostless_prev_dir = str(prev_dir).split(":")[1]
-            images = read_aims_output(f"{hostless_prev_dir}/aims.out")
-            if not isinstance(images, Sequence):
-                images = [images]
-
-            for img in images:
-                img.calc = None
+            output = AimsOutput.from_outfile(f"{hostless_prev_dir}/aims.out")
+            images = [output.get_results_for_image(ii) for ii in range(output.n_images)]
 
             for ii in range(-1 * len(structure), 0, -1):
                 if structure[ii] in images:

--- a/src/atomate2/aims/run.py
+++ b/src/atomate2/aims/run.py
@@ -9,7 +9,7 @@ import subprocess
 from os.path import expandvars
 from typing import TYPE_CHECKING
 
-from ase.calculators.aims import Aims
+from ase.calculators.aims import Aims, AimsProfile
 from ase.calculators.socketio import SocketIOCalculator
 from monty.json import MontyDecoder
 from pymatgen.io.ase import AseAtomsAdaptor
@@ -112,9 +112,13 @@ def run_aims_socket(
         parameters.pop(key)
 
     if aims_cmd:
-        parameters["command"] = aims_cmd
-    elif "command" not in parameters:
-        parameters["command"] = SETTINGS.AIMS_CMD
+        command = aims_cmd
+    elif "command" in parameters:
+        command = parameters["command"]
+    else:
+        command = SETTINGS.AIMS_CMD
+
+    parameters["profile"] = AimsProfile(command=command)
 
     calculator = Aims(**parameters)
     port = parameters["use_pimd_wrapper"][1]

--- a/tests/aims/test_flows/test_phonon_workflow.py
+++ b/tests/aims/test_flows/test_phonon_workflow.py
@@ -187,9 +187,9 @@ def test_phonon_socket_flow(si, clean_dir, mock_aims, species_dir):
 
     assert output.temperatures == list(range(0, 500, 10))
     assert output.heat_capacities[0] == 0.0
-    assert np.round(output.heat_capacities[-1], 2) == 23.06
+    assert np.round(output.heat_capacities[-1], 2) == 22.9
     assert output.phonopy_settings.schema_json() == json.dumps(phonopy_settings_schema)
-    assert np.round(output.phonon_bandstructure.bands[-1, 0], 2) == 14.41
+    assert np.round(output.phonon_bandstructure.bands[-1, 0], 2) == 15.48
 
 
 def test_phonon_default_flow(si, clean_dir, mock_aims, species_dir):
@@ -225,80 +225,6 @@ def test_phonon_default_flow(si, clean_dir, mock_aims, species_dir):
 
     # validation the outputs of the job
     output = responses[flow.job_uuids[-1]][1].output
-    phonopy_settings_schema = {
-        "description": "Collection to store computational settings for "
-        "the phonon computation.",
-        "properties": {
-            "npoints_band": {
-                "default": "number of points for band structure computation",
-                "title": "Npoints Band",
-                "type": "integer",
-            },
-            "kpath_scheme": {
-                "default": "indicates the kpath scheme",
-                "title": "Kpath Scheme",
-                "type": "string",
-            },
-            "kpoint_density_dos": {
-                "default": "number of points for computation of free energies "
-                "and densities of states",
-                "title": "Kpoint Density Dos",
-                "type": "integer",
-            },
-        },
-        "title": "PhononComputationalSettings",
-        "type": "object",
-    }
-    assert output.code == "aims"
-    assert output.born is None
-    assert not output.has_imaginary_modes
-
-    assert output.temperatures == list(range(0, 500, 10))
-    assert output.heat_capacities[0] == 0.0
-    assert np.round(output.heat_capacities[-1], 2) == 22.85
-    assert output.phonopy_settings.schema_json() == json.dumps(phonopy_settings_schema)
-    assert np.round(output.phonon_bandstructure.bands[-1, 0], 2) == 15.02
-
-    if aims_sd is not None:
-        SETTINGS["AIMS_SPECIES_DIR"] = aims_sd
-
-
-@pytest.mark.skip(reason="Currently not mocked and needs FHI-aims binary")
-def test_phonon_default_socket_flow(si, clean_dir, mock_aims, species_dir):
-    import numpy as np
-    from jobflow import run_locally
-    from pymatgen.core import SETTINGS
-
-    from atomate2.aims.flows.phonons import PhononMaker
-
-    aims_sd = SETTINGS.get("AIMS_SPECIES_DIR")
-    SETTINGS["AIMS_SPECIES_DIR"] = str(species_dir / "light")
-
-    # mapping from job name to directory containing test files
-    ref_paths = {
-        "Relaxation calculation": "phonon-relax-default-si",
-        "phonon static aims 1/1": "phonon-disp-default-si",
-        "SCF Calculation": "phonon-energy-default-si",
-    }
-
-    # settings passed to fake_run_aims
-    fake_run_aims_kwargs = {}
-
-    # automatically use fake FHI-aims
-    mock_aims(ref_paths, fake_run_aims_kwargs)
-
-    # generate job
-
-    maker = PhononMaker(socket=True)
-    maker.name = "phonons"
-    flow = maker.make(si, supercell_matrix=np.ones((3, 3)) - 2 * np.eye(3))
-
-    # run the flow or job and ensure that it finished running successfully
-    responses = run_locally(flow, create_folders=True, ensure_success=True)
-
-    # validation the outputs of the job
-    output = responses[flow.job_uuids[-1]][1].output
-
     phonopy_settings_schema = {
         "description": "Collection to store computational settings for "
         "the phonon computation.",

--- a/tests/aims/test_makers/test_socket_calc.py
+++ b/tests/aims/test_makers/test_socket_calc.py
@@ -1,12 +1,13 @@
 import os
 
 import pytest
+from pymatgen.core import Lattice
 
 cwd = os.getcwd()
 
 
 @pytest.mark.skip(reason="Currently not mocked and needs FHI-aims binary")
-def test_static_socket_maker(si, species_dir, mock_aims, tmp_path):
+def test_static_socket_maker(si, species_dir, tmp_path):
     from jobflow import run_locally
     from pymatgen.io.aims.sets.core import SocketIOSetGenerator
 
@@ -15,17 +16,8 @@ def test_static_socket_maker(si, species_dir, mock_aims, tmp_path):
 
     atoms = si
     atoms_list = [atoms, atoms.copy(), atoms.copy()]
-    atoms_list[1].positions[0, 0] += 0.02
-    atoms_list[2].cell[:, :] *= 1.02
-
-    # mapping from job name to directory containing test files
-    ref_paths = {"socket": "socket_tests"}
-
-    # settings passed to fake_run_aims; adjust these to check for certain input settings
-    fake_run_aims_kwargs = {}
-
-    # automatically use fake FHI-aims
-    mock_aims(ref_paths, fake_run_aims_kwargs)
+    atoms_list[1].cart_coords[0, 0] += 0.02
+    atoms_list[2].lattice = Lattice(atoms_list[2].lattice.matrix * 1.02)
 
     parameters = {
         "k_grid": [2, 2, 2],
@@ -47,13 +39,13 @@ def test_static_socket_maker(si, species_dir, mock_aims, tmp_path):
     outputs = responses[job.uuid][1].output
     assert isinstance(outputs, AimsTaskDoc)
     assert len(outputs.output.trajectory) == 3
-    assert outputs.output.trajectory[0].get_potential_energy() == pytest.approx(
+    assert outputs.output.trajectory[0].properties["energy"] == pytest.approx(
         -15800.0997410132
     )
-    assert outputs.output.trajectory[1].get_potential_energy() == pytest.approx(
+    assert outputs.output.trajectory[1].properties["energy"] == pytest.approx(
         -15800.0962356206
     )
-    assert outputs.output.trajectory[2].get_potential_energy() == pytest.approx(
-        -15800.1847237514
+    assert outputs.output.trajectory[2].properties["energy"] == pytest.approx(
+        -15800.2028334278
     )
     # assert output1.output.energy == pytest.approx(-15800.099740991)


### PR DESCRIPTION
## Summary

This PR updates how atomate2 reads FHI-aims output files for SocketIO calculation flows to be compatible with pyfhiaims ≥ 1.0.

In version 1.0, pyfhiaims.external_interfaces was removed in favor of plugin-based integrations with packages like ASE and pymatgen. Previously, atomate2 used pymatgen.io.aims.outputs.AimsOutput in most cases, but relied on ASE via the pyfhiaims external interface for SocketIO workflows.

This PR removes that inconsistency by switching SocketIO output parsing to also use pymatgen.io.aims.outputs.AimsOutput, aligning it with the rest of the codebase.

See PR #1461 for related CI failures caused by the removal of the external interface.

@tpurcell90, can you check if all is good here? 

* Fix using ASE external interface for SocketIO in favor of `pymatgen.io.aims` 

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [x] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
