### PR TITLE
Replace duplicate vasp set with temporary getattr

### DIFF
--- a/src/atomate2/vasp/jobs/core.py
+++ b/src/atomate2/vasp/jobs/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
@@ -26,6 +27,7 @@ from atomate2.vasp.sets.core import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Any
 
     from jobflow import Response
     from pymatgen.core.structure import Structure
@@ -175,41 +177,6 @@ class TightRelaxMaker(BaseVaspMaker):
 class TightRelaxConstVolMaker(BaseVaspMaker):
     """
     Maker to create tight constant volume VASP relaxation jobs.
-
-    Parameters
-    ----------
-    name : str
-        The job name.
-    input_set_generator : .VaspInputGenerator
-        A generator used to make the input set.
-    write_input_set_kwargs : dict
-        Keyword arguments that will get passed to :obj:`.write_vasp_input_set`.
-    copy_vasp_kwargs : dict
-        Keyword arguments that will get passed to :obj:`.copy_vasp_outputs`.
-    run_vasp_kwargs : dict
-        Keyword arguments that will get passed to :obj:`.run_vasp`.
-    task_document_kwargs : dict
-        Keyword arguments that will get passed to :obj:`.TaskDoc.from_directory`.
-    stop_children_kwargs : dict
-        Keyword arguments that will get passed to :obj:`.should_stop_children`.
-    write_additional_data : dict
-        Additional data to write to the current directory. Given as a dict of
-        {filename: data}. Note that if using FireWorks, dictionary keys cannot contain
-        the "." character which is typically used to denote file extensions. To avoid
-        this, use the ":" character, which will automatically be converted to ".". E.g.
-        ``{"my_file:txt": "contents of the file"}``.
-    """
-
-    name: str = "tight relax"
-    input_set_generator: VaspInputGenerator = field(
-        default_factory=TightRelaxConstVolSetGenerator
-    )
-
-
-@dataclass
-class TightConstVolRelaxMaker(BaseVaspMaker):
-    """
-    Maker to create tight VASP relaxation jobs.
 
     Parameters
     ----------
@@ -643,3 +610,19 @@ class TransmuterMaker(BaseVaspMaker):
         self.write_additional_data.setdefault("transformations:json", tjson)
 
         return super().make.original(self, structure, prev_dir)
+
+
+def __getattr__(name: str) -> Any:
+    if name == "TightConstVolRelaxMaker":
+        warnings.warn(
+            (
+                "`TightConstVolRelaxMaker` is a duplicate of "
+                " `TightRelaxConstVolMaker`, and will be removed on "
+                "1 October, 2026. Please migrate to `TightRelaxConstVolMaker`."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return TightRelaxConstVolMaker
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
- Closes #1533 
- Replaces duplicate vasp input set with module-level getattr with removal date 01-Oct-2026