### PR TITLE
Fixed calculation of mu from input potential

### DIFF
--- a/src/atomate2/jdftx/sets/base.py
+++ b/src/atomate2/jdftx/sets/base.py
@@ -238,7 +238,7 @@ class JdftxInputGenerator(InputGenerator):
         solvent_model = self.settings["pcm-variant"]
         ashep = self.config_dict["ASHEP"][solvent_model]
         # calculate absolute potential in Hartree
-        mu = -(ashep - self.potential) / eV_to_Ha
+        mu = -(-ashep + self.potential) * eV_to_Ha
         self.settings["target-mu"] = {"mu": mu}
         return
 


### PR DESCRIPTION
## Summary

* The old equation to calculate the mu input to set as "target-mu" in input file from the user potential (given in V) was incorrect. Fixed it according to the JDFTx documentation. 
Link to the docs: [https://jdftx.org/CommandTargetMu.html]
