### PR TITLE
Amset interpolation convergence

### DIFF
--- a/src/atomate2/amset/files.py
+++ b/src/atomate2/amset/files.py
@@ -3,17 +3,13 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
-
-from monty.serialization import loadfn
-
-from atomate2 import SETTINGS
-from atomate2.common.files import copy_files, get_zfile, gunzip_files, rename_files
-from atomate2.utils.file_client import FileClient, auto_fileclient
-from atomate2.utils.path import strip_hostname
-
 from pathlib import Path
 
+from atomate2 import SETTINGS
+from atomate2.common.files import copy_files, get_zfile, gunzip_files
+from atomate2.utils.file_client import FileClient, auto_fileclient
+from atomate2.utils.path import strip_hostname
+from monty.serialization import loadfn
 
 logger = logging.getLogger(__name__)
 

--- a/src/atomate2/amset/files.py
+++ b/src/atomate2/amset/files.py
@@ -12,7 +12,6 @@ from atomate2.common.files import copy_files, get_zfile, gunzip_files, rename_fi
 from atomate2.utils.file_client import FileClient, auto_fileclient
 from atomate2.utils.path import strip_hostname
 
-
 from pathlib import Path
 
 

--- a/src/atomate2/amset/files.py
+++ b/src/atomate2/amset/files.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from monty.serialization import loadfn
+
 from atomate2 import SETTINGS
 from atomate2.common.files import copy_files, get_zfile, gunzip_files
 from atomate2.utils.file_client import FileClient, auto_fileclient
 from atomate2.utils.path import strip_hostname
-from monty.serialization import loadfn
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ def copy_amset_files(
         found_file = get_zfile(directory_listing, file, allow_missing=True)
         if found_file is not None:
             files.append(found_file)
-    files.append("transport_*.json*")
+    files.append(Path("transport_*.json*"))
 
     copy_files(
         src_dir,

--- a/src/atomate2/amset/files.py
+++ b/src/atomate2/amset/files.py
@@ -12,8 +12,8 @@ from atomate2.common.files import copy_files, get_zfile, gunzip_files, rename_fi
 from atomate2.utils.file_client import FileClient, auto_fileclient
 from atomate2.utils.path import strip_hostname
 
-if TYPE_CHECKING:
-    from pathlib import Path
+
+from pathlib import Path
 
 
 logger = logging.getLogger(__name__)
@@ -55,17 +55,18 @@ def copy_amset_files(
         "band_structure_data.json",
         "wavefunction.h5",
         "deformation.h5",
-        "transport.json",
     ):
         found_file = get_zfile(directory_listing, file, allow_missing=True)
         if found_file is not None:
             files.append(found_file)
+    files.append("transport_*.json*")
 
     copy_files(
         src_dir,
         src_host=src_host,
         include_files=files,
         file_client=file_client,
+        allow_missing=True,
     )
 
     gunzip_files(
@@ -74,7 +75,9 @@ def copy_amset_files(
         file_client=file_client,
     )
 
-    rename_files({"transport.json": "transport.prev.json"}, allow_missing=True)
+    local_transport = next(Path().glob("transport_*.json*"), None)
+    if local_transport is not None:
+        local_transport.rename("transport.prev.json")
     logger.info("Finished copying inputs")
 
 

--- a/tests/amset/test_files.py
+++ b/tests/amset/test_files.py
@@ -5,22 +5,26 @@ from atomate2.amset.files import copy_amset_files
 @pytest.mark.parametrize(
     "transport_filename,expect_prev_file",
     [
-        ("transport_55x55x83.json", True),
+        ("transport_55x55x83.json.gz", True),
         (None, False),
     ],
 )
+#testing if a transport file can be extracted from the prev_dir and renamed
+#testing that first run case where no prev_dir exists behaves 
 def test_copy_amset_files_transport_handling(
     tmp_path, monkeypatch, transport_filename, expect_prev_file
 ):
     prev_dir = tmp_path / "prev_job"
     prev_dir.mkdir()
     if transport_filename:
-        (prev_dir / transport_filename).write_text("{}")
+        with gzip.open(prev_dir / transport_filename, "wt") as f:
+            f.write("{}") # write the file to the prev_dir 
+   
 
     new_dir = tmp_path / "new_job"
     new_dir.mkdir()
     monkeypatch.chdir(new_dir)
-
-    copy_amset_files(src_dir=str(prev_dir))  
+    
+    copy_amset_files(src_dir=str(prev_dir)) # copy file from prev_dir to new_dir, changing the name to transport.prev.json
 
     assert (new_dir / "transport.prev.json").exists() == expect_prev_file

--- a/tests/amset/test_files.py
+++ b/tests/amset/test_files.py
@@ -1,4 +1,7 @@
+import gzip
+
 import pytest
+
 from atomate2.amset.files import copy_amset_files
 
 
@@ -10,7 +13,7 @@ from atomate2.amset.files import copy_amset_files
     ],
 )
 #testing if a transport file can be extracted from the prev_dir and renamed
-#testing that first run case where no prev_dir exists behaves 
+#testing that first run case where no prev_dir exists behaves
 def test_copy_amset_files_transport_handling(
     tmp_path, monkeypatch, transport_filename, expect_prev_file
 ):
@@ -18,13 +21,13 @@ def test_copy_amset_files_transport_handling(
     prev_dir.mkdir()
     if transport_filename:
         with gzip.open(prev_dir / transport_filename, "wt") as f:
-            f.write("{}") # write the file to the prev_dir 
-   
+            f.write("{}") # write the file to the prev_dir
+
 
     new_dir = tmp_path / "new_job"
     new_dir.mkdir()
     monkeypatch.chdir(new_dir)
-    
-    copy_amset_files(src_dir=str(prev_dir)) # copy file from prev_dir to new_dir, changing the name to transport.prev.json
+    # copy file from prev_dir to new_dir, changing the name to transport.prev.json
+    copy_amset_files(src_dir=str(prev_dir))
 
     assert (new_dir / "transport.prev.json").exists() == expect_prev_file

--- a/tests/amset/test_files.py
+++ b/tests/amset/test_files.py
@@ -13,7 +13,7 @@ from atomate2.amset.files import copy_amset_files
     ],
 )
 #testing if a transport file can be extracted from the prev_dir and renamed
