### PR TITLE
Add run_stats calculations and corresponding tests for FHI-aims

### DIFF
--- a/src/atomate2/aims/schemas/calculation.py
+++ b/src/atomate2/aims/schemas/calculation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import warnings
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -85,6 +87,11 @@ class CalculationOutput(BaseModel):
         The valence band maximum in eV (if system is not metallic)
     atomic_steps: list[Structure or Molecule]
         Structures for each ionic step"
+    run_stats (dict[str, float | None]):
+        Various useful run stats including "System time (sec)",
+        "Total CPU time used (sec)", "Minimum memory used (kb)",
+        "Maximum memory used (kb)", "Average memory used (kb)",
+        "cores".
     """
 
     energy: float = Field(
@@ -130,6 +137,9 @@ class CalculationOutput(BaseModel):
     )
     atomic_steps: list[Structure | Molecule] = Field(
         None, description="Structures for each ionic step"
+    )
+    run_stats: dict[str, Any] | None = Field(
+        None, description="Summary of runtime statistics for this calculation"
     )
 
     @classmethod
@@ -345,6 +355,7 @@ class Calculation(BaseModel):
             aims_objects[AimsObject.BANDSTRUCTURE] = bandstructure  # type: ignore  # noqa: PGH003
 
         output_doc = CalculationOutput.from_aims_output(aims_output)
+        output_doc.run_stats = _parse_run_stats(aims_output_file)
 
         has_aims_completed = (
             TaskState.SUCCESS if aims_output.completed else TaskState.FAILED
@@ -388,6 +399,41 @@ def _get_output_file_paths(volumetric_files: list[str]) -> dict[AimsObject, str]
             if aims_object.name in str(volumetric_file):
                 output_file_paths[aims_object] = str(volumetric_file)
     return output_file_paths
+
+
+def _parse_run_stats(aims_output_file: Path | str) -> dict[str, Any]:
+    """Parse timing/memory/core stats from an aims.out file.
+
+    Returns
+    -------
+    dict[str, float | None]
+        "cpu_time" (sec), "wall_time" (sec), "cores",
+        "memory_min_kb", "memory_max_kb", "memory_avg_kb"
+    """
+    text = Path(aims_output_file).read_text()
+    time_match = re.search(r"\| Total time\s*:\s*([\d.]+) s\s*([\d.]+) s", text)
+    cores_match = re.search(r"Using\s*(\d+) parallel tasks\.", text)
+    mem_match = re.search(
+        r"Peak values for overall tracked memory usage:\s*"
+        r"\|\s*Minimum:\s*([\d.]+) MB.*?"
+        r"\|\s*Maximum:\s*([\d.]+) MB.*?"
+        r"\|\s*Average:\s*([\d.]+) MB",
+        text,
+        re.DOTALL,
+    )
+
+    return {
+        "CPU time (sec)": float(time_match[1])
+        if time_match
+        else None,  # max(cpu_time) across tasks
+        "Elapsed time (sec)": float(time_match[2])
+        if time_match
+        else None,  # wall_clock(cpu1)
+        "cores": int(cores_match[1]) if cores_match else None,
+        "Minimum memory used (kb)": float(mem_match[1]) * 1000 if mem_match else None,
+        "Maximum memory used (kb)": float(mem_match[2]) * 1000 if mem_match else None,
+        "Average memory used (kb)": float(mem_match[3]) * 1000 if mem_match else None,
+    }
 
 
 def _get_volumetric_data(
@@ -466,16 +512,24 @@ def _parse_bandstructure(
     ----------
     parse_bandstructure: str or bool
         Whether to parse. Does not support the auto/line distinction currently.
-    aims_ouput: .AimsOutput
+    aims_output: .AimsOutput
         The output object to parse
 
     Returns
     -------
-    The bandstructure
+    The bandstructure, or None if band structure parsing is not yet
+    supported for this AimsOutput.
     """
-    if parse_bandstructure:
-        return aims_output.band_structure
-    return None
+    if not parse_bandstructure:
+        return None
+    if not hasattr(aims_output, "band_structure"):
+        warnings.warn(
+            "Band structure parsing was requested but is not yet implemented "
+            "for AimsOutput; skipping.",
+            stacklevel=2,
+        )
+        return None
+    return aims_output.band_structure
 
 
 def _parse_trajectory(aims_output: AimsOutput) -> Trajectory | None:

