### PR TITLE
Update torchsim model picker

### DIFF
--- a/src/atomate2/torchsim/core.py
+++ b/src/atomate2/torchsim/core.py
@@ -341,9 +341,14 @@ def pick_model(
             return MaceModel(model=model_path, **model_kwargs)
 
         case TorchSimModelType.MATTERSIM:
+            from mattersim.forcefield.potential import Potential
             from torch_sim.models.mattersim import MatterSimModel
 
-            return MatterSimModel(model=model_path, **model_kwargs)
+            model_instance = Potential.from_checkpoint(
+                load_path=model_path,
+                load_training_state=False,
+            )
+            return MatterSimModel(model=model_instance, **model_kwargs)
 
         case TorchSimModelType.METATOMIC:
             from torch_sim.models.metatomic import MetatomicModel
@@ -353,12 +358,25 @@ def pick_model(
         case TorchSimModelType.NEQUIPFRAMEWORK:
             from torch_sim.models.nequip_framework import NequIPFrameworkModel
 
-            return NequIPFrameworkModel(model=model_path, **model_kwargs)
+            return NequIPFrameworkModel.from_compiled_model(
+                model=model_path, **model_kwargs
+            )
 
         case TorchSimModelType.ORB:
+            from orb_models.forcefield.pretrained import ORB_PRETRAINED_MODELS
             from torch_sim.models.orb import OrbModel
 
-            return OrbModel(model=model_path, **model_kwargs)
+            model_fn = ORB_PRETRAINED_MODELS.get(str(model_path))
+            if model_fn is None:
+                raise ValueError(
+                    f"Invalid ORB model name: {model_path}. "
+                    f"Available ORB models: {list(ORB_PRETRAINED_MODELS.keys())}"
+                )
+
+            model_instance, atoms_adapter = model_fn()
+            return OrbModel(
+                model=model_instance, atoms_adapter=atoms_adapter, **model_kwargs
+            )
 
         case TorchSimModelType.SEVENNET:
             from torch_sim.models.sevennet import SevenNetModel

--- a/src/atomate2/torchsim/core.py
+++ b/src/atomate2/torchsim/core.py
@@ -320,20 +320,10 @@ def pick_model(
         If an invalid model type is provided.
     """
     match model_type:
-        case TorchSimModelType.FAIRCHEMV1:
-            from torch_sim.models.fairchem_legacy import FairChemV1Model
-
-            return FairChemV1Model(model=model_path, **model_kwargs)
-
         case TorchSimModelType.FAIRCHEM:
             from torch_sim.models.fairchem import FairChemModel
 
             return FairChemModel(model=model_path, **model_kwargs)
-
-        case TorchSimModelType.GRAPHPESWRAPPER:
-            from torch_sim.models.graphpes import GraphPESWrapper
-
-            return GraphPESWrapper(model=model_path, **model_kwargs)
 
         case TorchSimModelType.MACE:
             from torch_sim.models.mace import MaceModel

--- a/src/atomate2/torchsim/core.py
+++ b/src/atomate2/torchsim/core.py
@@ -323,33 +323,28 @@ def pick_model(
         case TorchSimModelType.FAIRCHEM:
             from torch_sim.models.fairchem import FairChemModel
 
-            return FairChemModel(model=model_path, **model_kwargs)
+            base_model = FairChemModel(model=model_path, **model_kwargs)
 
         case TorchSimModelType.MACE:
             from torch_sim.models.mace import MaceModel
 
-            return MaceModel(model=model_path, **model_kwargs)
+            base_model = MaceModel(model=model_path, **model_kwargs)
 
         case TorchSimModelType.MATTERSIM:
-            from mattersim.forcefield.potential import Potential
             from torch_sim.models.mattersim import MatterSimModel
 
-            model_instance = Potential.from_checkpoint(
-                load_path=model_path,
-                load_training_state=False,
-            )
-            return MatterSimModel(model=model_instance, **model_kwargs)
+            base_model = MatterSimModel(model=model_path, **model_kwargs)
 
         case TorchSimModelType.METATOMIC:
             from torch_sim.models.metatomic import MetatomicModel
 
-            return MetatomicModel(model=model_path, **model_kwargs)
+            base_model = MetatomicModel(model=model_path, **model_kwargs)
 
         case TorchSimModelType.NEQUIPFRAMEWORK:
             from torch_sim.models.nequip_framework import NequIPFrameworkModel
 
-            return NequIPFrameworkModel.from_compiled_model(
-                model=model_path, **model_kwargs
+            base_model = NequIPFrameworkModel.from_compiled_model(
+                compile_path=model_path, **model_kwargs
             )
 
         case TorchSimModelType.ORB:
@@ -364,22 +359,24 @@ def pick_model(
                 )
 
             model_instance, atoms_adapter = model_fn()
-            return OrbModel(
+            base_model = OrbModel(
                 model=model_instance, atoms_adapter=atoms_adapter, **model_kwargs
             )
 
         case TorchSimModelType.SEVENNET:
             from torch_sim.models.sevennet import SevenNetModel
 
-            return SevenNetModel(model=model_path, **model_kwargs)
+            base_model = SevenNetModel(model=model_path, **model_kwargs)
 
         case TorchSimModelType.LENNARD_JONES:
             from torch_sim.models.lennard_jones import LennardJonesModel
 
-            return LennardJonesModel(**model_kwargs)
+            base_model = LennardJonesModel(**model_kwargs)
 
         case _:
             raise ValueError(f"Invalid model type: {model_type}")
+
+    return base_model
 
 
 @dataclass

--- a/src/atomate2/torchsim/schema.py
+++ b/src/atomate2/torchsim/schema.py
@@ -20,9 +20,7 @@ if TYPE_CHECKING:
 class TorchSimModelType(StrEnum):  # type: ignore[attr-defined]
     """Enum for model types."""
 
-    FAIRCHEMV1 = "FairChemV1Model"
     FAIRCHEM = "FairChemModel"
-    GRAPHPESWRAPPER = "GraphPESWrapper"
     MACE = "MaceModel"
     MATTERSIM = "MatterSimModel"
     METATOMIC = "MetatomicModel"

--- a/tests/torchsim/test_models.py
+++ b/tests/torchsim/test_models.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import importlib.metadata
+from pathlib import Path
+
+import pytest
+
+from atomate2.torchsim.core import pick_model
+from atomate2.torchsim.schema import TorchSimModelType
+
+try:
+    from huggingface_hub.utils._auth import get_token
+
+    HAS_HF = True
+except ImportError:
+    HAS_HF = False
+
+
+def _is_backend_missing(package_names: str | list[str]) -> bool:
+    if isinstance(package_names, str):
+        package_names = [package_names]
+
+    missing = False
+    try:
+        for pkg_name in package_names:
+            importlib.metadata.distribution(pkg_name)
+    except importlib.metadata.PackageNotFoundError:
+        missing = True
+
+    return missing
+
+
+_SKIP_FAIRCHEM = _is_backend_missing("fairchem-core")
+_SKIP_MACE = _is_backend_missing("mace-torch")
+_SKIP_MATTERSIM = _is_backend_missing("mattersim")
+_SKIP_METATOMIC = _is_backend_missing(["metatomic_torchsim", "upet"])
+_SKIP_NEQUIP = _is_backend_missing("nequip")
+_SKIP_ORB = _is_backend_missing("orb_models")
+_SKIP_SEVENNET = _is_backend_missing("sevenn")
+
+
+@pytest.mark.skipif(
+    not HAS_HF or get_token() is None,
+    reason="Hugging Face is not installed or token is not available.",
+)
+@pytest.mark.skipif(_SKIP_FAIRCHEM, reason="FAIRCHEM is not installed.")
+def test_pick_model_fairchem() -> None:
+    pick_model(TorchSimModelType.FAIRCHEM, model_path="uma-s-1p1")
+
+
+@pytest.mark.skipif(_SKIP_MACE, reason="MACE is not installed.")
+def test_pick_model_mace() -> None:
+    from mace.calculators.foundations_models import download_mace_mp_checkpoint
+
+    path = download_mace_mp_checkpoint("small")
+    pick_model(TorchSimModelType.MACE, model_path=path)
+
+
+@pytest.mark.skipif(_SKIP_MATTERSIM, reason="MATTERSIM is not installed.")
+def test_pick_model_mattersim() -> None:
+    pick_model(TorchSimModelType.MATTERSIM, model_path="mattersim-v1.0.0-1m.pth")
+
+
+# Upstreamed in torchsim v0.6.0
+@pytest.mark.skipif(_SKIP_METATOMIC, reason="METATOMIC or UPET is not installed.")
+def test_pick_model_metatomic() -> None:
+    from upet import get_upet
+
+    # get_upet returns an instance of AtomisticModel and not a path
+    # which will break the type checker but is actually supported by
+    # MetatomicModel so its good enough for testing
+    model = get_upet(model="pet-mad", size="s")
+    pick_model(TorchSimModelType.METATOMIC, model_path=model)
+
+
+# Upstreamed in torchsim v0.5.1
+@pytest.mark.skipif(_SKIP_NEQUIP, reason="NEQUIP is not installed.")
+def test_pick_model_nequip() -> None:
+    path = (
+        Path(__file__).parent.parent
+        / "test_data"
+        / "forcefields"
+        / "nequip"
+        / "nequip_ff_sr_ti_o3.nequip.pth"
+    )
+    pick_model(TorchSimModelType.NEQUIPFRAMEWORK, model_path=path)
+
+
+# Upstreamed in torchsim 0.6.0
+@pytest.mark.skipif(_SKIP_ORB, reason="ORB is not installed.")
+def test_pick_model_orb() -> None:
+    pick_model(TorchSimModelType.ORB, model_path="orb-v2")
+
+
+# Upstreamed in torchsim 0.6.0
+@pytest.mark.skipif(_SKIP_SEVENNET, reason="SEVENN is not installed.")
+def test_pick_model_sevennet() -> None:
+    pick_model(TorchSimModelType.SEVENNET, model_path="7net-0")

--- a/tests/torchsim/test_models.py
+++ b/tests/torchsim/test_models.py
@@ -1,9 +1,14 @@
+"""Tests for TorchSim models APIs."""
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 import importlib.metadata
 from pathlib import Path
 
 import pytest
+
+ts = pytest.importorskip("torch_sim")
 
 from atomate2.torchsim.core import pick_model
 from atomate2.torchsim.schema import TorchSimModelType


### PR DESCRIPTION
## Summary

Include a summary of major changes in bullet points:

* Remove GraphPES and Fairchem V1 models, as they were officially dropped in torchsim v0.6.0
* Building a NequIP model now calls `from_compiled_model`
* Use Orb model name to get both the model and atoms adapter instances required by the new API
* Add tests that try to load each model to ensure API compatibility

## TODO (if any)

Support D3 correction for any TorchSim model. Here, there is at least one question to be answered first. Since TorchSim is not providing a direct way to get D3 parameters from, eg. the functional name, what would you prefer? Passing the D3 parameters in model_kwargs, get the parameters from asset files (such as the one in [simple-dftd3](https://github.com/dftd3/simple-dftd3) and Grimme group website, or something else?

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

* [X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [X] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [X] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [X] Tests have been added for any new functionality or bug fixes.
* [X] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.