-#testing that first run case where no prev_dir exists behaves
+#testing first run case where no prev_dir exists is well behaved
 def test_copy_amset_files_transport_handling(
     tmp_path, monkeypatch, transport_filename, expect_prev_file
 ):

--- a/tests/amset/test_files.py
+++ b/tests/amset/test_files.py
@@ -12,8 +12,8 @@ from atomate2.amset.files import copy_amset_files
         (None, False),
     ],
 )
-#testing if a transport file can be extracted from the prev_dir and renamed
-#testing that first run case where no prev_dir exists behaves
+# testing if a transport file can be extracted from the prev_dir and renamed
+# testing that first run case where no prev_dir exists behaves
 def test_copy_amset_files_transport_handling(
     tmp_path, monkeypatch, transport_filename, expect_prev_file
 ):
@@ -21,8 +21,7 @@ def test_copy_amset_files_transport_handling(
     prev_dir.mkdir()
     if transport_filename:
         with gzip.open(prev_dir / transport_filename, "wt") as f:
-            f.write("{}") # write the file to the prev_dir
-
+            f.write("{}")  # write the file to the prev_dir
 
     new_dir = tmp_path / "new_job"
     new_dir.mkdir()

--- a/tests/amset/test_files.py
+++ b/tests/amset/test_files.py
@@ -1,0 +1,26 @@
+import pytest
+from atomate2.amset.files import copy_amset_files
+
+
+@pytest.mark.parametrize(
+    "transport_filename,expect_prev_file",
+    [
+        ("transport_55x55x83.json", True),
+        (None, False),
+    ],
+)
+def test_copy_amset_files_transport_handling(
+    tmp_path, monkeypatch, transport_filename, expect_prev_file
+):
+    prev_dir = tmp_path / "prev_job"
+    prev_dir.mkdir()
+    if transport_filename:
+        (prev_dir / transport_filename).write_text("{}")
+
+    new_dir = tmp_path / "new_job"
+    new_dir.mkdir()
+    monkeypatch.chdir(new_dir)
+
+    copy_amset_files(src_dir=str(prev_dir))  # should not raise either way
+
+    assert (new_dir / "transport.prev.json").exists() == expect_prev_file

--- a/tests/amset/test_files.py
+++ b/tests/amset/test_files.py
@@ -21,6 +21,6 @@ def test_copy_amset_files_transport_handling(
     new_dir.mkdir()
     monkeypatch.chdir(new_dir)
 
-    copy_amset_files(src_dir=str(prev_dir))  # should not raise either way
+    copy_amset_files(src_dir=str(prev_dir))  
 
     assert (new_dir / "transport.prev.json").exists() == expect_prev_file


### PR DESCRIPTION
`copy_amset_files()` currently looks for a file named `transport.json`. AMSET writes the transport files as `transport_{mesh}.json` by default. Because that file is never found, `transport.prev.json` is never created, so `check_converged()` has nothing to compare against on a resubmission, leaving jobs resubmitting weather the interpolation factor is converged or not. 

## Summary

- Replaces the exact match lookup of `transport.json` with the wildcard pattern `transport_*.json*`, matching the default file naming.
- `rename_files()` doesn't support wildcards, so the transport file is renamed with a plain pathlib glob + rename instead of going through `rename_files()`.
- Added `allow_missing=True` into `copy_files`, replacing what was in `rename_files`, to avoid crashing on the first run when no previous file exists.