--- a/src/atomate2/aims/schemas/calculation.py
+++ b/src/atomate2/aims/schemas/calculation.py
@@ -404,11 +404,18 @@ def _get_output_file_paths(volumetric_files: list[str]) -> dict[AimsObject, str]
 def _parse_run_stats(aims_output_file: Path | str) -> dict[str, Any]:
     """Parse timing/memory/core stats from an aims.out file.
 
+    Parameters
+    ----------
+    aims_output_file: Path or str
+        Path to the main output of aims job, relative to dir_name.
+
     Returns
     -------
-    dict[str, float | None]
-        "cpu_time" (sec), "wall_time" (sec), "cores",
-        "memory_min_kb", "memory_max_kb", "memory_avg_kb"
+    Dict[str, float | None]
+        Dictionary containing the run stats read from the aims.out file.
+        "CPU time (sec)", "Elapsed time (sec)", "cores",
+        "Minimum memory used (kb)", "Maximum memory used (kb)",
+        "Average memory used (kb)"
     """
     text = Path(aims_output_file).read_text()
     time_match = re.search(r"\| Total time\s*:\s*([\d.]+) s\s*([\d.]+) s", text)

--- a/src/atomate2/aims/schemas/task.py
+++ b/src/atomate2/aims/schemas/task.py
@@ -383,6 +383,11 @@ class AimsTaskDoc(BaseTaskDocument, StructureMetadata, MoleculeMetadata):
         Author extracted from transformations
     icsd_id: str
         International crystal structure database id of the structure
+    run_stats (dict[str, float | None]):
+        Various useful run stats including "System time (sec)",
+        "Total CPU time used (sec)", "Minimum memory used (kb)",
+        "Maximum memory used (kb)", "Average memory used (kb)",
+        "cores".
     calcs_reversed: List[.Calculation]
         The inputs and outputs for all FHI-aims runs in this task.
     transformations: Dict[str, Any]
