### PR TITLE
Hard-coded paths to deal with MatGL removals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ strict-forcefields-torch-limited = [
     # Mac / Windows users will need to install from source
     "dgl==2.2.0; sys_platform == 'darwin' or sys_platform == 'win32'",
     "dgl<=2.4.0; sys_platform == 'linux'",
-    "torch==2.11.0; sys_platform == 'darwin' or sys_platform == 'win32'",
+    "torch==2.2.0; sys_platform == 'darwin' or sys_platform == 'win32'",
     "torch==2.2.0; sys_platform == 'linux'",
     "torchdata==0.7.1",
     "nequip==0.17.1", # requires numpy<2 because of matscipy

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -378,7 +378,9 @@ def ase_calculator(
                 # matgl has removed many of the old models,
                 # need to hard code paths to previous models
                 if "path" not in kwargs:
-                    matgl.config.PRETRAINED_MODELS_BASE_URL = "https://github.com/materialyzeai/matgl/raw/v2.1.1/pretrained_models"
+                    base_matgl_url = "https://github.com/materialyzeai/matgl/raw/v2.1.1/pretrained_models/"
+                    matgl.config.PRETRAINED_MODELS_BASE_URL = base_matgl_url
+                    matgl.utils.io.PRETRAINED_MODELS_BASE_URL = base_matgl_url
 
                 calculator = matgl_calc(matgl.load_model(path), **kwargs)
 

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -340,14 +340,24 @@ def ase_calculator(
                     except ImportError:
                         pass
 
+                from urllib.parse import urljoin
+
                 import matgl
 
+                # matgl has removed many of the old models,
+                # need to hard code paths to previous models
+                base_matgl_path = "https://github.com/materialyzeai/matgl/tree/v2.1.1/pretrained_models"
                 match calculator_name:
                     case MLFF.M3GNet:
-                        path = "https://github.com/materialyzeai/matgl/tree/v2.2.1/pretrained_models/M3GNet-MP-2021.2.8-PES"
+                        path = kwargs.get(
+                            "path", urljoin(base_matgl_path, "M3GNet-MP-2021.2.8-PES")
+                        )
                         matgl.config.BACKEND = "DGL"
                     case MLFF.CHGNet:
-                        path = kwargs.get("path", "CHGNet-MPtrj-2023.12.1-2.7M-PES")
+                        path = kwargs.get(
+                            "path",
+                            urljoin(base_matgl_path, "CHGNet-MPtrj-2023.12.1-2.7M-PES"),
+                        )
                         matgl.config.BACKEND = "DGL"
 
                         warnings.warn(
@@ -358,11 +368,12 @@ def ase_calculator(
                             stacklevel=2,
                         )
                     case MLFF.MATPES_R2SCAN | MLFF.MATPES_PBE:
-                        path = (
+                        path = urljoin(
+                            base_matgl_path,
                             f"{kwargs.pop('architecture', 'TensorNet')}"
                             f"-{calculator_name.value}"
                             f"-v{kwargs.pop('version', '2025.1')}"
-                            "-PES"
+                            "-PES",
                         )
                         matgl.config.BACKEND = "PYG"
 

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -365,7 +365,7 @@ def ase_calculator(
                             f"{kwargs.pop('architecture', 'TensorNet')}"
                             f"-{calculator_name.value}"
                             f"-v{kwargs.pop('version', '2025.1')}"
-                            "-PES",
+                            "-PES"
                         )
                         matgl.config.BACKEND = "PYG"
 

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -342,9 +342,6 @@ def ase_calculator(
 
                 import matgl
 
-                # matgl has removed many of the old models,
-                # need to hard code paths to previous models
-                matgl.config.PRETRAINED_MODELS_BASE_URL = "https://github.com/materialyzeai/matgl/raw/v2.1.1/pretrained_models"
                 match calculator_name:
                     case MLFF.M3GNet:
                         path = kwargs.get("path", "M3GNet-MP-2021.2.8-PES")
@@ -377,6 +374,12 @@ def ase_calculator(
                     "PESCalculator",
                     None,
                 )
+
+                # matgl has removed many of the old models,
+                # need to hard code paths to previous models
+                if "path" not in kwargs:
+                    matgl.config.PRETRAINED_MODELS_BASE_URL = "https://github.com/materialyzeai/matgl/raw/v2.1.1/pretrained_models"
+
                 calculator = matgl_calc(matgl.load_model(path), **kwargs)
 
             case MLFF.MACE | MLFF.MACE_MP_0 | MLFF.MACE_MPA_0 | MLFF.MACE_MP_0B3:

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -344,7 +344,7 @@ def ase_calculator(
 
                 # matgl has removed many of the old models,
                 # need to hard code paths to previous models
-                base_matgl_path = r"https://github.com/materialyzeai/matgl/tree/v2.1.1/pretrained_models"
+                base_matgl_path = r"https://github.com/materialyzeai/matgl/raw/v2.1.1/pretrained_models"
                 match calculator_name:
                     case MLFF.M3GNet:
                         path = kwargs.get(

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -346,7 +346,7 @@ def ase_calculator(
 
                 # matgl has removed many of the old models,
                 # need to hard code paths to previous models
-                base_matgl_path = "https://github.com/materialyzeai/matgl/tree/v2.1.1/pretrained_models"
+                base_matgl_path = r"https://github.com/materialyzeai/matgl/tree/v2.1.1/pretrained_models"
                 match calculator_name:
                     case MLFF.M3GNet:
                         path = kwargs.get(

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -344,7 +344,7 @@ def ase_calculator(
 
                 match calculator_name:
                     case MLFF.M3GNet:
-                        path = kwargs.get("path", "M3GNet-MP-2021.2.8-PES")
+                        path = "https://github.com/materialyzeai/matgl/tree/v2.2.1/pretrained_models/M3GNet-MP-2021.2.8-PES"
                         matgl.config.BACKEND = "DGL"
                     case MLFF.CHGNet:
                         path = kwargs.get("path", "CHGNet-MPtrj-2023.12.1-2.7M-PES")

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -344,18 +344,13 @@ def ase_calculator(
 
                 # matgl has removed many of the old models,
                 # need to hard code paths to previous models
-                base_matgl_path = r"https://github.com/materialyzeai/matgl/raw/v2.1.1/pretrained_models"
+                matgl.config.PRETRAINED_MODELS_BASE_URL = "https://github.com/materialyzeai/matgl/raw/v2.1.1/pretrained_models"
                 match calculator_name:
                     case MLFF.M3GNet:
-                        path = kwargs.get(
-                            "path", f"{base_matgl_path}/M3GNet-MP-2021.2.8-PES"
-                        )
+                        path = kwargs.get("path", "M3GNet-MP-2021.2.8-PES")
                         matgl.config.BACKEND = "DGL"
                     case MLFF.CHGNet:
-                        path = kwargs.get(
-                            "path",
-                            f"{base_matgl_path}/CHGNet-MPtrj-2023.12.1-2.7M-PES",
-                        )
+                        path = kwargs.get("path", "CHGNet-MPtrj-2023.12.1-2.7M-PES")
                         matgl.config.BACKEND = "DGL"
 
                         warnings.warn(
@@ -367,7 +362,6 @@ def ase_calculator(
                         )
                     case MLFF.MATPES_R2SCAN | MLFF.MATPES_PBE:
                         path = (
-                            f"{base_matgl_path}/",
                             f"{kwargs.pop('architecture', 'TensorNet')}"
                             f"-{calculator_name.value}"
                             f"-v{kwargs.pop('version', '2025.1')}"

--- a/src/atomate2/forcefields/utils.py
+++ b/src/atomate2/forcefields/utils.py
@@ -340,8 +340,6 @@ def ase_calculator(
                     except ImportError:
                         pass
 
-                from urllib.parse import urljoin
-
                 import matgl
 
                 # matgl has removed many of the old models,
@@ -350,13 +348,13 @@ def ase_calculator(
                 match calculator_name:
                     case MLFF.M3GNet:
                         path = kwargs.get(
-                            "path", urljoin(base_matgl_path, "M3GNet-MP-2021.2.8-PES")
+                            "path", f"{base_matgl_path}/M3GNet-MP-2021.2.8-PES"
                         )
                         matgl.config.BACKEND = "DGL"
                     case MLFF.CHGNet:
                         path = kwargs.get(
                             "path",
-                            urljoin(base_matgl_path, "CHGNet-MPtrj-2023.12.1-2.7M-PES"),
+                            f"{base_matgl_path}/CHGNet-MPtrj-2023.12.1-2.7M-PES",
                         )
                         matgl.config.BACKEND = "DGL"
 
@@ -368,8 +366,8 @@ def ase_calculator(
                             stacklevel=2,
                         )
                     case MLFF.MATPES_R2SCAN | MLFF.MATPES_PBE:
-                        path = urljoin(
-                            base_matgl_path,
+                        path = (
+                            f"{base_matgl_path}/",
                             f"{kwargs.pop('architecture', 'TensorNet')}"
                             f"-{calculator_name.value}"
                             f"-v{kwargs.pop('version', '2025.1')}"


### PR DESCRIPTION
MatGL has removed M3GNet and other [legacy models](https://github.com/materialyzeai/matgl/tree/main/pretrained_models) from their github, which has been leading to CI failures

Until we can decide if we drop support for these older potentials, hard coding their model paths to older git versions (brittle!) to ensure continuous user support