### PR TITLE
Fix `structure` field shadowing `sort_structure` in `VaspInputGenerator`

### DIFF
--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -173,8 +173,6 @@ class VaspInputGenerator(VaspInputSet):
             from_prev_calc.
     """
 
-    # Do not redeclare `structure` here: VaspInputSet so setting structure
-    # uses pymatgen.io.vasp.sets setter which sorts the structure
     config_dict: dict = field(default_factory=lambda: _BASE_VASP_SET)
     files_to_transfer: dict = field(default_factory=dict)
     user_incar_settings: dict = field(default_factory=dict)

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -174,7 +174,8 @@ class VaspInputGenerator(VaspInputSet):
             from_prev_calc.
     """
 
-    structure: Structure | None = None
+    # Do not redeclare `structure` here: VaspInputSet so setting structure
+    # uses pymatgen.io.vasp.sets setter which sorts the structure
     config_dict: dict = field(default_factory=lambda: _BASE_VASP_SET)
     files_to_transfer: dict = field(default_factory=dict)
     user_incar_settings: dict = field(default_factory=dict)

--- a/src/atomate2/vasp/sets/base.py
+++ b/src/atomate2/vasp/sets/base.py
@@ -10,7 +10,6 @@ from pymatgen.io.vasp.sets import MPRelaxSet, MPScanRelaxSet, VaspInputSet
 from atomate2 import SETTINGS
 
 if TYPE_CHECKING:
-    from pymatgen.core import Structure
     from pymatgen.io.vasp import Kpoints
     from pymatgen.io.vasp.sets import UserPotcarFunctional
 

--- a/tests/vasp/test_sets.py
+++ b/tests/vasp/test_sets.py
@@ -1,7 +1,8 @@
 import pytest
 from pymatgen.core import Lattice, Species, Structure
-from pymatgen.io.vasp.sets import MPScanRelaxSet
+from pymatgen.io.vasp.sets import MPScanRelaxSet, VaspInputSet
 
+from atomate2.vasp.sets.base import VaspInputGenerator
 from atomate2.vasp.sets.core import (
     ElectronPhononSetGenerator,
     HSEBSSetGenerator,
@@ -292,3 +293,47 @@ def test_core(struct_no_magmoms):
     assert incar["EDIFF"] == 1e-7
     assert incar["ISYM"] == 0
     assert incar["LWAVE"] is True
+
+
+def test_structure_field_not_shadowed():
+    """VaspInputGenerator must not redeclare `structure` as a plain field:
+    pymatgen's VaspInputSet already defines it as a property (with a setter
+    that applies sort_structure/reduce_structure/validate_magmom), and
+    redeclaring it here would shadow that property in the MRO, silently
+    disabling the setter for every generator derived from this class.
+    """
+    # The property should be the one pymatgen's VaspInputSet defines, not
+    # redeclared (and thereby shadowed) on atomate2's VaspInputGenerator.
+    assert "structure" not in vars(VaspInputGenerator)
+    assert isinstance(vars(VaspInputSet)["structure"], property)
+
+    # Setting `.structure` on a generator must still work end-to-end.
+    input_gen = MDSetGenerator()
+    structure = Structure(
+        lattice=Lattice.cubic(3),
+        species=("Fe", "O"),
+        coords=((0, 0, 0), (0.5, 0.5, 0.5)),
+    )
+    input_gen.structure = structure
+    assert input_gen.structure.composition == structure.composition
+
+
+def test_md_set_generator_sorts_structure():
+    """MDSetGenerator's npt ensemble sizes LANGEVIN_GAMMA to the number of
+    distinct elements, but VASP counts POSCAR "types" as contiguous
+    same-element runs. If the structure passed in isn't already grouped by
+    element and sort_structure doesn't run, the two counts diverge and VASP
+    aborts with "Error reading item LANGEVIN_GAMMA from file INCAR".
+    """
+    structure = Structure(
+        lattice=Lattice.cubic(10),
+        species=["Al", "Cl", "Al", "Cl", "O", "Cl", "Li", "Li"],
+        coords=[[0.1 * i, 0.1 * i, 0.1 * i] for i in range(8)],
+    )
+
+    input_gen = MDSetGenerator(ensemble="npt")
+    vasp_input = input_gen.get_input_set(structure, potcar_spec=True)
+
+    n_types_in_poscar = len(vasp_input["POSCAR"].natoms)
+    n_langevin_gamma = len(vasp_input["INCAR"]["LANGEVIN_GAMMA"])
+    assert n_types_in_poscar == n_langevin_gamma


### PR DESCRIPTION
## Summary

* `VaspInputGenerator` redeclared `structure` as a plain dataclass field, overriding the `structure` property (with its `sort_structure`/`reduce_structure`/`validate_magmom` setter) inherited from pymatgen's `VaspInputSet`. As a result, `sort_structure` silently never ran for any atomate2 VASP input-set generator.
* This surfaces destructively in `MDSetGenerator`'s `npt` ensemble: `LANGEVIN_GAMMA` is sized to the number of distinct elements, while VASP counts POSCAR "types" as contiguous same-element runs. With an unsorted structure the two counts diverge and VASP aborts with `Error reading item LANGEVIN_GAMMA from file INCAR`.
* Fix: remove the redundant field declaration so the inherited property is no longer shadowed.
* Added regression tests (`tests/vasp/test_sets.py`) and a standalone repro (`example.py`).

**Alternatively, we modify MDSetGenerator something like:**
```python
class MDSetGenerator(VaspInputGenerator):
    def get_input_set(self, structure=None, prev_dir=None, potcar_spec=False):
        if structure is not None and self.sort_structure:
            structure = structure.get_sorted_structure()
        return super().get_input_set(structure, prev_dir=prev_dir, potcar_spec=potcar_spec)
```
**for a more targeted fix.**

## Additional dependencies introduced (if any)

* None.

## TODO (if any)

* None.

## Checklist

Work-in-progress pull requests are encouraged, but please put [WIP] in the pull request
title.

Before a pull request can be merged, the following items must be checked:

* [x] Code is in the [standard Python style](https://www.python.org/dev/peps/pep-0008/).
  The easiest way to handle this is to run the following in the **correct sequence** on
  your local machine. Start with running [`ruff`](https://docs.astral.sh/ruff) and `ruff format` on your new code. This will
  automatically reformat your code to PEP8 conventions and fix many linting issues.
* [x] Doc strings have been added in the [Numpy docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
  Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Type annotations are **highly** encouraged. Run [mypy](http://mypy-lang.org) to
  type check your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [x] All linting and tests pass.

Note that the CI system will run all the above checks. But it will be much more
efficient if you already fix most errors prior to submitting the PR. It is highly
recommended that you use the pre-commit hook provided in the repository. Simply run
`pre-commit install` and a check will be run prior to allowing commits.

## Issue
Closes #1529. See this issue for bug reproduction instructions.