@@ -434,6 +439,9 @@ class AimsTaskDoc(BaseTaskDocument, StructureMetadata, MoleculeMetadata):
     )
     icsd_id: str | None = Field(
         None, description="International crystal structure database id of the structure"
+    )
+    run_stats: dict[str, Any] | None = Field(
+        None, description="Summary of runtime statistics for this calculation"
     )
     calcs_reversed: list[Calculation] | None = Field(
         None, description="The inputs and outputs for all FHI-aims runs in this task."
@@ -522,6 +530,7 @@ class AimsTaskDoc(BaseTaskDocument, StructureMetadata, MoleculeMetadata):
             "tags": tags,
             "completed": calcs_reversed[-1].completed,
             "completed_at": calcs_reversed[-1].completed_at,
+            "run_stats": calcs_reversed[-1].output.run_stats,
             "input": InputDoc.from_aims_calc_doc(calcs_reversed[-1]),
             "output": OutputDoc.from_aims_calc_doc(calcs_reversed[-1]),
             "state": _get_state(calcs_reversed, analysis),

--- a/tests/aims/test_schemas.py
+++ b/tests/aims/test_schemas.py
@@ -1,0 +1,88 @@
+"""Tests for FHI-aims run_stats parsing."""
+
+import gzip
+import shutil
+from pathlib import Path
+
+import pytest
+
+from atomate2.aims.schemas.calculation import _parse_run_stats
+
+TEST_DIR = Path(__file__).parents[1] / "test_data" / "aims"
+
+
+@pytest.fixture
+def relax_si_aims_out(tmp_path) -> Path:
+    """Decompress the completed relax-si aims.out.gz fixture to a plain-text file."""
+    gz_path = TEST_DIR / "relax-si" / "outputs" / "aims.out.gz"
+    out_path = tmp_path / "aims.out"
+    with gzip.open(gz_path, "rt") as f_in, open(out_path, "w") as f_out:
+        shutil.copyfileobj(f_in, f_out)
+    return out_path
+
+
+def test_parse_run_stats_completed_run(relax_si_aims_out):
+    """A completed run should yield fully populated, plausible run_stats."""
+    stats = _parse_run_stats(relax_si_aims_out)
+
+    expected_keys = {
+        "CPU time (sec)",
+        "Elapsed time (sec)",
+        "cores",
+        "Minimum memory used (kb)",
+        "Maximum memory used (kb)",
+        "Average memory used (kb)",
+    }
+    assert set(stats) == expected_keys
+
+    # Timing
+    assert stats["CPU time (sec)"] == 68.393
+    assert stats["Elapsed time (sec)"] == 68.399
+
+    # Cores
+    assert isinstance(stats["cores"], int)
+    assert stats["cores"] == 4
+
+    # Memory: min <= avg <= max, all positive
+    mem_min = stats["Minimum memory used (kb)"]
+    mem_max = stats["Maximum memory used (kb)"]
+    mem_avg = stats["Average memory used (kb)"]
+    assert mem_min == 18526.0
+    assert mem_max == 18888.0
+    assert mem_avg == 18712.0
+    assert mem_min <= mem_avg <= mem_max
+
+
+def test_parse_run_stats_missing_file_data(tmp_path):
+    """A file with none of the expected patterns should degrade to all None."""
+    aims_out = tmp_path / "aims.out"
+    aims_out.write_text("nothing useful here\n")
+
+    stats = _parse_run_stats(aims_out)
+    assert stats == {
+        "CPU time (sec)": None,
+        "Elapsed time (sec)": None,
+        "cores": None,
+        "Minimum memory used (kb)": None,
+        "Maximum memory used (kb)": None,
+        "Average memory used (kb)": None,
+    }
+
+
+def test_parse_run_stats_incomplete_run(tmp_path):
+    """A run killed mid-execution has no timing/memory block; degrade to None."""
+    aims_out = tmp_path / "aims.out"
+    aims_out.write_text(
+        "===================================================================================\n"
+        "=   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES\n"
+        "=   RANK 1 PID 66572 RUNNING AT andrey-Latitude-5411\n"
+        "=   KILLED BY SIGNAL: 9 (Killed)\n"
+        "===================================================================================\n"
+    )
+
+    stats = _parse_run_stats(aims_out)
+    assert stats["CPU time (sec)"] is None
+    assert stats["Elapsed time (sec)"] is None
+    assert stats["Minimum memory used (kb)"] is None
+    assert stats["Maximum memory used (kb)"] is None
+    assert stats["Average memory used (kb)"] is None


### PR DESCRIPTION
## Summary
* Add `_parse_run_stats` helper to `atomate2/aims/schemas/calculation.py` that parses timing, peak memory, and core-count stats directly from `aims.out` (CPU/elapsed time, min/max/avg tracked memory, core count), analogous to VASP's `Outcar.run_stats`.
* Add `run_stats: dict[str, Any] | None` field to `CalculationOutput` (`schemas/calculation.py`), populated in `Calculation.from_aims_files` via `_parse_run_stats`.
* Add `run_stats: dict[str, Any] | None` field to `AimsTaskDoc` (`schemas/task.py`), populated in `from_directory` from `calcs_reversed[-1].output.run_stats` — mirrors VASP's two-level `TaskDoc`/`CalculationOutput` pattern, no re-parsing.
* Fix `_parse_bandstructure` (`schemas/calculation.py`) raising `AttributeError: 'AimsOutput' object has no attribute 'band_structure'` whenever `parse_bandstructure` was truthy. Now guards with `hasattr` and warns + returns `None` if band structure parsing isn't yet supported by the installed `pymatgen.io.aims.outputs.AimsOutput`.

## Additional dependencies introduced (if any)
None. Uses `re` and `pathlib.Path`, both already in the standard library and already imported elsewhere in this codebase.

## TODO (if any)
* `run_stats` is parsed directly from `aims.out` text in atomate2 as a stopgap. This should eventually be upstreamed so `pyfhiaims.outputs.stdout.AimsStdout` and `pymatgen.io.aims.outputs.AimsOutput` expose `run_stats` natively (matching how VASP's `Outcar.run_stats` is parsed in pymatgen, not atomate2). Once that lands, `_parse_run_stats` here should be removed and `Calculation.from_aims_files` updated to read `aims_output.run_stats` directly.
* Band structure parsing (`AimsOutput.band_structure`) is not implemented upstream in pymatgen. This PR only prevents the crash when it's requested; actual band structure support is out of scope here and tracked as a separate follow-up.

## Checklist
- [ X] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/). The easiest way to handle this is to run the following in the **correct sequence** on your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will automatically reformat your code to PEP8 conventions and fix many linting issues.
- [ X] Doc strings have been added in the [Numpy docstring format] (https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html). Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
- [ X] Type annotations are **highly** encouraged. Run [mypy] (http://mypy-lang.org) to type check your code.
- [ X] Tests have been added for any new functionality or bug fixes.
- [ X] All linting and tests pass.