### PR TITLE
Fix numerical residues in symmetry-expanded elastic strains

### DIFF
--- a/src/atomate2/common/schemas/elastic.py
+++ b/src/atomate2/common/schemas/elastic.py
@@ -306,11 +306,8 @@ def expand_strains(
         raise ValueError(f"tol must be positive, got {tol}")
     for strain in strains:
         applied_components = np.abs(strain.voigt)
-        nonzero_components = applied_components[applied_components != 0]
-        if not len(nonzero_components) or np.any(nonzero_components <= tol):
-            raise ValueError(
-                "tol must be smaller than every nonzero applied strain component"
-            )
+        if len(applied_components[applied_components > tol]) == 0:
+            raise ValueError("tol must be smaller than the applied strain magnitude")
 
     def zero_numerical_components(strain: Strain) -> Strain:
         voigt = np.asarray(strain.voigt).copy()

--- a/src/atomate2/common/schemas/elastic.py
+++ b/src/atomate2/common/schemas/elastic.py
@@ -302,15 +302,32 @@ def expand_strains(
         strains will not contain the ones with other strain states. Also see:
         `generate_elastic_deformations()`.
     """
+    if tol <= 0:
+        raise ValueError(f"tol must be positive, got {tol}")
+    for strain in strains:
+        applied_components = np.abs(strain.voigt)
+        nonzero_components = applied_components[applied_components != 0]
+        if not len(nonzero_components) or np.any(nonzero_components <= tol):
+            raise ValueError(
+                "tol must be smaller than every nonzero applied strain component"
+            )
+
+    def zero_numerical_components(strain: Strain) -> Strain:
+        voigt = np.asarray(strain.voigt).copy()
+        voigt[np.abs(voigt) <= tol] = 0
+        return Strain.from_voigt(voigt)
+
     sga = SpacegroupAnalyzer(structure, symprec=symprec)
     symm_ops = sga.get_symmetry_operations(cartesian=True)
 
-    full_strains = deepcopy(strains)
+    full_strains = [zero_numerical_components(strain) for strain in strains]
     full_stresses = deepcopy(stresses)
     full_uuids = deepcopy(uuids)
     full_job_dirs = deepcopy(job_dirs)
 
-    mapping = TensorMapping(full_strains, [True for _ in full_strains])
+    # Preserve the original strains for identity comparisons so normalization does
+    # not change which symmetry-equivalent strains are accepted.
+    mapping = TensorMapping(deepcopy(strains), [True for _ in strains])
     for idx, strain in enumerate(strains):
         for symm_op in symm_ops:
             rotated_strain = strain.transform(symm_op)
@@ -327,7 +344,7 @@ def expand_strains(
             mapping[rotated_strain] = True
 
             # expand the other properties
-            full_strains.append(rotated_strain)
+            full_strains.append(zero_numerical_components(rotated_strain))
             full_stresses.append(stresses[idx].transform(symm_op))
             full_uuids.append(uuids[idx])
             full_job_dirs.append(job_dirs[idx])

--- a/tests/common/jobs/test_elastic.py
+++ b/tests/common/jobs/test_elastic.py
@@ -76,7 +76,6 @@ def test_expand_strains_zeroes_numerical_components():
         (-1e-3, [0.01, 0, 0, 0, 0, 0]),
         (0, [0.01, 0, 0, 0, 0, 0]),
         (1e-3, [5e-4, 0, 0, 0, 0, 0]),
-        (1e-3, [0.01, 5e-4, 0, 0, 0, 0]),
     ],
 )
 def test_expand_strains_rejects_invalid_zero_tolerance(tol, strain_voigt):

--- a/tests/common/jobs/test_elastic.py
+++ b/tests/common/jobs/test_elastic.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 from jobflow import run_locally
-from pymatgen.analysis.elasticity import Stress
+from pymatgen.analysis.elasticity import Strain, Stress
+from pymatgen.core import Lattice, Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from atomate2 import SETTINGS
@@ -41,6 +42,57 @@ def test_reduce_expand_strains(clean_dir, symmetry_structure, conventional):
 
     for fs in full_strains:
         assert any(np.allclose(fs, rs) for rs in recovered_strains)
+
+
+def test_expand_strains_zeroes_numerical_components():
+    """Ensure symmetry residues use the same zero tolerance as expansion."""
+    base = Structure.from_spacegroup("Im-3m", Lattice.cubic(2.87), ["Fe"], [[0, 0, 0]])
+    lattice = np.asarray(base.lattice.matrix).copy()
+    lattice[0, 1] += 1e-3
+    lattice[1, 2] -= 7e-4
+    lattice[2, 0] += 3e-4
+    structure = Structure(Lattice(lattice), base.species, base.frac_coords)
+
+    strain = Strain.from_voigt([0.01, 0, 0, 0, 0, 0])
+    stresses = [Stress(np.zeros((3, 3)))]
+    expanded, _, _, _ = expand_strains(
+        structure,
+        [strain],
+        stresses=stresses,
+        uuids=["dummy"],
+        job_dirs=["dummy"],
+        symprec=0.1,
+    )
+
+    assert len(expanded) == 3
+    for expanded_strain in expanded:
+        components = np.abs(expanded_strain.voigt)
+        assert np.all((components == 0) | (components > 1e-3))
+
+
+@pytest.mark.parametrize(
+    ("tol", "strain_voigt"),
+    [
+        (-1e-3, [0.01, 0, 0, 0, 0, 0]),
+        (0, [0.01, 0, 0, 0, 0, 0]),
+        (1e-3, [5e-4, 0, 0, 0, 0, 0]),
+        (1e-3, [0.01, 5e-4, 0, 0, 0, 0]),
+    ],
+)
+def test_expand_strains_rejects_invalid_zero_tolerance(tol, strain_voigt):
+    structure = Structure(Lattice.cubic(2.87), ["Fe"], [[0, 0, 0]])
+    strain = Strain.from_voigt(strain_voigt)
+
+    with pytest.raises(ValueError, match="tol"):
+        expand_strains(
+            structure,
+            [strain],
+            stresses=[Stress(np.zeros((3, 3)))],
+            uuids=["dummy"],
+            job_dirs=["dummy"],
+            symprec=0.1,
+            tol=tol,
+        )
 
 
 def _get_strains(structure, sym_reduce):


### PR DESCRIPTION
## Summary

- zero strain components at or below the existing `expand_strains` tolerance before handing them to pymatgen fitting
- use the same caller-provided tolerance for both classification and stored values
- validate that the tolerance is positive and smaller than the applied strain components
- preserve the original, unsanitized strains in `TensorMapping`, so symmetry acceptance and deduplication select the same entries as before
- leave calculated stresses unchanged

## Why

`expand_strains` accepts a rotated strain as single-component with a default `1e-3` threshold, but previously stored that strain with numerical residues around `1e-9` to `1e-8`. Pymatgen fitting uses a tighter default threshold and can interpret those residues as mixed strain states, producing an ill-conditioned order-2 fit.

## Validation

- targeted elastic schema/job tests: 32 passed in an isolated environment
- Ruff checks passed
- regression covers a slightly perturbed high-symmetry cell and asserts that every stored expanded component is either exactly zero or above `tol`
- archived replay evidence kept the expanded strain counts unchanged across all records; the largest unchanged-case specific-stiffness difference was `2e-5 GPa cm^3/g`, while the pathological high-value BPC4 population was removed

The immediate downstream benchmark workaround uses `sym_reduce=False`, so benchmark correctness does not depend on this PR merging or releasing.